### PR TITLE
fix: stabilize usable research loop

### DIFF
--- a/frontend/src/lib/components/RunReviewWorkspace.svelte
+++ b/frontend/src/lib/components/RunReviewWorkspace.svelte
@@ -103,6 +103,7 @@
         }
 
         isSelectedRunLoading = true;
+        selectedRecord = null;
         try {
             selectedRecord = await fetchResearchRun(runId);
             selectedRunError = null;

--- a/frontend/src/lib/state/researchWorkflow.ts
+++ b/frontend/src/lib/state/researchWorkflow.ts
@@ -74,7 +74,7 @@ export const researchTemplates: ResearchTemplatePreset[] = [
       "TW daily features, tree regression, model diagnostics, baselines, and an offline backtest.",
     defaultCapabilities: ["technical_indicators"],
     recommendedFamilyId: "tree_ensemble",
-    recommendedVariantId: "xgboost",
+    recommendedVariantId: "extra_trees",
   },
 ];
 
@@ -98,7 +98,7 @@ export const modelVariants: ModelVariantDefinition[] = [
     id: "xgboost",
     label: "XGBoost",
     summary:
-      "Default gradient-boosted tree path and the fastest way to a valid baseline run.",
+      "Gradient-boosted tree path. Requires the local XGBoost native runtime to be available.",
     status: "available",
   },
   {
@@ -112,7 +112,7 @@ export const modelVariants: ModelVariantDefinition[] = [
     id: "extra_trees",
     label: "Extra Trees",
     summary:
-      "A higher-randomness tree ensemble for quick comparison against the default boosted path.",
+      "Default no-native-runtime tree baseline for quick local research loops.",
     status: "available",
   },
   {
@@ -505,12 +505,24 @@ export const deriveCapabilityIdsFromRun = (
 export const deriveSubmissionSummaryFromRun = (
   run: Partial<ResearchRunRecord & ResearchRunResponse>,
 ): ResearchSubmissionSummary => {
+  const requestModel = run.request_payload?.model;
+  const requestModelType =
+    typeof requestModel === "object" &&
+    requestModel !== null &&
+    "type" in requestModel &&
+    typeof requestModel.type === "string"
+      ? requestModel.type
+      : null;
   const modelVariantId = (
-    run.model_family === "gradient_boosted_trees"
-      ? "xgboost"
-      : run.model_family === "bagging_trees"
-        ? "random_forest"
-        : "xgboost"
+    requestModelType === "extra_trees" ||
+    requestModelType === "random_forest" ||
+    requestModelType === "xgboost"
+      ? requestModelType
+      : run.model_family === "gradient_boosted_trees"
+        ? "xgboost"
+        : run.model_family === "bagging_trees"
+          ? "random_forest"
+          : "xgboost"
   ) as ModelVariantId;
 
   return {


### PR DESCRIPTION
## Summary
- switch the default v1 research builder model from XGBoost to Extra Trees so local usable-loop runs do not depend on native XGBoost/OpenMP runtime
- keep persisted run summaries faithful to the stored request payload, including Extra Trees vs Random Forest under the same bagging model family
- clear stale selected-result content before loading a persisted run

## Validation
- agent-browser usable-loop smoke: Start -> Builder -> Run -> Review -> Reload -> Compare against Docker DB and local backend/frontend
- bun x tsc -p frontend/tsconfig.json --noEmit
- bun run build
- uv lock --check
- .venv/bin/python -m pytest -q (248 passed)

## Notes
- The UI verification seeded temporary V1LOOP TW daily data and removed it after validation.
- The original XGBoost option remains available, but is no longer the default local loop path.