### PR TITLE
fix: simplify v1 research workflow usability

### DIFF
--- a/frontend/src/lib/components/Dashboard.svelte
+++ b/frontend/src/lib/components/Dashboard.svelte
@@ -85,45 +85,17 @@
 </script>
 
 <div class="dashboard-shell">
-    <section class="surface shell-hero">
-        <div class="shell-hero__copy">
-            <p class="eyebrow">TW Daily Quant ML Research Workbench</p>
-            <h2>
-                Start with a baseline experiment, inspect model quality, then
-                compare persisted research runs.
-            </h2>
-            <p class="muted">
-                The default path is Dataset, Features, Prediction Task, Model
-                Diagnostics, Strategy Backtest, and Experiment Comparison.
-            </p>
-        </div>
-
-        <div class="shell-hero__meta">
-            <div class="meta-card">
-                <span>V1 Focus</span>
-                <strong>TW daily baseline study</strong>
-                <p>Regression diagnostics first, strategy metrics second.</p>
-            </div>
-            <div class="meta-card">
-                <span>Artifacts</span>
-                <strong>Persisted review</strong>
-                <p>Config, diagnostics, signals, equity, baselines, warnings.</p>
-            </div>
-            <div class="meta-card">
-                <span>Scope</span>
-                <strong>Public v1 surface</strong>
-                <p>Baseline builder, experiment review, and TW daily data readiness.</p>
-            </div>
-        </div>
-    </section>
-
     {#if activeSurface === "start"}
         <section class="surface task-entry">
             <div class="surface-header surface-header--stack">
                 <div>
-                    <p class="eyebrow">Start</p>
-                    <h3>Choose the next research task</h3>
+                    <p class="eyebrow">TW Daily Quant ML Research Workbench</p>
+                    <h2>What do you want to do next?</h2>
                 </div>
+                <p class="muted">
+                    Start a baseline run, review a saved run, or check whether
+                    the requested TW daily data is ready.
+                </p>
             </div>
 
             <div class="task-grid">
@@ -133,8 +105,8 @@
                     onclick={() => setSurface("builder")}
                 >
                     <span>Start Baseline Study</span>
-                    <strong>Open the experiment builder</strong>
-                    <p>TW daily dataset, features, model, validation, review.</p>
+                    <strong>Build and run a TW daily experiment</strong>
+                    <p>Dataset, features, model, validation, and review.</p>
                 </button>
                 <button
                     type="button"
@@ -147,7 +119,7 @@
                             ? `Latest: ${latestResult.run_id}`
                             : "Load from persisted runs"}
                     </strong>
-                    <p>Review diagnostics, artifacts, and comparison context.</p>
+                    <p>Reload a saved result, inspect it, then compare.</p>
                 </button>
                 <button
                     type="button"
@@ -156,64 +128,89 @@
                 >
                     <span>Check Data Readiness</span>
                     <strong>{readinessCounts.ready} ready symbols</strong>
-                    <p>Review warning and missing/stale symbols before running research.</p>
+                    <p>Troubleshoot warning or missing symbols before a run.</p>
                 </button>
             </div>
 
