### PR TITLE
fix(data): avoid ingestion temp table races

### DIFF
--- a/scripts/market_data_ingestion.py
+++ b/scripts/market_data_ingestion.py
@@ -3,6 +3,7 @@ import logging
 import os
 import re
 import sys
+import uuid
 from dataclasses import asdict, dataclass
 from datetime import date, datetime, timedelta, timezone
 from functools import partial
@@ -389,6 +390,44 @@ def _parse_ingestion_date_override(date_str: str | None) -> date | None:
         return datetime.strptime(date_str, "%Y%m%d").date()
     except ValueError:
         return None
+
+
+def _build_staging_table_name(prefix: str) -> str:
+    table_name = f"{prefix}_{uuid.uuid4().hex}"
+    _validate_sql_identifier(table_name)
+    return table_name
+
+
+def _create_staging_table(conn, *, table_name: str, like_table_name: str) -> None:
+    _validate_sql_identifier(table_name)
+    _validate_sql_identifier(like_table_name)
+    conn.execute(
+        text(
+            f"""
+            CREATE TEMP TABLE {table_name}
+            (LIKE {like_table_name} INCLUDING DEFAULTS)
+            ON COMMIT DROP
+            """
+        )
+    )
+
+
+def _drop_staging_table(conn, table_name: str) -> None:
+    _validate_sql_identifier(table_name)
+    drop_statement = text(f"DROP TABLE IF EXISTS {table_name}")
+    try:
+        if conn.in_transaction():
+            conn.execute(drop_statement)
+        else:
+            with conn.begin():
+                conn.execute(drop_statement)
+    except Exception:
+        logger.exception("Failed to drop staging table name=%s", table_name)
+
+
+def _validate_sql_identifier(identifier: str) -> None:
+    if not re.fullmatch(r"[a-z0-9_]+", identifier):
+        raise ValueError(f"Unsafe SQL identifier: {identifier}")
 
 
 def _list_symbol_daily_trading_days(
@@ -1122,7 +1161,7 @@ def load_to_db(df: pd.DataFrame, metadata: RawTraceMetadata | None = None) -> di
         )
         return summary
 
-    temp_table_name = "daily_ohlcv_temp"
+    temp_table_name = _build_staging_table_name("daily_ohlcv_temp")
     if not OFFICIAL_SOURCES:
         raise ValueError("OFFICIAL_SOURCES must not be empty.")
     official_source_params = {
@@ -1156,65 +1195,75 @@ def load_to_db(df: pd.DataFrame, metadata: RawTraceMetadata | None = None) -> di
         else:
             validated_df["parser_version"] = parser_version
         with engine.connect() as conn:
-            with conn.begin():
-                validated_df.to_sql(
-                    temp_table_name, conn, if_exists="replace", index=False
-                )
+            try:
+                with conn.begin():
+                    _create_staging_table(
+                        conn,
+                        table_name=temp_table_name,
+                        like_table_name=DailyOHLCV.__tablename__,
+                    )
+                    validated_df.to_sql(
+                        temp_table_name, conn, if_exists="append", index=False
+                    )
 
-                override_count = conn.execute(
-                    text(
-                        f"""
-                        SELECT COUNT(*)
-                        FROM {DailyOHLCV.__tablename__} existing
-                        INNER JOIN {temp_table_name} incoming
-                            ON existing.date = incoming.date
-                           AND existing.symbol = incoming.symbol
-                        WHERE incoming.source IN (
-                                {official_source_placeholders}
-                        )
-                          AND (
-                            existing.source IS NULL
-                            OR existing.source NOT IN (
-                                {official_source_placeholders}
+                    override_count = conn.execute(
+                        text(
+                            f"""
+                            SELECT COUNT(*)
+                            FROM {DailyOHLCV.__tablename__} existing
+                            INNER JOIN {temp_table_name} incoming
+                                ON existing.date = incoming.date
+                               AND existing.symbol = incoming.symbol
+                            WHERE incoming.source IN (
+                                    {official_source_placeholders}
                             )
-                          )
-                        """
-                    ),
-                    official_source_params,
-                ).scalar_one()
+                              AND (
+                                existing.source IS NULL
+                                OR existing.source NOT IN (
+                                    {official_source_placeholders}
+                                )
+                              )
+                            """
+                        ),
+                        official_source_params,
+                    ).scalar_one()
 
