### PR TITLE
fix: address validation and dependency issues

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -15,7 +15,7 @@ in the v1 product navigation.
 
 ## Status Scope
 
-- status date: `2026-04-26`
+- status date: `2026-05-12`
 - status terms:
   - `implemented`: behavior exists and is usable in the current codebase
   - `partial`: meaningful foundation exists, but the v1 product expectation is
@@ -30,7 +30,7 @@ in the v1 product navigation.
 | Workbench product direction | implemented | README, goals, plan, spec, and gates describe the v1 workbench direction |
 | Start / Builder / Experiments / Data Ops shell | implemented | frontend shell uses task-oriented surfaces instead of the old platform-first navigation |
 | Baseline TW daily experiment builder | implemented | baseline workflow creates research runs from dataset, features, model, validation, and backtest settings |
-| Regression diagnostics contract | partial | backend and frontend types include `model_diagnostics`; validation still needs end-to-end artifact checks |
+| Regression diagnostics contract | implemented | backend, frontend types, and review UI include `model_diagnostics`, including residual samples |
 | Persisted result artifacts | partial | DB/model/repository support exists for diagnostics, equity, signals, and baselines; old records still need fallback handling |
 | Experiments comparison | partial | search, sort, load, and compare UI foundations exist; comparison explanations still need hardening |
 | Classification | contract-defined | task and diagnostics are specified, but implementation is deferred |
@@ -119,8 +119,8 @@ These foundations are implementation inventory, not v1 product scope.
 
 - legacy `PredictionStudio` and `MaintenanceWorkspace` should be removed once
   the current workbench surfaces fully replace them
-- residual diagnostics need either a dedicated UI section or an explicit
-  product decision that residuals are represented inside diagnostic sample rows
+- residual diagnostics now have a dedicated sample section in the persisted run
+  review surface
 - comparison UI needs clearer reason labels for non-comparable or
   metadata-only runs
 
@@ -153,6 +153,7 @@ Move to the v1 implementation cleanup stage:
 1. replace advanced gate counts on the start surface with TW daily data
    readiness
 2. verify migration `0008` and persisted artifact reload in a real database
-3. close the residual diagnostics UI/spec interpretation gap
+3. verify the residual diagnostics UI against persisted records with and without
+   artifact JSON
 4. deprecate or remove legacy frontend surfaces once the replacement flow is
    confirmed

--- a/frontend/src/lib/components/research-runs/ResearchRunDiagnostics.svelte
+++ b/frontend/src/lib/components/research-runs/ResearchRunDiagnostics.svelte
@@ -5,6 +5,10 @@
 
     const formatNumber = (value: number | null | undefined) =>
         value === null || value === undefined ? "N/A" : value.toFixed(4);
+
+    $: recentPredictionSamples =
+        diagnostics?.actual_vs_predicted.slice(-8) ?? [];
+    $: recentResidualSamples = diagnostics?.residuals.slice(-8) ?? [];
 </script>
 
 <section class="surface diagnostics-surface">
@@ -47,7 +51,7 @@
                         <h4>Recent Samples</h4>
                     </div>
                 </div>
