### PR TITLE
fix: clarify research comparison eligibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ promotes them deliberately.
 | Research-run core | implemented | run creation, registry records, runtime metadata, and saved-run lookup exist |
 | TW daily data readiness | implemented with diagnostics | ingestion, replay, lifecycle, important-event, and recovery surfaces support data trust checks |
 | Baseline experiment builder | implemented | a researcher can start from the baseline workflow without editing API payloads |
-| Regression diagnostics | in progress | v1 requires persisted model-quality artifacts, not strategy metrics alone |
-| Experiment comparison | in progress | persisted runs must be searchable, loadable, and comparable with clear caveats |
+| Regression diagnostics | implemented | successful regression runs return and reload model-quality artifacts before strategy interpretation |
+| Persisted artifact reload | verified | new successful runs reload request config, diagnostics, equity, signals, baselines, warnings, and runtime metadata |
+| Experiment comparison | in progress | search, load, and compare work; eligibility labels now distinguish complete research-review runs from metadata-only records |
 | Advanced/platform modules | hidden advanced | execution, adaptive, peer, factor, and tick archive capabilities are not v1 main-flow surfaces |
 
 For the fuller implementation inventory, use
@@ -82,9 +83,6 @@ include lower-level or advanced foundations that are not v1 product commitments.
 
 ## Still Partial Or Deferred
 
-- persisted runs need complete model diagnostics, predictions/signals, equity
-  curve, baselines, warnings, runtime metadata, and request config available
-  after reload
 - classification is specified but not implemented in the first code pass
 - comparison needs clearer eligibility and reason labels when runs should not be
   compared

--- a/backend/shared/analytics/strategy.py
+++ b/backend/shared/analytics/strategy.py
@@ -13,6 +13,7 @@ VNEXT_SPEC_MODE = "vnext_spec_mode"
 RESEARCH_SPEC_V1 = "research_spec_v1"
 THRESHOLD_POLICY_VERSION = "static_absolute_gross_label_v1"
 COMPARISON_ELIGIBILITY = "comparison_metadata_only"