-                result = conn.execute(
-                    text(
-                        f"""
-                        INSERT INTO {DailyOHLCV.__tablename__} (
-                            date, symbol, market, source, open, high, low, close, volume,
-                            raw_payload_id, archive_object_reference, parser_version
-                        )
-                        SELECT date, symbol, market, source, open, high, low, close, volume,
-                               raw_payload_id, archive_object_reference, parser_version
-                        FROM {temp_table_name}
-                        ON CONFLICT (date, symbol) DO UPDATE SET
-                            market = EXCLUDED.market,
-                            source = EXCLUDED.source,
-                            open = EXCLUDED.open,
-                            high = EXCLUDED.high,
-                            low = EXCLUDED.low,
-                            close = EXCLUDED.close,
-                            volume = EXCLUDED.volume,
-                            raw_payload_id = EXCLUDED.raw_payload_id,
-                            archive_object_reference = EXCLUDED.archive_object_reference,
-                            parser_version = EXCLUDED.parser_version
-                        WHERE EXCLUDED.source IN (
-                                {official_source_placeholders}
+                    result = conn.execute(
+                        text(
+                            f"""
+                            INSERT INTO {DailyOHLCV.__tablename__} (
+                                date, symbol, market, source, open, high, low, close, volume,
+                                raw_payload_id, archive_object_reference, parser_version
                             )
-                           OR {DailyOHLCV.__tablename__}.source IS NULL
-                           OR {DailyOHLCV.__tablename__}.source NOT IN (
-                                {official_source_placeholders}
-                            )
-                        """
-                    ),
-                    official_source_params,
-                )
+                            SELECT date, symbol, market, source, open, high, low, close, volume,
+                                   raw_payload_id, archive_object_reference, parser_version
+                            FROM {temp_table_name}
+                            ON CONFLICT (date, symbol) DO UPDATE SET
+                                market = EXCLUDED.market,
+                                source = EXCLUDED.source,
+                                open = EXCLUDED.open,
+                                high = EXCLUDED.high,
+                                low = EXCLUDED.low,
+                                close = EXCLUDED.close,
+                                volume = EXCLUDED.volume,
+                                raw_payload_id = EXCLUDED.raw_payload_id,
+                                archive_object_reference = EXCLUDED.archive_object_reference,
+                                parser_version = EXCLUDED.parser_version
+                            WHERE EXCLUDED.source IN (
+                                    {official_source_placeholders}
+                                )
+                               OR {DailyOHLCV.__tablename__}.source IS NULL
+                               OR {DailyOHLCV.__tablename__}.source NOT IN (
+                                    {official_source_placeholders}
+                                )
+                            """
+                        ),
+                        official_source_params,
+                    )
+                _drop_staging_table(conn, temp_table_name)
+            except Exception:
+                _drop_staging_table(conn, temp_table_name)
+                raise
         summary["official_overrides"] = int(override_count)
         summary["upserted_rows"] = (
             result.rowcount
@@ -1249,7 +1298,7 @@ def load_minute_to_db(
         )
         return summary
 
-    temp_table_name = "minute_ohlcv_temp"
+    temp_table_name = _build_staging_table_name("minute_ohlcv_temp")
     try:
         validated_df = validated_df.copy()
         if "raw_payload_id" in validated_df.columns:
@@ -1266,35 +1315,45 @@ def load_minute_to_db(
             validated_df["parser_version"] = parser_version
 
         with engine.connect() as conn:
-            with conn.begin():
-                validated_df.to_sql(
-                    temp_table_name, conn, if_exists="replace", index=False
-                )
-                result = conn.execute(
-                    text(
-                        f"""
-                        INSERT INTO {MinuteOHLCV.__tablename__} (
-                            market, symbol, bar_ts, trading_date, source,
-                            open, high, low, close, volume,
-                            raw_payload_id, parser_version
-                        )
-                        SELECT market, symbol, bar_ts, trading_date, source,
-                               open, high, low, close, volume,
-                               raw_payload_id, parser_version
-                        FROM {temp_table_name}
-                        ON CONFLICT (market, symbol, bar_ts) DO UPDATE SET
-                            trading_date = EXCLUDED.trading_date,
-                            source = EXCLUDED.source,
-                            open = EXCLUDED.open,
-                            high = EXCLUDED.high,
-                            low = EXCLUDED.low,
-                            close = EXCLUDED.close,
-                            volume = EXCLUDED.volume,
-                            raw_payload_id = EXCLUDED.raw_payload_id,
-                            parser_version = EXCLUDED.parser_version
-                        """
+            try:
+                with conn.begin():
+                    _create_staging_table(
+                        conn,
+                        table_name=temp_table_name,
+                        like_table_name=MinuteOHLCV.__tablename__,
                     )
-                )
+                    validated_df.to_sql(
+                        temp_table_name, conn, if_exists="append", index=False
+                    )
+                    result = conn.execute(
+                        text(
+                            f"""
+                            INSERT INTO {MinuteOHLCV.__tablename__} (
+                                market, symbol, bar_ts, trading_date, source,
+                                open, high, low, close, volume,
+                                raw_payload_id, parser_version
+                            )
+                            SELECT market, symbol, bar_ts, trading_date, source,
+                                   open, high, low, close, volume,
+                                   raw_payload_id, parser_version
+                            FROM {temp_table_name}
+                            ON CONFLICT (market, symbol, bar_ts) DO UPDATE SET
+                                trading_date = EXCLUDED.trading_date,
+                                source = EXCLUDED.source,
+                                open = EXCLUDED.open,
+                                high = EXCLUDED.high,
+                                low = EXCLUDED.low,
+                                close = EXCLUDED.close,
+                                volume = EXCLUDED.volume,
+                                raw_payload_id = EXCLUDED.raw_payload_id,
+                                parser_version = EXCLUDED.parser_version
+                            """
+                        )
+                    )
+                _drop_staging_table(conn, temp_table_name)
+            except Exception:
+                _drop_staging_table(conn, temp_table_name)
+                raise
         summary["upserted_rows"] = (
             result.rowcount
             if result.rowcount and result.rowcount > 0

--- a/tests/scripts/test_market_data_ingestion.py
+++ b/tests/scripts/test_market_data_ingestion.py
@@ -7,6 +7,61 @@ import requests
 from scripts import market_data_ingestion as scraper
 
 
+class _FakeResult:
+    def __init__(self, *, scalar_value=None, rowcount=None):
+        self._scalar_value = scalar_value
+        self.rowcount = rowcount
+
+    def scalar_one(self):
+        return self._scalar_value
+
+
+class _FakeTransaction:
+    def __init__(self, connection):
+        self.connection = connection
+
+    def __enter__(self):
+        self.connection.transaction_depth += 1
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.connection.transaction_depth -= 1
+        return False
+
+
+class _FakeConnection:
+    def __init__(self, execute_plan=None):
+        self.execute_plan = list(execute_plan or [])
+        self.statements = []
+        self.to_sql_names = []
+        self.dropped_tables = []
+        self.transaction_depth = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def begin(self):
+        return _FakeTransaction(self)
+
+    def in_transaction(self):
+        return self.transaction_depth > 0
+
+    def execute(self, statement, params=None):
+        sql = str(statement).strip()
+        self.statements.append((sql, params))
+        if sql.startswith("DROP TABLE IF EXISTS "):
+            self.dropped_tables.append(sql.removeprefix("DROP TABLE IF EXISTS ").strip())
+        if not self.execute_plan:
+            return _FakeResult()
+        action = self.execute_plan.pop(0)
+        if isinstance(action, Exception):
+            raise action
+        return action
+
+
 def test_validate_ohlcv_with_report_tracks_removed_rows():
     df = pd.DataFrame(
         [
@@ -64,6 +119,319 @@ def test_load_to_db_empty_summary():
     assert summary["validated_rows"] == 0
     assert summary["upserted_rows"] == 0
     assert summary["official_overrides"] == 0
+
+
+def test_load_to_db_uses_unique_staging_tables_and_cleans_up(monkeypatch):
+    df = pd.DataFrame(
+        [
+            {
+                "date": "2024-01-02",
+                "symbol": "2330",
+                "market": "TW",
+                "source": scraper.SOURCE_TWSE,
+                "open": 10.0,
+                "high": 11.0,
+                "low": 9.0,
+                "close": 10.5,
+                "volume": 100,
+            }
+        ]
+    )
+    connections = []
+    execute_plans = [
+        [_FakeResult(), _FakeResult(scalar_value=1), _FakeResult(rowcount=1), _FakeResult()],
+        [_FakeResult(), _FakeResult(scalar_value=1), _FakeResult(rowcount=1), _FakeResult()],
+    ]
+
+    def fake_connect():
+        connection = _FakeConnection(execute_plan=execute_plans.pop(0))
+        connections.append(connection)
+        return connection
+
+    def fake_to_sql(self, name, conn, if_exists="fail", index=True, **kwargs):
+        conn.to_sql_names.append((name, if_exists, index))
+
+    monkeypatch.setattr(scraper.engine, "connect", fake_connect)
+    monkeypatch.setattr(
+        scraper,
+        "validate_ohlcv_with_report",
+        lambda frame, label: (
+            frame.copy(),
+            scraper.QualityReport(input_rows=len(frame), output_rows=len(frame)),
+        ),
+    )
+    monkeypatch.setattr(pd.DataFrame, "to_sql", fake_to_sql)
+
+    summary_a = scraper.load_to_db(df)
+    summary_b = scraper.load_to_db(df)
+
+    first_name = connections[0].to_sql_names[0][0]
+    second_name = connections[1].to_sql_names[0][0]
+    first_create_sql = connections[0].statements[0][0]
+    second_create_sql = connections[1].statements[0][0]
+    assert summary_a["official_overrides"] == 1
+    assert summary_a["upserted_rows"] == 1
+    assert summary_b["official_overrides"] == 1
+    assert summary_b["upserted_rows"] == 1
+    assert first_name != second_name
+    assert connections[0].to_sql_names[0][1] == "append"
+    assert connections[1].to_sql_names[0][1] == "append"
+    assert first_create_sql.startswith("CREATE TEMP TABLE")
+    assert second_create_sql.startswith("CREATE TEMP TABLE")
+    assert "ON COMMIT DROP" in first_create_sql
+    assert "ON COMMIT DROP" in second_create_sql
+    assert connections[0].dropped_tables == [first_name]
+    assert connections[1].dropped_tables == [second_name]
+
+
+def test_load_to_db_cleans_up_staging_table_on_failure(monkeypatch):
+    df = pd.DataFrame(
+        [
+            {
+                "date": "2024-01-02",
+                "symbol": "2330",
+                "market": "TW",
+                "source": scraper.SOURCE_TWSE,
+                "open": 10.0,
+                "high": 11.0,
+                "low": 9.0,
+                "close": 10.5,
+                "volume": 100,
+            }
+        ]
+    )
+    connection = _FakeConnection(
+        execute_plan=[
+            _FakeResult(),
+            _FakeResult(scalar_value=1),
+            RuntimeError("insert failed"),
+            _FakeResult(),
+        ]
+    )
+
+    def fake_to_sql(self, name, conn, if_exists="fail", index=True, **kwargs):
+        conn.to_sql_names.append((name, if_exists, index))
+
+    monkeypatch.setattr(scraper.engine, "connect", lambda: connection)
+    monkeypatch.setattr(
+        scraper,
+        "validate_ohlcv_with_report",
+        lambda frame, label: (
+            frame.copy(),
+            scraper.QualityReport(input_rows=len(frame), output_rows=len(frame)),
+        ),
+    )
+    monkeypatch.setattr(pd.DataFrame, "to_sql", fake_to_sql)
+
+    with pytest.raises(RuntimeError, match="insert failed"):
+        scraper.load_to_db(df)
+
+    staging_name = connection.to_sql_names[0][0]
+    assert connection.statements[0][0].startswith("CREATE TEMP TABLE")
+    assert connection.dropped_tables == [staging_name]
+
+
+def test_load_to_db_cleanup_failure_does_not_override_insert_error(monkeypatch):
+    df = pd.DataFrame(
+        [
+            {
+                "date": "2024-01-02",
+                "symbol": "2330",
+                "market": "TW",
+                "source": scraper.SOURCE_TWSE,
+                "open": 10.0,
+                "high": 11.0,
+                "low": 9.0,
+                "close": 10.5,
+                "volume": 100,
+            }
+        ]
+    )
+    connection = _FakeConnection(
+        execute_plan=[
+            _FakeResult(),
+            _FakeResult(scalar_value=1),
+            RuntimeError("insert failed"),
+            RuntimeError("drop failed"),
+        ]
+    )
+
+    def fake_to_sql(self, name, conn, if_exists="fail", index=True, **kwargs):
+        conn.to_sql_names.append((name, if_exists, index))
+
+    monkeypatch.setattr(scraper.engine, "connect", lambda: connection)
+    monkeypatch.setattr(
+        scraper,
+        "validate_ohlcv_with_report",
+        lambda frame, label: (
+            frame.copy(),
+            scraper.QualityReport(input_rows=len(frame), output_rows=len(frame)),
+        ),
+    )
+    monkeypatch.setattr(pd.DataFrame, "to_sql", fake_to_sql)
+
+    with pytest.raises(RuntimeError, match="insert failed"):
+        scraper.load_to_db(df)
+
+    staging_name = connection.to_sql_names[0][0]
+    assert connection.statements[0][0].startswith("CREATE TEMP TABLE")
+    assert connection.dropped_tables == [staging_name]
+
+
+def test_load_minute_to_db_uses_unique_staging_tables_and_cleans_up(monkeypatch):
+    df = pd.DataFrame(
+        [
+            {
+                "trading_date": date(2024, 1, 2),
+                "bar_ts": pd.Timestamp("2024-01-02T01:00:00Z"),
+                "symbol": "2330",
+                "market": "TW",
+                "source": scraper.SOURCE_YFINANCE_MINUTE_1M,
+                "open": 10.0,
+                "high": 11.0,
+                "low": 9.0,
+                "close": 10.5,
+                "volume": 100,
+            }
+        ]
+    )
+    connections = []
+    execute_plans = [
+        [_FakeResult(), _FakeResult(rowcount=1), _FakeResult()],
+        [_FakeResult(), _FakeResult(rowcount=1), _FakeResult()],
+    ]
+
+    def fake_connect():
+        connection = _FakeConnection(execute_plan=execute_plans.pop(0))
+        connections.append(connection)
+        return connection
+
+    def fake_to_sql(self, name, conn, if_exists="fail", index=True, **kwargs):
+        conn.to_sql_names.append((name, if_exists, index))
+
+    monkeypatch.setattr(scraper.engine, "connect", fake_connect)
+    monkeypatch.setattr(
+        scraper,
+        "validate_minute_ohlcv_with_report",
+        lambda frame, label: (
+            frame.copy(),
+            scraper.QualityReport(input_rows=len(frame), output_rows=len(frame)),
+        ),
+    )
+    monkeypatch.setattr(pd.DataFrame, "to_sql", fake_to_sql)
+
+    summary_a = scraper.load_minute_to_db(df)
+    summary_b = scraper.load_minute_to_db(df)
+
+    first_name = connections[0].to_sql_names[0][0]
+    second_name = connections[1].to_sql_names[0][0]
+    first_create_sql = connections[0].statements[0][0]
+    second_create_sql = connections[1].statements[0][0]
+    assert summary_a["upserted_rows"] == 1
+    assert summary_b["upserted_rows"] == 1
+    assert first_name != second_name
+    assert connections[0].to_sql_names[0][1] == "append"
+    assert connections[1].to_sql_names[0][1] == "append"
+    assert first_create_sql.startswith("CREATE TEMP TABLE")
+    assert second_create_sql.startswith("CREATE TEMP TABLE")
+    assert "ON COMMIT DROP" in first_create_sql
+    assert "ON COMMIT DROP" in second_create_sql
+    assert connections[0].dropped_tables == [first_name]
+    assert connections[1].dropped_tables == [second_name]
+
+
+def test_load_minute_to_db_cleans_up_staging_table_on_failure(monkeypatch):
+    df = pd.DataFrame(
+        [
+            {
+                "trading_date": date(2024, 1, 2),
+                "bar_ts": pd.Timestamp("2024-01-02T01:00:00Z"),
+                "symbol": "2330",
+                "market": "TW",
+                "source": scraper.SOURCE_YFINANCE_MINUTE_1M,
+                "open": 10.0,
+                "high": 11.0,
+                "low": 9.0,
+                "close": 10.5,
+                "volume": 100,
+            }
+        ]
+    )
+    connection = _FakeConnection(
+        execute_plan=[
+            _FakeResult(),
+            RuntimeError("insert failed"),
+            _FakeResult(),
+        ]
+    )
+
+    def fake_to_sql(self, name, conn, if_exists="fail", index=True, **kwargs):
+        conn.to_sql_names.append((name, if_exists, index))
+
+    monkeypatch.setattr(scraper.engine, "connect", lambda: connection)
+    monkeypatch.setattr(
+        scraper,
+        "validate_minute_ohlcv_with_report",
+        lambda frame, label: (
+            frame.copy(),
+            scraper.QualityReport(input_rows=len(frame), output_rows=len(frame)),
+        ),
+    )
+    monkeypatch.setattr(pd.DataFrame, "to_sql", fake_to_sql)
+
+    with pytest.raises(RuntimeError, match="insert failed"):
+        scraper.load_minute_to_db(df)
+
+    staging_name = connection.to_sql_names[0][0]
+    assert connection.statements[0][0].startswith("CREATE TEMP TABLE")
+    assert connection.dropped_tables == [staging_name]
+
+
+def test_load_minute_to_db_cleanup_failure_does_not_override_insert_error(monkeypatch):
+    df = pd.DataFrame(
+        [
+            {
+                "trading_date": date(2024, 1, 2),
+                "bar_ts": pd.Timestamp("2024-01-02T01:00:00Z"),
+                "symbol": "2330",
+                "market": "TW",
+                "source": scraper.SOURCE_YFINANCE_MINUTE_1M,
+                "open": 10.0,
+                "high": 11.0,
+                "low": 9.0,
+                "close": 10.5,
+                "volume": 100,
+            }
+        ]
+    )
+    connection = _FakeConnection(
+        execute_plan=[
+            _FakeResult(),
+            RuntimeError("insert failed"),
+            RuntimeError("drop failed"),
+        ]
+    )
+
+    def fake_to_sql(self, name, conn, if_exists="fail", index=True, **kwargs):
+        conn.to_sql_names.append((name, if_exists, index))
+
+    monkeypatch.setattr(scraper.engine, "connect", lambda: connection)
+    monkeypatch.setattr(
+        scraper,
+        "validate_minute_ohlcv_with_report",
+        lambda frame, label: (
+            frame.copy(),
+            scraper.QualityReport(input_rows=len(frame), output_rows=len(frame)),
+        ),
+    )
+    monkeypatch.setattr(pd.DataFrame, "to_sql", fake_to_sql)
+
+    with pytest.raises(RuntimeError, match="insert failed"):
+        scraper.load_minute_to_db(df)
+
+    staging_name = connection.to_sql_names[0][0]
+    assert connection.statements[0][0].startswith("CREATE TEMP TABLE")
+    assert connection.dropped_tables == [staging_name]
 
 
 def test_sanitize_numeric_value_strips_html_tags():


### PR DESCRIPTION
## Summary
- switch daily and minute ingestion staging tables to session-scoped temp tables with unique names
- validate generated SQL identifiers and keep explicit cleanup outside the upsert transaction
- add loader tests for unique staging tables plus failure-path cleanup behavior

## Testing
- not run (per repo instruction)