-                {#if diagnostics.actual_vs_predicted.length}
+                {#if recentPredictionSamples.length}
                     <div class="table-wrap">
                         <table>
                             <thead>
@@ -59,7 +63,7 @@
                                 </tr>
                             </thead>
                             <tbody>
-                                {#each diagnostics.actual_vs_predicted.slice(-8) as point}
+                                {#each recentPredictionSamples as point}
                                     <tr>
                                         <td>{point.date}</td>
                                         <td>{point.symbol}</td>
@@ -72,6 +76,39 @@
                     </div>
                 {:else}
                     <p class="muted">No prediction samples were persisted.</p>
+                {/if}
+            </div>
+
+            <div>
+                <div class="surface-header">
+                    <div>
+                        <p class="eyebrow">Residuals</p>
+                        <h4>Recent Errors</h4>
+                    </div>
+                </div>
+                {#if recentResidualSamples.length}
+                    <div class="table-wrap">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Symbol</th>
+                                    <th>Residual</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {#each recentResidualSamples as point}
+                                    <tr>
+                                        <td>{point.date}</td>
+                                        <td>{point.symbol}</td>
+                                        <td>{formatNumber(point.residual)}</td>
+                                    </tr>
+                                {/each}
+                            </tbody>
+                        </table>
+                    </div>
+                {:else}
+                    <p class="muted">No residual samples were persisted.</p>
                 {/if}
             </div>
 
@@ -138,7 +175,9 @@
     }
 
     .diagnostic-columns {
-        grid-template-columns: minmax(0, 1.3fr) minmax(280px, 0.7fr);
+        grid-template-columns:
+            minmax(0, 1.1fr) minmax(240px, 0.8fr)
+            minmax(240px, 0.7fr);
     }
 
     @media (max-width: 1100px) {

--- a/scripts/market_data_ingestion.py
+++ b/scripts/market_data_ingestion.py
@@ -430,6 +430,12 @@ def _validate_sql_identifier(identifier: str) -> None:
         raise ValueError(f"Unsafe SQL identifier: {identifier}")
 
 
+def _table_name(model_class: type) -> str:
+    table_name = model_class.__table__.name
+    _validate_sql_identifier(table_name)
+    return table_name
+
+
 def _list_symbol_daily_trading_days(
     *,
     symbol: str,
@@ -440,7 +446,7 @@ def _list_symbol_daily_trading_days(
     query = text(
         f"""
         SELECT DISTINCT date
-        FROM {DailyOHLCV.__tablename__}
+        FROM {_table_name(DailyOHLCV)}
         WHERE symbol = :symbol
           AND market = :market
           AND date >= :start_date
@@ -471,7 +477,7 @@ def _list_symbol_minute_trading_days(
     query = text(
         f"""
         SELECT DISTINCT trading_date
-        FROM {MinuteOHLCV.__tablename__}
+        FROM {_table_name(MinuteOHLCV)}
         WHERE symbol = :symbol
           AND market = :market
           AND trading_date >= :start_date
@@ -1200,7 +1206,7 @@ def load_to_db(df: pd.DataFrame, metadata: RawTraceMetadata | None = None) -> di
                     _create_staging_table(
                         conn,
                         table_name=temp_table_name,
-                        like_table_name=DailyOHLCV.__tablename__,
+                        like_table_name=_table_name(DailyOHLCV),
                     )
                     validated_df.to_sql(
                         temp_table_name, conn, if_exists="append", index=False
@@ -1210,7 +1216,7 @@ def load_to_db(df: pd.DataFrame, metadata: RawTraceMetadata | None = None) -> di
                         text(
                             f"""
                             SELECT COUNT(*)
-                            FROM {DailyOHLCV.__tablename__} existing
+                            FROM {_table_name(DailyOHLCV)} existing
                             INNER JOIN {temp_table_name} incoming
                                 ON existing.date = incoming.date
                                AND existing.symbol = incoming.symbol
@@ -1231,7 +1237,7 @@ def load_to_db(df: pd.DataFrame, metadata: RawTraceMetadata | None = None) -> di
                     result = conn.execute(
                         text(
                             f"""
-                            INSERT INTO {DailyOHLCV.__tablename__} (
+                            INSERT INTO {_table_name(DailyOHLCV)} (
                                 date, symbol, market, source, open, high, low, close, volume,
                                 raw_payload_id, archive_object_reference, parser_version
                             )
@@ -1252,8 +1258,8 @@ def load_to_db(df: pd.DataFrame, metadata: RawTraceMetadata | None = None) -> di
                             WHERE EXCLUDED.source IN (
                                     {official_source_placeholders}
                                 )
-                               OR {DailyOHLCV.__tablename__}.source IS NULL
-                               OR {DailyOHLCV.__tablename__}.source NOT IN (
+                               OR {_table_name(DailyOHLCV)}.source IS NULL
+                               OR {_table_name(DailyOHLCV)}.source NOT IN (
                                     {official_source_placeholders}
                                 )
                             """
@@ -1320,7 +1326,7 @@ def load_minute_to_db(
                     _create_staging_table(
                         conn,
                         table_name=temp_table_name,
-                        like_table_name=MinuteOHLCV.__tablename__,
+                        like_table_name=_table_name(MinuteOHLCV),
                     )
                     validated_df.to_sql(
                         temp_table_name, conn, if_exists="append", index=False
@@ -1328,7 +1334,7 @@ def load_minute_to_db(
                     result = conn.execute(
                         text(
                             f"""
-                            INSERT INTO {MinuteOHLCV.__tablename__} (
+                            INSERT INTO {_table_name(MinuteOHLCV)} (
                                 market, symbol, bar_ts, trading_date, source,
                                 open, high, low, close, volume,
                                 raw_payload_id, parser_version

--- a/uv.lock
+++ b/uv.lock
@@ -742,14 +742,14 @@ wheels = [
 
 [[package]]
 name = "mako"
-version = "1.3.11"
+version = "1.3.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/8a/805404d0c0b9f3d7a326475ca008db57aea9c5c9f2e1e39ed0faa335571c/mako-1.3.11.tar.gz", hash = "sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069", size = 399811, upload-time = "2026-04-14T20:19:51.493Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl", hash = "sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77", size = 78503, upload-time = "2026-04-14T20:19:53.233Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
 ]
 
 [[package]]
@@ -1963,11 +1963,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- bump vulnerable transitive Python packages in uv.lock: Mako 1.3.12 and urllib3 2.7.0
- add residual sample display to persisted run diagnostics
- fix ingestion staging table name lookup for imperative SQLAlchemy mapped models
- refresh implementation status for the diagnostics cleanup

## Validation
- uv lock --check
- bun x tsc -p frontend/tsconfig.json --noEmit
- cd frontend && bun run build
- .venv/bin/python -m pytest tests/research/test_research_api.py tests/market_data/test_market_data_api.py tests/platform/test_system_api.py tests/market_data/test_tick_archive_api.py -q
- .venv/bin/python -m pytest tests/research/test_execution.py tests/research/test_runs.py tests/research/test_run_repository.py -q
- .venv/bin/python -m pytest tests/market_data/test_market_data_api.py tests/market_data/test_services.py tests/market_data/test_recovery_and_replay.py -q
- .venv/bin/python -m pytest tests/scripts/test_market_data_ingestion.py -q
- .venv/bin/python -m pytest -q
- agent-browser smoke against local frontend/backend with Docker DB and Alembic migrations

## Notes
- Docker DB was started with the default compose volume and stopped with docker-compose down; the volume was not deleted.
- Default DB had no TW daily rows, so readiness showed missing/stale as expected.