+RESEARCH_ONLY_COMPARABLE = "research_only_comparable"
 FINAL_COMPARISON_PENDING = "sample_window_pending"
 PRICE_BASIS_VERSION_TEMPLATE = (
     "label_{return_target}__entry_ohlc_default__exit_ohlc_default__benchmark_unset_v1"
@@ -238,15 +239,18 @@ def build_comparison_eligibility(
 ) -> str:
     if corporate_event_state == "unresolved_corporate_event":
         return "unresolved_event_quarantine"
-    # Reserved for a future sample-window gate. Current callers intentionally keep
-    # this disabled until the underlying comparability check is implemented.
-    if sample_window_pending and (
+    has_core_comparison_metadata = (
         price_basis_version is not None
         and threshold_policy_version is not None
         and execution_cost_model_version is not None
-    ):
+    )
+    if not has_core_comparison_metadata:
+        return COMPARISON_ELIGIBILITY
+    # Reserved for a future sample-window gate. Current callers intentionally keep
+    # this disabled until the underlying comparability check is implemented.
+    if sample_window_pending:
         return FINAL_COMPARISON_PENDING
-    return COMPARISON_ELIGIBILITY
+    return RESEARCH_ONLY_COMPARABLE
 
 
 def get_strategy_runner(strategy_type: str) -> StrategyRunner:

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -31,8 +31,8 @@ in the v1 product navigation.
 | Start / Builder / Experiments / Data Ops shell | implemented | frontend shell uses task-oriented surfaces instead of the old platform-first navigation |
 | Baseline TW daily experiment builder | implemented | baseline workflow creates research runs from dataset, features, model, validation, and backtest settings |
 | Regression diagnostics contract | implemented | backend, frontend types, and review UI include `model_diagnostics`, including residual samples |
-| Persisted result artifacts | partial | DB/model/repository support exists for diagnostics, equity, signals, and baselines; old records still need fallback handling |
-| Experiments comparison | partial | search, sort, load, and compare UI foundations exist; comparison explanations still need hardening |
+| Persisted result artifacts | verified | new successful runs reload request config, diagnostics, equity curve, signals, baselines, metrics, warnings, and runtime metadata; old metadata-only records show explicit fallback copy |
+| Experiments comparison | partial | search, sort, load, and compare UI foundations exist; complete research-review runs no longer appear as metadata-only, while deeper comparison explanations still need hardening |
 | Classification | contract-defined | task and diagnostics are specified, but implementation is deferred |
 | Data readiness | implemented | start surface uses requested-symbol TW daily readiness with ready/warning/missing-stale counts |
 | Advanced/platform modules | hidden advanced | execution, adaptive, peer, factor, external-signal, and tick-archive surfaces remain code foundations, not v1 main-flow commitments |
@@ -126,19 +126,45 @@ These foundations are implementation inventory, not v1 product scope.
 
 ### Backend
 
-- persisted artifact reload should be verified end to end after migration
-  `0008`
-- old records without artifact JSON need clear fallback responses and UI copy
 - classification remains specification-only
+- comparison caveat labels still need deeper hardening for non-comparable runs,
+  such as sample-window, target, feature, and cost-basis mismatch cases
 - hidden advanced foundations may stay reachable for diagnostics and legacy
   tooling, but should not return to the v1 navigation without a roadmap
   decision
 
 ## Latest Local Verification
 
+- persisted artifact reload verification:
+  - Docker DB started with the default compose volume
+  - migration applied with `.venv/bin/python -m alembic upgrade head`
+  - deterministic `V1VERIFY` TW daily fixture created and cleaned up
+  - successful run reloaded through `GET /api/v1/research/runs/{run_id}`
+  - result: request config, diagnostics, residuals, equity curve, signals,
+    baselines, warnings, metrics, and runtime metadata reloaded correctly
+- browser smoke:
+  - `agent-browser` verified the Experiments surface for a successful run and a
+    metadata-only fallback record
+  - result: successful run showed diagnostics, residuals, equity, validation,
+    baselines, and signals; metadata-only run showed explicit fallback copy
+- comparison eligibility verification:
+  - two successful `V1COMPARE` runs were created through the API against a
+    Docker DB fixture and reloaded from persisted records
+  - result: both runs returned `research_only_comparable`, appeared as
+    `Research-only comparable` in Experiments, and compared with model-config
+    caveats instead of metadata-only warnings
 - frontend typecheck:
   - `bun x tsc -p frontend/tsconfig.json --noEmit`
   - result: passed
+- frontend build:
+  - `cd frontend && bun run build`
+  - result: passed
+- lockfile check:
+  - `uv lock --check`
+  - result: passed
+- backend regression:
+  - `.venv/bin/python -m pytest -q`
+  - result: `248 passed`
 - public-surface targeted tests:
   - `.venv/bin/python -m pytest tests/research/test_research_api.py tests/market_data/test_market_data_api.py tests/platform/test_system_api.py tests/market_data/test_tick_archive_api.py -q`
   - result: `22 passed`
@@ -150,10 +176,11 @@ These foundations are implementation inventory, not v1 product scope.
 
 Move to the v1 implementation cleanup stage:
 
-1. replace advanced gate counts on the start surface with TW daily data
-   readiness
-2. verify migration `0008` and persisted artifact reload in a real database
-3. verify the residual diagnostics UI against persisted records with and without
-   artifact JSON
+1. verify the full usable loop: Start -> Builder -> Run -> Review -> Reload ->
+   Compare
+2. harden comparison caveats for non-comparable runs across sample-window,
+   target, feature, and cost-basis mismatch cases
+3. keep Data Ops secondary to the main research loop, and remove any remaining
+   advanced/platform language from the default path
 4. deprecate or remove legacy frontend surfaces once the replacement flow is
    confirmed

--- a/tests/research/test_execution.py
+++ b/tests/research/test_execution.py
@@ -301,4 +301,5 @@ def test_execute_research_run_accepts_foundation_version_pack_fields(monkeypatch
     assert artifacts.response.peer_policy_version == "cluster_nearest_neighbors_v1"
     assert artifacts.response.adaptive_mode == "shadow"
     assert artifacts.response.reward_definition_version == "reward_v1"
+    assert artifacts.response.comparison_eligibility == "research_only_comparable"
     assert exclusion_calls == ["run_foundation_response"]

--- a/tests/shared/test_strategy.py
+++ b/tests/shared/test_strategy.py
@@ -1,0 +1,50 @@
+from backend.shared.analytics.strategy import build_comparison_eligibility
+
+
+def test_build_comparison_eligibility_returns_research_comparable_for_complete_metadata():
+    assert (
+        build_comparison_eligibility(
+            corporate_event_state="clear",
+            price_basis_version="label_open_to_open__entry_ohlc_default__exit_ohlc_default__benchmark_unset_v1",
+            threshold_policy_version="static_absolute_gross_label_v1",
+            execution_cost_model_version="fees_slippage_only_v1",
+        )
+        == "research_only_comparable"
+    )
+
+
+def test_build_comparison_eligibility_keeps_metadata_only_when_core_metadata_missing():
+    assert (
+        build_comparison_eligibility(
+            corporate_event_state="clear",
+            price_basis_version=None,
+            threshold_policy_version="static_absolute_gross_label_v1",
+            execution_cost_model_version="fees_slippage_only_v1",
+        )
+        == "comparison_metadata_only"
+    )
+
+
+def test_build_comparison_eligibility_prioritizes_event_quarantine():
+    assert (
+        build_comparison_eligibility(
+            corporate_event_state="unresolved_corporate_event",
+            price_basis_version="label_open_to_open__entry_ohlc_default__exit_ohlc_default__benchmark_unset_v1",
+            threshold_policy_version="static_absolute_gross_label_v1",
+            execution_cost_model_version="fees_slippage_only_v1",
+        )
+        == "unresolved_event_quarantine"
+    )
+
+
+def test_build_comparison_eligibility_reports_sample_window_pending():
+    assert (
+        build_comparison_eligibility(
+            corporate_event_state="clear",
+            price_basis_version="label_open_to_open__entry_ohlc_default__exit_ohlc_default__benchmark_unset_v1",
+            threshold_policy_version="static_absolute_gross_label_v1",
+            execution_cost_model_version="fees_slippage_only_v1",
+            sample_window_pending=True,
+        )
+        == "sample_window_pending"
+    )


### PR DESCRIPTION
## Summary
- mark complete research-review runs as `research_only_comparable` instead of metadata-only when core comparison metadata is present
- add comparison eligibility unit coverage and execution response coverage
- update README and implementation status with persisted artifact and comparison verification results

## Validation
- `uv lock --check`
- `bun x tsc -p frontend/tsconfig.json --noEmit`
- `cd frontend && bun run build`
- `.venv/bin/python -m pytest tests/shared/test_strategy.py tests/research/test_execution.py tests/research/test_registry.py tests/research/test_runs.py tests/research/test_research_api.py tests/research/test_run_repository.py -q` -> 60 passed
- `.venv/bin/python -m pytest -q` -> 248 passed
- Docker DB + backend/frontend + agent-browser smoke: two successful runs appeared as Research-only comparable and compared with model-config caveats

## Risks
- Existing running/rejected/metadata-incomplete records still remain metadata-only by design.
- Deeper non-comparable caveat labels remain a follow-up for sample-window, target, feature, and cost-basis mismatch cases.