-            <div class="readiness-controls">
-                <label>
-                    <span>Requested Symbols</span>
-                    <input
-                        bind:value={readinessSymbolsInput}
-                        placeholder="2330, 2317"
-                    />
-                </label>
-                <label>
-                    <span>Start Date</span>
-                    <input type="date" bind:value={readinessStartDate} />
-                </label>
-                <label>
-                    <span>End Date</span>
-                    <input type="date" bind:value={readinessEndDate} />
-                </label>
-                <button
-                    type="button"
-                    class="secondary"
-                    onclick={() => void loadTwDailyReadiness()}
-                >
-                    Refresh Readiness
-                </button>
-            </div>
-            {#if readinessLoadError}
-                <p class="muted readiness-message">{readinessLoadError}</p>
-            {/if}
-            {#if readinessData?.symbols.length}
-                <div class="readiness-details" aria-label="TW daily readiness details">
-                    {#each readinessData.symbols.slice(0, 4) as symbol}
-                        <article class={`readiness-row readiness-row--${symbol.status}`}>
-                            <div>
-                                <strong>{symbol.symbol}</strong>
-                                <span>{symbol.status}</span>
-                            </div>
-                            <p>
-                                {#if symbol.warnings.length}
-                                    {symbol.warnings[0]}
-                                {:else}
-                                    Latest daily row: {symbol.latest_daily_date ?? "unavailable"}
-                                {/if}
-                            </p>
-                        </article>
-                    {/each}
+            <details class="readiness-support">
+                <summary>
+                    Data readiness support:
+                    {readinessCounts.ready} ready,
+                    {readinessCounts.warning} warning,
+                    {readinessCounts.missing + readinessCounts.stale}
+                    missing or stale
+                </summary>
+
+                <div class="readiness-controls">
+                    <label>
+                        <span>Requested Symbols</span>
+                        <input
+                            bind:value={readinessSymbolsInput}
+                            placeholder="2330, 2317"
+                        />
+                    </label>
+                    <label>
+                        <span>Start Date</span>
+                        <input type="date" bind:value={readinessStartDate} />
+                    </label>
+                    <label>
+                        <span>End Date</span>
+                        <input type="date" bind:value={readinessEndDate} />
+                    </label>
+                    <button
+                        type="button"
+                        class="secondary"
+                        onclick={() => void loadTwDailyReadiness()}
+                    >
+                        Refresh
+                    </button>
                 </div>
-            {/if}
+                {#if readinessLoadError}
+                    <p class="muted readiness-message">{readinessLoadError}</p>
+                {/if}
+                {#if readinessData?.symbols.length}
+                    <div
+                        class="readiness-details"
+                        aria-label="TW daily readiness details"
+                    >
+                        {#each readinessData.symbols.slice(0, 4) as symbol}
+                            <article
+                                class={`readiness-row readiness-row--${symbol.status}`}
+                            >
+                                <div>
+                                    <strong>{symbol.symbol}</strong>
+                                    <span>{symbol.status}</span>
+                                </div>
+                                <p>
+                                    {#if symbol.warnings.length}
+                                        {symbol.warnings[0]}
+                                    {:else}
+                                        Latest daily row: {symbol.latest_daily_date ?? "unavailable"}
+                                    {/if}
+                                </p>
+                            </article>
+                        {/each}
+                    </div>
+                {/if}
+            </details>
+
+            <div class="workflow-strip" aria-label="Core workflow">
+                <span>Start</span>
+                <span>Builder</span>
+                <span>Run</span>
+                <span>Review</span>
+                <span>Reload</span>
+                <span>Compare</span>
+            </div>
         </section>
     {/if}
 
-    <section class="surface shell-nav">
+    {#if activeSurface !== "start"}
+        <section class="surface shell-nav">
         <div class="surface-header">
             <div>
                 <p class="eyebrow">Navigation</p>
-                <h3>Workbench surfaces</h3>
+                <h3>Research workflow</h3>
             </div>
             <div class="readiness-strip">
                 <span>{readinessCounts.ready} ready</span>
@@ -234,7 +231,7 @@
                 onclick={() => setSurface("start")}
             >
                 <span>Start</span>
-                <strong>Task entry for the baseline research loop</strong>
+                <strong>Choose the next task</strong>
             </button>
             <button
                 type="button"
@@ -243,7 +240,7 @@
                 onclick={() => setSurface("builder")}
             >
                 <span>Experiment Builder</span>
-                <strong>Dataset, features, prediction task, validation</strong>
+                <strong>Dataset, features, model, validation</strong>
             </button>
             <button
                 type="button"
@@ -255,8 +252,8 @@
                 <span>Experiments</span>
                 <strong>
                     {latestResult
-                        ? `Latest run ${latestResult.run_id} is ready to review`
-                        : "Load, inspect, and compare persisted runs"}
+                        ? `Latest run ${latestResult.run_id} is ready`
+                        : "Reload, inspect, and compare runs"}
                 </strong>
             </button>
             <button
@@ -266,11 +263,12 @@
                     "data_ops"}
                 onclick={() => setSurface("data_ops")}
             >
-                <span>Data Ops</span>
-                <strong>Secondary diagnostics for data readiness</strong>
+                <span>Data Readiness</span>
+                <strong>Support checks for requested TW symbols</strong>
             </button>
         </div>
-    </section>
+        </section>
+    {/if}
 
     {#if activeSurface === "builder"}
         <ResearchWorkspace
@@ -294,30 +292,10 @@
 
 <style lang="scss">
     .dashboard-shell,
-    .shell-hero__meta,
     .surface-nav,
     .task-grid {
         display: grid;
         gap: var(--space-4);
-    }
-
-    .shell-hero {
-        grid-template-columns: minmax(0, 1.4fr) minmax(300px, 0.9fr);
-        align-items: stretch;
-        gap: var(--space-5);
-        background:
-            linear-gradient(
-                135deg,
-                rgba(10, 31, 44, 0.96),
-                rgba(8, 20, 34, 0.94)
-            ),
-            var(--surface-1);
-    }
-
-    .shell-hero__copy {
-        display: grid;
-        gap: var(--space-3);
-        align-content: start;
     }
 
     h2,
@@ -327,16 +305,11 @@
     }
 
     h2 {
-        font-size: clamp(2rem, 4vw, 3.3rem);
-        line-height: 1.05;
+        font-size: clamp(1.7rem, 3vw, 2.55rem);
+        line-height: 1.08;
         letter-spacing: 0;
     }
 
-    .shell-hero__meta {
-        grid-template-columns: 1fr;
-    }
-
-    .meta-card,
     .surface-nav__button {
         display: grid;
         gap: 0.45rem;
@@ -347,7 +320,6 @@
         background: rgba(6, 18, 30, 0.84);
     }
 
-    .meta-card span,
     .surface-nav__button span {
         color: var(--accent-primary);
         font-size: 0.76rem;
@@ -356,7 +328,6 @@
         text-transform: uppercase;
     }
 
-    .meta-card p,
     .surface-nav__button strong {
         color: var(--text-secondary);
         line-height: 1.45;
@@ -368,6 +339,43 @@
 
     .task-entry {
         gap: var(--space-4);
+    }
+
+    .readiness-support {
+        display: grid;
+        gap: var(--space-3);
+        padding: 0.95rem;
+        border-radius: var(--radius-md);
+        border: 1px solid rgba(148, 163, 184, 0.12);
+        background: rgba(6, 18, 30, 0.58);
+    }
+
+    .readiness-support summary {
+        cursor: pointer;
+        color: var(--text-secondary);
+        font-weight: 600;
+    }
+
+    .readiness-support[open] summary {
+        margin-bottom: var(--space-3);
+    }
+
+    .workflow-strip {
+        display: flex;
+        gap: 0.55rem;
+        flex-wrap: wrap;
+    }
+
+    .workflow-strip span {
+        display: inline-flex;
+        align-items: center;
+        min-height: 2rem;
+        padding: 0.2rem 0.7rem;
+        border-radius: 999px;
+        border: 1px solid rgba(148, 163, 184, 0.12);
+        background: rgba(15, 35, 54, 0.72);
+        color: var(--muted);
+        font-size: 0.8rem;
     }
 
     .task-grid {
@@ -501,7 +509,6 @@
     }
 
     @media (max-width: 1100px) {
-        .shell-hero,
         .surface-nav,
         .task-grid,
         .readiness-details,

--- a/frontend/src/lib/components/ResearchWorkspace.svelte
+++ b/frontend/src/lib/components/ResearchWorkspace.svelte
@@ -27,12 +27,10 @@
         getModelVariantById,
         modelFamilies,
         parseSymbols,
-        researchCapabilityRegistry,
         researchTemplates,
         updateModelFamily,
         validateResearchWorkflow,
         VNEXT_SPEC_MODE,
-        withCapabilityToggled,
     } from "../state/researchWorkflow";
     import type {
         AppError,
@@ -45,7 +43,6 @@
         ResearchRunResponse,
     } from "../types";
     import WorkspaceSection from "./layout/WorkspaceSection.svelte";
-    import CapabilityCard from "./research/CapabilityCard.svelte";
 
     export let capabilityReadiness: Record<
         ResearchCapabilityId,
@@ -127,33 +124,8 @@
     const getOptionLabel = (value: string) => optionLabels[value] ?? value;
     const featureRegistry = () => featureRegistryQuery.data?.features;
 
-    const getReadiness = (capabilityId: ResearchCapabilityId) =>
-        capabilityReadiness[capabilityId] ?? {
-            capabilityId,
-            status: "not_implemented",
-            summary: "Capability readiness is unavailable.",
-            gateId: null,
-            overallStatus: null,
-        };
-
     const getCapabilityLabel = (capabilityId: ResearchCapabilityId) =>
         getCapabilityDefinition(capabilityId).label;
-
-    const getCapabilityIdsByStage = (stageId: ResearchWorkflowStageId) =>
-        researchCapabilityRegistry
-            .filter((capability) => capability.stage === stageId)
-            .map((capability) => capability.id);
-
-    const isCapabilityToggleDisabled = (capabilityId: ResearchCapabilityId) => {
-        const readiness = getReadiness(capabilityId);
-        if (capabilityId === "technical_indicators") {
-            return true;
-        }
-        return (
-            readiness.status === "gated" ||
-            readiness.status === "not_implemented"
-        );
-    };
 
     const addIndicator = () => {
         draft = {
@@ -217,17 +189,6 @@
         errors = {};
         submitError = null;
         activeStage = "universe";
-    };
-
-    const handleCapabilityToggle = (
-        capabilityId: ResearchCapabilityId,
-        checked: boolean,
-    ) => {
-        draft = withCapabilityToggled(draft, capabilityId, checked);
-        errors = {
-            ...errors,
-            [`${capabilityId}Gate`]: "",
-        };
     };
 
     const handleModelFamilySelect = (
@@ -302,7 +263,7 @@
         {
             id: "model_family",
             label: "03",
-            title: "Prediction Task",
+            title: "Model",
             summary: `${getModelFamilyById(draft.modelFamily.familyId).label} / ${
                 getModelVariantById(draft.modelFamily.variantId).label
             }`,
@@ -310,7 +271,7 @@
         {
             id: "evaluation",
             label: "04",
-            title: "Diagnostics and Backtest",
+            title: "Validation and Backtest",
             summary: `${draft.evaluation.validationMethod} / research only`,
         },
         {
@@ -320,7 +281,7 @@
             summary:
                 Object.keys(errors).length > 0
                     ? `${Object.keys(errors).length} issue(s) to resolve`
-                    : "Ready to submit the workflow",
+                    : "Ready to start the run",
         },
     ] satisfies StageSummary[];
 
@@ -336,6 +297,12 @@
         (template) => template.id === draft.templateId,
     );
     $: activeModelFamily = getModelFamilyById(draft.modelFamily.familyId);
+    $: availableModelFamilies = modelFamilies.filter(
+        (family) => family.status === "available",
+    );
+    $: availableModelVariants = activeModelFamily.variantIds
+        .map((variantId) => getModelVariantById(variantId))
+        .filter((variant) => variant.status === "available");
     $: activeTemplateCapabilityLabels =
         activeTemplate?.defaultCapabilities.map((capabilityId) =>
             getCapabilityLabel(capabilityId),
@@ -345,42 +312,43 @@
 <WorkspaceSection
     id="research-workspace"
     eyebrow="Experiment Builder"
-    title="Run a baseline TW daily experiment without editing an API payload."
-    description="Move from dataset and features into prediction task, diagnostics, backtest, and review."
+    title="Build a baseline TW daily run."
+    description="Choose the dataset, feature rows, model, validation settings, then start the run."
 >
     <div class="research-shell">
         <section class="surface surface--intro">
             <div class="surface-header surface-header--stack">
                 <div>
                     <p class="eyebrow">Baseline</p>
-                    <h3>Start from the v1 research loop</h3>
+                    <h3>Defaults are already selected</h3>
                 </div>
                 <p class="muted">
-                    The public builder only sends TW daily baseline payloads
-                    with technical indicators and research-only evaluation.
+                    The baseline path uses TW daily data, technical indicators,
+                    tree regression, model diagnostics, and an offline backtest.
                 </p>
             </div>
-
-            <div class="template-grid">
-                {#each researchTemplates as template}
-                    <button
-                        type="button"
-                        class:template-card={true}
-                        class:template-card--active={template.id ===
-                            draft.templateId}
-                        onclick={() => handleTemplateSelect(template.id)}
-                    >
-                        <span>{template.label}</span>
-                        <strong>{template.summary}</strong>
-                    </button>
-                {/each}
-            </div>
+            {#if researchTemplates.length > 1}
+                <div class="template-grid">
+                    {#each researchTemplates as template}
+                        <button
+                            type="button"
+                            class:template-card={true}
+                            class:template-card--active={template.id ===
+                                draft.templateId}
+                            onclick={() => handleTemplateSelect(template.id)}
+                        >
+                            <span>{template.label}</span>
+                            <strong>{template.summary}</strong>
+                        </button>
+                    {/each}
+                </div>
+            {/if}
         </section>
 
         <section class="surface surface--stages">
             <div class="surface-header surface-header--stack">
                 <div>
-                    <p class="eyebrow">Workflow</p>
+                    <p class="eyebrow">Steps</p>
                     <h3>
                         {stageSummaries.find(
                             (stage) => stage.id === activeStage,
@@ -426,10 +394,10 @@
 
         {#if mutation.isPending}
             <div class="surface status-surface" aria-live="polite">
-                <strong>Compiling research workflow</strong>
+                <strong>Starting the run</strong>
                 <span class="muted">
-                    The current workflow is being translated into the existing
-                    research run contract.
+                    The selected settings are being sent to the research run
+                    service.
                 </span>
             </div>
         {/if}
@@ -439,7 +407,7 @@
                 <div class="surface-header">
                     <div>
                         <p class="eyebrow">01 Universe</p>
-                        <h3>Choose the TW market backtest window</h3>
+                        <h3>Choose the TW daily window</h3>
                     </div>
                     <button
                         type="button"
@@ -524,7 +492,7 @@
                 <div class="surface-header surface-header--stack">
                     <div>
                         <p class="eyebrow">02 Features</p>
-                        <h3>Choose the baseline feature set</h3>
+                        <h3>Choose the feature rows</h3>
                     </div>
                     <p class="muted">
                         {activeTemplate?.label} uses
@@ -534,132 +502,114 @@
                     </p>
                 </div>
 
-                <div class="capability-grid capability-grid--full">
-                    <CapabilityCard
-                        capability={getCapabilityDefinition(
-                            "technical_indicators",
-                        )}
-                        readiness={getReadiness("technical_indicators")}
-                        isEnabled={true}
-                        isToggleDisabled={true}
-                        titleSuffix=" (Core)"
-                    >
-                        <div class="module-section">
-                            <div class="surface-header">
-                                <div>
-                                    <p class="eyebrow">Core Inputs</p>
-                                    <h4>Indicator rows</h4>
-                                </div>
+                <div class="surface surface--nested">
+                    <div class="surface-header">
+                        <div>
+                            <p class="eyebrow">Core Inputs</p>
+                            <h4>Technical indicator rows</h4>
+                        </div>
+                        <button
+                            type="button"
+                            class="secondary"
+                            onclick={addIndicator}
+                        >
+                            Add Indicator
+                        </button>
+                    </div>
+                    <div class="feature-list">
+                        {#each draft.signalSources.indicatorRows as feature}
+                            <div class="feature-row">
+                                <label>
+                                    <span>Name</span>
+                                    <select
+                                        value={feature.name}
+                                        onchange={(event) =>
+                                            updateIndicator(
+                                                feature.id,
+                                                "name",
+                                                (
+                                                    event.currentTarget as HTMLSelectElement
+                                                )
+                                                    .value as ResearchFeatureRow["name"],
+                                            )}
+                                    >
+                                        {#each getFeatureDefinitions(featureRegistry()) as definition}
+                                            <option value={definition.name}
+                                                >{definition.name}</option
+                                            >
+                                        {/each}
+                                    </select>
+                                </label>
+                                <label>
+                                    <span>Window</span>
+                                    <input
+                                        type="number"
+                                        min="1"
+                                        value={feature.window}
+                                        onchange={(event) =>
+                                            updateIndicator(
+                                                feature.id,
+                                                "window",
+                                                Number(
+                                                    (
+                                                        event.currentTarget as HTMLInputElement
+                                                    ).value,
+                                                ),
+                                            )}
+                                    />
+                                </label>
+                                <label>
+                                    <span>Source</span>
+                                    <select
+                                        value={feature.source}
+                                        onchange={(event) =>
+                                            updateIndicator(
+                                                feature.id,
+                                                "source",
+                                                (
+                                                    event.currentTarget as HTMLSelectElement
+                                                )
+                                                    .value as ResearchFeatureRow["source"],
+                                            )}
+                                    >
+                                        {#each getAllowedSources(feature.name, featureRegistry()) as source}
+                                            <option value={source}>{source}</option>
+                                        {/each}
+                                    </select>
+                                </label>
+                                <label>
+                                    <span>Shift</span>
+                                    <input
+                                        type="number"
+                                        min="0"
+                                        value={feature.shift}
+                                        onchange={(event) =>
+                                            updateIndicator(
+                                                feature.id,
+                                                "shift",
+                                                Number(
+                                                    (
+                                                        event.currentTarget as HTMLInputElement
+                                                    ).value,
+                                                ),
+                                            )}
+                                    />
+                                </label>
                                 <button
                                     type="button"
-                                    class="secondary"
-                                    onclick={addIndicator}
+                                    class="danger"
+                                    onclick={() => removeIndicator(feature.id)}
                                 >
-                                    Add Indicator
+                                    Remove
                                 </button>
+                                {#if errors[`feature-${feature.id}`]}
+                                    <small class="form-grid__wide">
+                                        {errors[`feature-${feature.id}`]}
+                                    </small>
+                                {/if}
                             </div>
-                            <div class="feature-list">
-                                {#each draft.signalSources.indicatorRows as feature}
-                                    <div class="feature-row">
-                                        <label>
-                                            <span>Name</span>
-                                            <select
-                                                value={feature.name}
-                                                onchange={(event) =>
-                                                    updateIndicator(
-                                                        feature.id,
-                                                        "name",
-                                                        (
-                                                            event.currentTarget as HTMLSelectElement
-                                                        )
-                                                            .value as ResearchFeatureRow["name"],
-                                                    )}
-                                            >
-                                                {#each getFeatureDefinitions(featureRegistry()) as definition}
-                                                    <option
-                                                        value={definition.name}
-                                                        >{definition.name}</option
-                                                    >
-                                                {/each}
-                                            </select>
-                                        </label>
-                                        <label>
-                                            <span>Window</span>
-                                            <input
-                                                type="number"
-                                                min="1"
-                                                value={feature.window}
-                                                onchange={(event) =>
-                                                    updateIndicator(
-                                                        feature.id,
-                                                        "window",
-                                                        Number(
-                                                            (
-                                                                event.currentTarget as HTMLInputElement
-                                                            ).value,
-                                                        ),
-                                                    )}
-                                            />
-                                        </label>
-                                        <label>
-                                            <span>Source</span>
-                                            <select
-                                                value={feature.source}
-                                                onchange={(event) =>
-                                                    updateIndicator(
-                                                        feature.id,
-                                                        "source",
-                                                        (
-                                                            event.currentTarget as HTMLSelectElement
-                                                        )
-                                                            .value as ResearchFeatureRow["source"],
-                                                    )}
-                                            >
-                                                {#each getAllowedSources(feature.name, featureRegistry()) as source}
-                                                    <option value={source}
-                                                        >{source}</option
-                                                    >
-                                                {/each}
-                                            </select>
-                                        </label>
-                                        <label>
-                                            <span>Shift</span>
-                                            <input
-                                                type="number"
-                                                min="0"
-                                                value={feature.shift}
-                                                onchange={(event) =>
-                                                    updateIndicator(
-                                                        feature.id,
-                                                        "shift",
-                                                        Number(
-                                                            (
-                                                                event.currentTarget as HTMLInputElement
-                                                            ).value,
-                                                        ),
-                                                    )}
-                                            />
-                                        </label>
-                                        <button
-                                            type="button"
-                                            class="danger"
-                                            onclick={() =>
-                                                removeIndicator(feature.id)}
-                                        >
-                                            Remove
-                                        </button>
-                                        {#if errors[`feature-${feature.id}`]}
-                                            <small class="form-grid__wide">
-                                                {errors[
-                                                    `feature-${feature.id}`
-                                                ]}
-                                            </small>
-                                        {/if}
-                                    </div>
-                                {/each}
-                            </div>
-                        </div>
-                    </CapabilityCard>
+                        {/each}
+                    </div>
                 </div>
 
                 <div class="stage-actions">
@@ -675,7 +625,7 @@
                         class="submit"
                         onclick={() => moveStage(1)}
                     >
-                        Continue to Prediction Task
+                        Continue to Model
                     </button>
                 </div>
             </section>
@@ -685,19 +635,17 @@
             <section class="surface">
                 <div class="surface-header surface-header--stack">
                     <div>
-                        <p class="eyebrow">03 Prediction Task</p>
-                        <h3>
-                            Pick the regression model for this baseline study
-                        </h3>
+                        <p class="eyebrow">03 Model</p>
+                        <h3>Pick the model for this baseline study</h3>
                     </div>
                     <p class="muted">
-                        Classification is specified for future work. This code
-                        path runs regression diagnostics first.
+                        Results will show model diagnostics before backtest
+                        metrics.
                     </p>
                 </div>
 
                 <div class="family-grid">
-                    {#each modelFamilies as family}
+                    {#each availableModelFamilies as family}
                         <button
                             type="button"
                             class:family-card={true}
@@ -706,11 +654,7 @@
                             disabled={family.status !== "available"}
                             onclick={() => handleModelFamilySelect(family.id)}
                         >
-                            <span
-                                >{family.status === "available"
-                                    ? "Available"
-                                    : "Future"}</span
-                            >
+                            <span>Available</span>
                             <strong>{family.label}</strong>
                             <p>{family.summary}</p>
                         </button>
@@ -718,7 +662,7 @@
                 </div>
 
                 <div class="variant-grid">
-                    {#each activeModelFamily.variantIds.map( (variantId) => getModelVariantById(variantId), ) as variant}
+                    {#each availableModelVariants as variant}
                         <button
                             type="button"
                             class:variant-card={true}
@@ -734,11 +678,7 @@
                                     },
                                 })}
                         >
-                            <span
-                                >{variant.status === "available"
-                                    ? "Supported"
-                                    : "Blocked"}</span
-                            >
+                            <span>Supported</span>
                             <strong>{variant.label}</strong>
                             <p>{variant.summary}</p>
                         </button>
@@ -749,10 +689,10 @@
                     >{/if}
 
                 <details class="advanced-config">
-                    <summary>Research policy and selection controls</summary>
+                    <summary>Advanced strategy controls</summary>
                     <div class="form-grid form-grid--four">
                         <label>
-                            <span>Selection Mode</span>
+                            <span>Run Mode</span>
                             <select bind:value={draft.modelFamily.runtimeMode}>
                                 <option value={DEFAULT_RUNTIME_MODE}>
                                     {getOptionLabel(DEFAULT_RUNTIME_MODE)}
@@ -765,7 +705,7 @@
                                 >{/if}
                         </label>
                         <label>
-                            <span>Default Bundle</span>
+                            <span>Default Settings</span>
                             <select
                                 value={draft.modelFamily.defaultBundleVersion ??
                                     ""}
@@ -834,7 +774,7 @@
                         class="submit"
                         onclick={() => moveStage(1)}
                     >
-                        Continue to Diagnostics
+                        Continue to Validation
                     </button>
                 </div>
             </section>
@@ -844,21 +784,20 @@
             <section class="surface">
                 <div class="surface-header surface-header--stack">
                     <div>
-                        <p class="eyebrow">04 Diagnostics and Backtest</p>
+                        <p class="eyebrow">04 Validation and Backtest</p>
                         <h3>
-                            Decide validation, baselines, and offline backtest
-                            assumptions
+                            Choose validation and baseline comparisons
                         </h3>
                     </div>
                     <p class="muted">
-                        The run remains research-only. Model diagnostics are
-                        reviewed before strategy metrics.
+                        This remains an offline research run. It does not imply
+                        live-order readiness.
                     </p>
                 </div>
 
                 <div class="form-grid form-grid--three">
                     <label class="toggle">
-                        <span>Validation Enabled</span>
+                    <span>Use validation split</span>
                         <input
                             type="checkbox"
                             bind:checked={draft.evaluation.enableValidation}
@@ -878,7 +817,7 @@
                         </select>
                     </label>
                     <label>
-                        <span>Baselines</span>
+                        <span>Compare Against</span>
                         <div class="baseline-list">
                             {#each availableBaselines as baseline}
                                 <label class="checkbox">
@@ -900,7 +839,7 @@
                 {#if draft.evaluation.enableValidation}
                     <div class="form-grid form-grid--three">
                         <label>
-                            <span>Validation Splits</span>
+                            <span>Split Count</span>
                             <input
                                 type="number"
                                 min="1"
@@ -911,7 +850,7 @@
                             {/if}
                         </label>
                         <label>
-                            <span>Validation Test Size</span>
+                            <span>Test Size</span>
                             <input
                                 type="number"
                                 min="0.01"
@@ -939,13 +878,16 @@
                     </div>
                 {/if}
 
-                <label class="toggle">
-                    <span>Save as monitoring run</span>
-                    <input
-                        type="checkbox"
-                        bind:checked={draft.evaluation.recordAsMonitorRun}
-                    />
-                </label>
+                <details class="advanced-config">
+                    <summary>Advanced run metadata</summary>
+                    <label class="toggle">
+                        <span>Save as monitoring run</span>
+                        <input
+                            type="checkbox"
+                            bind:checked={draft.evaluation.recordAsMonitorRun}
+                        />
+                    </label>
+                </details>
 
                 <div class="stage-actions">
                     <button
@@ -971,12 +913,11 @@
                 <div class="surface-header surface-header--stack">
                     <div>
                         <p class="eyebrow">05 Review</p>
-                        <h3>Check the workflow before submitting it</h3>
+                        <h3>Check the run before starting it</h3>
                     </div>
                     <p class="muted">
-                        The workflow will still submit to the current
-                        `/api/v1/research/runs` contract. This screen turns the
-                        contract details into a research-facing checklist.
+                        Confirm the key choices. Advanced request details are
+                        available below if you need to inspect them.
                     </p>
                 </div>
 
@@ -995,7 +936,7 @@
                         </p>
                     </div>
                     <div class="review-card">
-                        <span>Capabilities</span>
+                        <span>Feature Sets</span>
                         <strong>{activeCapabilities.length}</strong>
                         <p>
                             {activeCapabilities
@@ -1036,19 +977,14 @@
                             </ul>
                         {:else}
                             <p class="muted">
-                                No blocking issues detected. This workflow is
-                                ready to submit.
+                                No blocking issues detected. This run is ready
+                                to start.
                             </p>
                         {/if}
                     </div>
 
-                    <div class="surface surface--nested">
-                        <div class="surface-header">
-                            <div>
-                                <p class="eyebrow">Payload Summary</p>
-                                <h4>What the backend will receive</h4>
-                            </div>
-                        </div>
+                    <details class="surface surface--nested advanced-config">
+                        <summary>Advanced request summary</summary>
                         <div class="mini-grid">
                             <div>
                                 <strong>Symbols</strong>
@@ -1059,7 +995,7 @@
                                 >
                             </div>
                             <div>
-                                <strong>Signal Sources</strong>
+                                <strong>Feature Sources</strong>
                                 <span>{activeCapabilities.join(", ")}</span>
                             </div>
                             <div>
@@ -1079,7 +1015,7 @@
                                 >
                             </div>
                         </div>
-                    </div>
+                    </details>
                 </div>
 
                 <div class="stage-actions">
@@ -1110,7 +1046,6 @@
     .research-shell,
     .template-grid,
     .stage-strip,
-    .capability-grid,
     .feature-list,
     .review-grid {
         display: grid;
@@ -1237,14 +1172,6 @@
         grid-column: 1 / -1;
     }
 
-    .capability-grid {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-
-    .capability-grid--full {
-        grid-template-columns: 1fr;
-    }
-
     .feature-row {
         grid-template-columns: repeat(5, minmax(0, 1fr));
         align-items: end;
@@ -1321,7 +1248,6 @@
     @media (max-width: 1200px) {
         .template-grid,
         .stage-strip,
-        .capability-grid,
         .review-grid,
         .review-grid--secondary,
         .form-grid--three,

--- a/frontend/src/lib/components/RunReviewWorkspace.svelte
+++ b/frontend/src/lib/components/RunReviewWorkspace.svelte
@@ -64,10 +64,10 @@
     let selectedCompareIds: string[] = [];
 
     const comparisonLabels: Record<ComparisonEligibility, string> = {
-        comparison_metadata_only: "Metadata only",
-        sample_window_pending: "Sample window pending",
+        comparison_metadata_only: "Old record only",
+        sample_window_pending: "Not enough samples yet",
         strategy_pair_comparable: "Comparable",
-        research_only_comparable: "Research-only comparable",
+        research_only_comparable: "Comparable for research",
         unresolved_event_quarantine: "Quarantined",
     };
 
@@ -367,8 +367,8 @@
 
         if (runs.some((run) => !hasCompleteArtifacts(run))) {
             findings.push({
-                label: "Missing artifacts",
-                detail: "At least one selected run has only metadata-level results.",
+                label: "Old record only",
+                detail: "At least one selected run does not have saved diagnostics or backtest artifacts.",
                 severity: "blocker",
             });
         }
@@ -379,8 +379,8 @@
             )
         ) {
             findings.push({
-                label: "Metadata-only eligibility",
-                detail: "At least one selected run lacks final comparison semantics or persisted artifacts.",
+                label: "Old record only",
+                detail: "At least one selected run only has the old saved record format.",
                 severity: "blocker",
             });
         }
@@ -390,8 +390,8 @@
             )
         ) {
             findings.push({
-                label: "Sample window pending",
-                detail: "At least one selected run has artifacts, but sample floors are not yet met.",
+                label: "Not enough samples yet",
+                detail: "At least one selected run has artifacts, but needs more samples before comparison is strong.",
                 severity: "blocker",
             });
         }
@@ -404,14 +404,14 @@
         ) {
             findings.push({
                 label: "Event quarantine",
-                detail: "At least one selected run has unresolved event state.",
+                detail: "At least one selected run is blocked by unresolved corporate-event data.",
                 severity: "blocker",
             });
         }
         if (runs.some((run) => !run.comparison_eligibility)) {
             findings.push({
                 label: "Eligibility unavailable",
-                detail: "At least one selected run is missing comparison_eligibility metadata.",
+                detail: "At least one selected run is missing comparison status.",
                 severity: "blocker",
             });
         }
@@ -420,29 +420,29 @@
         );
         if (missingDimensions.length) {
             findings.push({
-                label: "Comparison metadata incomplete",
-                detail: `Missing ${missingDimensions.join(", ")} fields in at least one selected run.`,
+                label: "Comparison details incomplete",
+                detail: `Missing ${missingDimensions.join(", ")} in at least one selected run.`,
                 severity: "blocker",
             });
         }
         if (uniqueValues(fields.map((field) => field.datasetSignature)).length > 1) {
             findings.push({
                 label: "Dataset differs",
-                detail: "Market, symbols, or date range are not aligned.",
+                detail: "Market, symbols, or date range do not match.",
                 severity: "blocker",
             });
         }
         if (uniqueValues(fields.map((field) => field.targetSignature)).length > 1) {
             findings.push({
                 label: "Target differs",
-                detail: "Return target or horizon are not aligned.",
+                detail: "Return target or horizon does not match.",
                 severity: "blocker",
             });
         }
         if (uniqueValues(fields.map((field) => field.costSignature)).length > 1) {
             findings.push({
-                label: "Cost basis differs",
-                detail: "Fees, slippage, or execution cost model versions are not aligned.",
+                label: "Backtest assumptions differ",
+                detail: "Fees, slippage, or cost model versions do not match.",
                 severity: "blocker",
             });
         }
@@ -450,8 +450,8 @@
             uniqueValues(fields.map((field) => field.priceBasisSignature)).length > 1
         ) {
             findings.push({
-                label: "Price basis differs",
-                detail: "Label, entry, exit, or benchmark price-basis versions are not aligned.",
+                label: "Backtest assumptions differ",
+                detail: "Label, entry, exit, or benchmark price basis does not match.",
                 severity: "blocker",
             });
         }
@@ -462,14 +462,14 @@
         ) {
             findings.push({
                 label: "Missing-feature policy differs",
-                detail: "Missing-feature policy state or version is not aligned.",
+                detail: "Missing-feature handling does not match.",
                 severity: "blocker",
             });
         }
         if (uniqueValues(fields.map((field) => field.featureSignature)).length > 1) {
             findings.push({
                 label: "Feature set differs",
-                detail: "Treat quality deltas as feature-ablation evidence.",
+                detail: "Treat quality changes as feature-set evidence.",
                 severity: "note",
             });
         }
@@ -487,10 +487,10 @@
 
         return {
             status: blockers.length
-                ? "Limited comparison"
+                ? "Compare with caution"
                 : findings.length
-                  ? "Comparable with caveats"
-                : "Comparable research review",
+                  ? "Compare with notes"
+                  : "Comparable",
             findings,
         };
     };
@@ -503,24 +503,24 @@
 
     const getComparableReason = (run: ReviewRun) => {
         if (!hasCompleteArtifacts(run)) {
-            return "Missing persisted result artifacts.";
+            return "Old record only. Saved diagnostics or backtest artifacts are unavailable.";
         }
         if (run.comparison_eligibility === "comparison_metadata_only") {
-            return "Metadata exists, but final comparison semantics or artifacts are incomplete.";
+            return "Old record only. Comparison details or artifacts are incomplete.";
         }
         if (run.comparison_eligibility === "sample_window_pending") {
-            return "Artifacts exist, but sample floors are not yet met.";
+            return "Not enough samples yet.";
         }
         if (run.comparison_eligibility === "unresolved_event_quarantine") {
-            return "Blocked by unresolved event state.";
+            return "Blocked by unresolved corporate-event data.";
         }
         if (run.comparison_eligibility === "strategy_pair_comparable") {
-            return "Comparable for strategy-pair analysis.";
+            return "Comparable.";
         }
         if (!run.comparison_eligibility) {
-            return "Comparison eligibility is unavailable.";
+            return "Comparison status is unavailable.";
         }
-        return "Comparable for research review.";
+        return "Comparable for research.";
     };
 
     onMount(() => {
@@ -619,21 +619,21 @@
 <WorkspaceSection
     id="run-review-workspace"
     eyebrow="Experiments"
-    title="Review persisted experiments with the same result surface."
-    description="Use model diagnostics first, then strategy artifacts, baselines, and comparison caveats."
+    title="Reload, review, and compare saved runs."
+    description="Pick a run, inspect model diagnostics and backtest artifacts, then compare two or more runs."
 >
     <div class="review-shell">
         <section class="surface surface--hero">
             <div class="surface-header surface-header--stack">
                 <div>
-                    <p class="eyebrow">Decision Summary</p>
-                    <h3>What this run means</h3>
+                    <p class="eyebrow">Run Summary</p>
+                    <h3>{activeRunId ? "Selected run" : "Choose a run to review"}</h3>
                 </div>
             </div>
 
             <div class="summary-grid">
                 <div class="summary-card">
-                    <span>Research Setup</span>
+                    <span>Setup</span>
                     <strong
                         >{reviewSummary?.templateLabel ??
                             "No run selected"}</strong
@@ -643,14 +643,14 @@
                             {reviewSummary.modelFamilyLabel} /
                             {reviewSummary.modelVariantLabel}
                         {:else}
-                            Submit or load a run to populate the setup summary.
+                            Load a run to populate the setup summary.
                         {/if}
                     </p>
                 </div>
                 <div class="summary-card">
                     <span>Model Quality</span>
                     <strong>{formatMetric(activeRun?.model_diagnostics?.rmse)}</strong>
-                    <p>RMSE is shown before strategy interpretation.</p>
+                    <p>Lower RMSE is better for this regression view.</p>
                 </div>
                 <div class="summary-card">
                     <span>Baseline Delta</span>
@@ -667,7 +667,7 @@
                     </p>
                 </div>
                 <div class="summary-card">
-                    <span>Comparison Eligibility</span>
+                    <span>Compare Status</span>
                     <strong>
                         {formatEligibility(activeRun?.comparison_eligibility)}
                     </strong>
@@ -679,8 +679,8 @@
         <section class="surface">
             <div class="surface-header">
                 <div>
-                    <p class="eyebrow">Registry</p>
-                    <h3>Recent persisted runs</h3>
+                    <p class="eyebrow">Select Run</p>
+                    <h3>Saved runs</h3>
                 </div>
                 <button
                     type="button"
@@ -688,7 +688,7 @@
                     onclick={() => void refreshRecentRuns()}
                     disabled={isRecentRunsLoading}
                 >
-                    {isRecentRunsLoading ? "Refreshing..." : "Refresh"}
+                    {isRecentRunsLoading ? "Refreshing..." : "Refresh List"}
                 </button>
             </div>
 
@@ -724,6 +724,11 @@
                 </label>
             </div>
 
+            <div class="registry-help">
+                <span>Review: use the row button to load one run.</span>
+                <span>Compare: check two or more rows.</span>
+            </div>
+
             {#if recentRunsError}
                 <p class="muted">{recentRunsError}</p>
             {:else if isRecentRunsLoading && !recentRuns.length}
@@ -733,7 +738,7 @@
                     <table>
                         <thead>
                             <tr>
-                                <th>Compare</th>
+                                <th>Select</th>
                                 <th>Run ID</th>
                                 <th>Status</th>
                                 <th>Created</th>
@@ -749,6 +754,7 @@
                                 <tr>
                                     <td>
                                         <input
+                                            aria-label={`Compare ${run.run_id}`}
                                             type="checkbox"
                                             checked={selectedCompareIds.includes(
                                                 run.run_id,
@@ -790,7 +796,7 @@
                                             onclick={() =>
                                                 (selectedRunId = run.run_id)}
                                         >
-                                            Load
+                                            Review
                                         </button>
                                     </td>
                                 </tr>
@@ -833,66 +839,70 @@
                         {/each}
                     {:else}
                         <p class="muted">
-                            Selected runs share dataset, target, feature set,
-                            model config, cost basis, price basis, and persisted
-                            result artifacts.
+                            Selected runs share the key dataset, target,
+                            feature, model, and backtest assumptions.
                         </p>
                     {/if}
                 </div>
-                <div class="table-wrap">
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Run ID</th>
-                                <th>Dataset</th>
-                                <th>Target</th>
-                                <th>Features</th>
-                                <th>Model</th>
-                                <th>Cost Basis</th>
-                                <th>Price Basis</th>
-                                <th>Missing Policy</th>
-                                <th>RMSE</th>
-                                <th>Rank IC</th>
-                                <th>Total Return</th>
-                                <th>Baseline Delta</th>
-                                <th>Caveat</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {#each comparisonRuns as run}
-                                {@const comparison = getComparisonFields(run)}
-                                {@const baseline = summarizeBaselineComparison(run)}
+                <details class="comparison-details">
+                    <summary>Show detailed comparison table</summary>
+                    <div class="table-wrap">
+                        <table>
+                            <thead>
                                 <tr>
-                                    <td>{run.run_id}</td>
-                                    <td>{comparison.datasetLabel}</td>
-                                    <td>{comparison.targetLabel}</td>
-                                    <td>{comparison.featureLabel}</td>
-                                    <td>{comparison.modelLabel}</td>
-                                    <td>{comparison.costLabel}</td>
-                                    <td>{comparison.priceBasisLabel}</td>
-                                    <td>
-                                        {comparison.missingFeaturePolicyLabel}
-                                    </td>
-                                    <td>
-                                        {formatMetric(
-                                            run.model_diagnostics?.rmse,
-                                        )}
-                                    </td>
-                                    <td>
-                                        {formatMetric(
-                                            run.model_diagnostics?.rank_ic,
-                                        )}
-                                    </td>
-                                    <td>
-                                        {formatMetric(run.metrics?.total_return)}
-                                    </td>
-                                    <td>{formatMetric(baseline?.delta)}</td>
-                                    <td>{getComparableReason(run)}</td>
+                                    <th>Run ID</th>
+                                    <th>Dataset</th>
+                                    <th>Target</th>
+                                    <th>Features</th>
+                                    <th>Model</th>
+                                    <th>Cost Basis</th>
+                                    <th>Price Basis</th>
+                                    <th>Missing Policy</th>
+                                    <th>RMSE</th>
+                                    <th>Rank IC</th>
+                                    <th>Total Return</th>
+                                    <th>Baseline Delta</th>
+                                    <th>Caveat</th>
                                 </tr>
-                            {/each}
-                        </tbody>
-                    </table>
-                </div>
+                            </thead>
+                            <tbody>
+                                {#each comparisonRuns as run}
+                                    {@const comparison = getComparisonFields(run)}
+                                    {@const baseline = summarizeBaselineComparison(run)}
+                                    <tr>
+                                        <td>{run.run_id}</td>
+                                        <td>{comparison.datasetLabel}</td>
+                                        <td>{comparison.targetLabel}</td>
+                                        <td>{comparison.featureLabel}</td>
+                                        <td>{comparison.modelLabel}</td>
+                                        <td>{comparison.costLabel}</td>
+                                        <td>{comparison.priceBasisLabel}</td>
+                                        <td>
+                                            {comparison.missingFeaturePolicyLabel}
+                                        </td>
+                                        <td>
+                                            {formatMetric(
+                                                run.model_diagnostics?.rmse,
+                                            )}
+                                        </td>
+                                        <td>
+                                            {formatMetric(
+                                                run.model_diagnostics?.rank_ic,
+                                            )}
+                                        </td>
+                                        <td>
+                                            {formatMetric(
+                                                run.metrics?.total_return,
+                                            )}
+                                        </td>
+                                        <td>{formatMetric(baseline?.delta)}</td>
+                                        <td>{getComparableReason(run)}</td>
+                                    </tr>
+                                {/each}
+                            </tbody>
+                        </table>
+                    </div>
+                </details>
             </section>
         {/if}
 
@@ -901,7 +911,7 @@
                 <div class="surface">
                     <div class="surface-header">
                         <div>
-                            <p class="eyebrow">Selected Result</p>
+                            <p class="eyebrow">Review Run</p>
                             <h3>{activeRunId}</h3>
                         </div>
                         {#if isSelectedRunLoading}
@@ -937,7 +947,7 @@
                     <div class="surface">
                         <p class="muted">
                             Equity curve is unavailable for this record. This is
-                            expected for older metadata-only runs.
+                            expected for older saved runs.
                         </p>
                     </div>
                 {/if}
@@ -996,27 +1006,24 @@
                     <div class="surface">
                         <p class="muted">
                             Signals are unavailable for this record. This is
-                            expected for older metadata-only runs.
+                            expected for older saved runs.
                         </p>
                     </div>
                 {/if}
             </section>
         {:else}
             <section class="surface">
-                <p class="muted">Submit or load a run to review results.</p>
+                <p class="muted">Load a run to review results.</p>
             </section>
         {/if}
 
-        <section class="surface">
-            <div class="surface-header surface-header--stack">
-                <div>
-                    <p class="eyebrow">Readiness Context</p>
-                    <h3>Baseline capability state for this run</h3>
-                </div>
-                <p class="muted">
-                    TW daily baseline readiness context. Current blocker count: {blockerCount}
-                </p>
-            </div>
+        <details class="surface support-surface">
+            <summary>
+                Readiness context
+                {#if activeCapabilities.length}
+                    ({blockerCount} blocker{blockerCount === 1 ? "" : "s"})
+                {/if}
+            </summary>
 
             {#if activeCapabilities.length}
                 <div class="governance-grid">
@@ -1034,15 +1041,14 @@
                 </div>
             {:else}
                 <p class="muted">
-                    Capability readiness will appear after you submit or load a
-                    run.
+                    Readiness context will appear after you load a run.
                 </p>
             {/if}
-        </section>
+        </details>
 
         {#if metadataRun}
             <details class="surface advanced-surface">
-                <summary>Advanced metadata</summary>
+                <summary>Advanced run metadata</summary>
                 <div class="metadata-grid">
                     <div>
                         <p class="eyebrow">Config Sources</p>
@@ -1104,6 +1110,24 @@
 
     .registry-controls {
         grid-template-columns: 1.4fr repeat(2, minmax(180px, 0.5fr));
+    }
+
+    .registry-help {
+        display: flex;
+        gap: 0.65rem;
+        flex-wrap: wrap;
+    }
+
+    .registry-help span {
+        display: inline-flex;
+        align-items: center;
+        min-height: 2rem;
+        padding: 0.2rem 0.7rem;
+        border-radius: 999px;
+        border: 1px solid rgba(148, 163, 184, 0.12);
+        color: var(--muted);
+        background: rgba(15, 35, 54, 0.72);
+        font-size: 0.8rem;
     }
 
     .summary-card,
@@ -1184,9 +1208,23 @@
         line-height: 1.45;
     }
 
+    .comparison-details,
+    .support-surface,
+    .advanced-surface {
+        gap: var(--space-3);
+    }
+
+    .comparison-details summary,
+    .support-surface summary,
     .advanced-surface summary {
         cursor: pointer;
         font-weight: 600;
+    }
+
+    .comparison-details[open] summary,
+    .support-surface[open] summary,
+    .advanced-surface[open] summary {
+        margin-bottom: var(--space-3);
     }
 
     @media (max-width: 1200px) {

--- a/frontend/src/lib/state/researchWorkflow.ts
+++ b/frontend/src/lib/state/researchWorkflow.ts
@@ -98,7 +98,7 @@ export const modelVariants: ModelVariantDefinition[] = [
     id: "xgboost",
     label: "XGBoost",
     summary:
-      "Gradient-boosted tree path. Requires the local XGBoost native runtime to be available.",
+      "Boosted-tree option for environments where XGBoost is installed.",
     status: "available",
   },
   {
@@ -111,8 +111,7 @@ export const modelVariants: ModelVariantDefinition[] = [
   {
     id: "extra_trees",
     label: "Extra Trees",
-    summary:
-      "Default no-native-runtime tree baseline for quick local research loops.",
+    summary: "Default quick baseline for local research loops.",
     status: "available",
   },
   {
@@ -128,8 +127,7 @@ export const modelFamilies: ModelFamilyDefinition[] = [
   {
     id: "tree_ensemble",
     label: "Tree Ensemble",
-    summary:
-      "Current production-ready family that maps cleanly to the existing backend run contract.",
+    summary: "Tree-based models for baseline TW daily research.",
     status: "available",
     variantIds: ["xgboost", "random_forest", "extra_trees"],
   },


### PR DESCRIPTION
## Summary
- Make Start focus on the three next-task entries and move data readiness into supporting details.
- Simplify Builder IA by hiding single-template and future-model noise, flattening feature setup, and moving advanced settings behind details.
- Clarify Experiments copy for reload/review/compare, use user-facing comparison labels, and collapse detailed comparison/readiness/metadata surfaces.

## Validation
- bun x tsc -p frontend/tsconfig.json --noEmit
- cd frontend && bun run build
- agent-browser desktop and narrow viewport smoke for Start, Builder, and Experiments at http://127.0.0.1:5173/

## Notes
- No API contract, backend behavior, dependency, or research-logic changes.