### PR TITLE
docs: refresh v1 usable loop status

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ promotes them deliberately.
 | Baseline experiment builder | implemented | a researcher can start from the baseline workflow without editing API payloads |
 | Regression diagnostics | implemented | successful regression runs return and reload model-quality artifacts before strategy interpretation |
 | Persisted artifact reload | verified | new successful runs reload request config, diagnostics, equity, signals, baselines, warnings, and runtime metadata |
-| Experiment comparison | in progress | search, load, and compare work; eligibility labels now distinguish complete research-review runs from metadata-only records |
+| Experiment comparison | usable for v1 loop | search, load, and compare work for complete research-review runs; non-comparable reason labels still need taxonomy hardening |
 | Advanced/platform modules | hidden advanced | execution, adaptive, peer, factor, and tick archive capabilities are not v1 main-flow surfaces |
 
 For the fuller implementation inventory, use
@@ -84,8 +84,8 @@ include lower-level or advanced foundations that are not v1 product commitments.
 ## Still Partial Or Deferred
 
 - classification is specified but not implemented in the first code pass
-- comparison needs clearer eligibility and reason labels when runs should not be
-  compared
+- comparison reason taxonomy still needs hardening for runs that should not be
+  compared, but the core persisted comparison loop is usable
 - execution, adaptive, peer, factor, and tick archive modules are deferred from
   the v1 main workflow
 

--- a/docs/decision-register.md
+++ b/docs/decision-register.md
@@ -31,6 +31,7 @@ stable across multiple implementation tasks.
 | `DEC-V1-007` | advanced/platform modules are hidden by default | accepted | execution, adaptive, peer, factor, external-signal, and tick archive modules are not default workflow requirements |
 | `DEC-V1-008` | v1 readiness denominator is requested-symbol coverage | accepted | readiness reports requested symbols over the requested date range using currently known TW daily market dates; exchange-calendar authority is deferred |
 | `DEC-V1-009` | advanced APIs remain available as internal foundations | accepted | advanced routes may stay reachable for diagnostics and legacy tooling, but they must stay out of v1 navigation and baseline workflow requirements |
+| `DEC-V1-010` | v1 baseline builder defaults to Extra Trees | accepted | the default research loop avoids requiring the XGBoost native runtime while keeping XGBoost and Random Forest selectable variants |
 
 ## Open V1 Decisions
 

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -119,6 +119,37 @@ Run TW market daily batch ingestion when a broader local dataset is needed:
 .venv/bin/python -m scripts.crawl_tw_daily_batch 2026-03-20 --refresh-universe
 ```
 
+## V1 Usable-Loop Verification
+
+The core manual path is:
+
+```text
+Start -> Builder -> Run -> Review -> Reload -> Compare
+```
+
+For a clean local database, load at least the default TW daily symbol before
+expecting the run path to succeed:
+
+```bash
+INGEST_SYMBOL=2330 INGEST_MARKET=TW INGEST_YEARS=3 \
+  .venv/bin/python -m scripts.market_data_ingestion
+```
+
+The Start readiness panel may report `warning` when some requested trading days
+are missing. That does not automatically block v1 research runs; the blocker is
+insufficient model-ready rows after feature generation, shifting, target
+alignment, and null filtering.
+
+After DB, migrations, backend, frontend, and data are ready, verify:
+
+- Start shows TW daily readiness context for the requested symbol
+- Builder opens from the baseline task and defaults to Extra Trees
+- Run creates a successful research record
+- Review shows diagnostics, equity, validation, baselines, and signals
+- Reload plus Load restores the persisted result
+- Compare can select two complete runs and shows dataset, target, feature,
+  model, cost-basis, metrics, baseline delta, and caveat fields
+
 ## Frontend
 
 The frontend lives in `frontend/` and uses `bun`.

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -15,7 +15,7 @@ in the v1 product navigation.
 
 ## Status Scope
 
-- status date: `2026-05-12`
+- status date: `2026-05-13`
 - status terms:
   - `implemented`: behavior exists and is usable in the current codebase
   - `partial`: meaningful foundation exists, but the v1 product expectation is
@@ -32,7 +32,7 @@ in the v1 product navigation.
 | Baseline TW daily experiment builder | implemented | baseline workflow creates research runs from dataset, features, model, validation, and backtest settings |
 | Regression diagnostics contract | implemented | backend, frontend types, and review UI include `model_diagnostics`, including residual samples |
 | Persisted result artifacts | verified | new successful runs reload request config, diagnostics, equity curve, signals, baselines, metrics, warnings, and runtime metadata; old metadata-only records show explicit fallback copy |
-| Experiments comparison | partial | search, sort, load, and compare UI foundations exist; complete research-review runs no longer appear as metadata-only, while deeper comparison explanations still need hardening |
+| Experiments comparison | implemented | search, sort, load, and compare work for complete research-review runs; deeper non-comparable reason taxonomy still needs hardening |
 | Classification | contract-defined | task and diagnostics are specified, but implementation is deferred |
 | Data readiness | implemented | start surface uses requested-symbol TW daily readiness with ready/warning/missing-stale counts |
 | Advanced/platform modules | hidden advanced | execution, adaptive, peer, factor, external-signal, and tick-archive surfaces remain code foundations, not v1 main-flow commitments |
@@ -111,7 +111,9 @@ These foundations are implementation inventory, not v1 product scope.
 
 ### Documentation
 
-- no known v1 direction blocker after the current rewrite
+- v1 direction is current after the usable-loop verification
+- developer-facing docs should keep the local data-prep caveat visible: a clean
+  DB needs TW daily data loaded before the run path is useful
 - future edits must keep advanced/platform modules out of the default research
   path unless `docs/plan.md` promotes them deliberately
 
@@ -121,8 +123,8 @@ These foundations are implementation inventory, not v1 product scope.
   the current workbench surfaces fully replace them
 - residual diagnostics now have a dedicated sample section in the persisted run
   review surface
-- comparison UI needs clearer reason labels for non-comparable or
-  metadata-only runs
+- comparison UI supports the v1 complete-run path; reason labels still need
+  hardening for non-comparable or metadata-only runs
 
 ### Backend
 
@@ -135,6 +137,22 @@ These foundations are implementation inventory, not v1 product scope.
 
 ## Latest Local Verification
 
+- usable-loop verification:
+  - `main` was synced to `origin/main` at `5b042e0`
+  - Docker DB started, migrations applied, backend and frontend started
+  - `2330` TW daily data was loaded through the existing ingestion path because
+    a clean DB had no daily rows
+  - `agent-browser` verified Start -> Builder -> Run -> Review -> Reload ->
+    Compare
+  - result: the builder defaulted to Extra Trees, a successful run showed
+    diagnostics, equity, validation, baselines, and signals, reload restored the
+    persisted result, and two comparable runs showed aligned dataset, target,
+    feature, model, and cost-basis fields
+- focused verification:
+  - `.venv/bin/python -m pytest -q tests/research tests/market_data/test_market_data_api.py`
+  - result: `86 passed`
+  - `bun x tsc -p frontend/tsconfig.json --noEmit`
+  - result: passed
 - persisted artifact reload verification:
   - Docker DB started with the default compose volume
   - migration applied with `.venv/bin/python -m alembic upgrade head`
@@ -174,13 +192,13 @@ These foundations are implementation inventory, not v1 product scope.
 
 ## Next Recommended Stage
 
-Move to the v1 implementation cleanup stage:
+Move from usable-loop verification to documentation and comparison cleanup:
 
-1. verify the full usable loop: Start -> Builder -> Run -> Review -> Reload ->
-   Compare
-2. harden comparison caveats for non-comparable runs across sample-window,
+1. harden comparison caveats for non-comparable runs across sample-window,
    target, feature, and cost-basis mismatch cases
-3. keep Data Ops secondary to the main research loop, and remove any remaining
+2. keep Data Ops secondary to the main research loop, and remove any remaining
    advanced/platform language from the default path
+3. document a clean-environment data-prep checklist for v1 demos and manual
+   verification
 4. deprecate or remove legacy frontend surfaces once the replacement flow is
    confirmed

--- a/docs/research-spec.md
+++ b/docs/research-spec.md
@@ -113,6 +113,10 @@ Regression predicts a numeric forward return target derived from:
 The active implementation uses tabular tree regressors and produces continuous
 scores used by the strategy backtest.
 
+The v1 baseline builder defaults to Extra Trees so the common local research
+loop does not require the XGBoost native runtime. XGBoost and Random Forest
+remain selectable tree-regression variants.
+
 ### SPEC-TASK-003: Classification target
 
 Classification must persist, when implemented:


### PR DESCRIPTION
## Summary
- refresh README and implementation status to reflect the verified v1 usable loop
- document clean-DB TW daily data prep and manual Start -> Builder -> Run -> Review -> Reload -> Compare checks
- record Extra Trees as the v1 baseline builder default and clarify selectable tree variants

## Validation
- git diff --check
- stale status text search for old comparison/verification wording

## Notes
- docs-only change; no runtime tests run for this commit