### PR TITLE
feat: improve market data sync usability

### DIFF
--- a/backend/app/application.py
+++ b/backend/app/application.py
@@ -62,7 +62,7 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
-    expose_headers=["X-Request-Id"],
+    expose_headers=["X-Request-Id", "X-Total-Count"],
 )
 
 app.include_router(system_router)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -14,6 +14,7 @@ export {
   createRecoveryDrill,
   createRecoveryDrillSchedule,
   createReplay,
+  fetchTwCompanyProfiles,
   fetchTwDailyReadiness,
   fetchImportantEvents,
   fetchLifecycleRecords,

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -66,3 +66,28 @@ export async function requestJson<T>(
   }
   return (await response.json()) as T;
 }
+
+export async function requestJsonWithHeaders<T>(
+  path: string,
+  init?: RequestInit,
+): Promise<{ data: T; headers: Headers }> {
+  const bodyIsFormData =
+    typeof FormData !== "undefined" && init?.body instanceof FormData;
+  const hasBody = init?.body !== undefined && init?.body !== null;
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    ...init,
+    headers: {
+      ...(hasBody && !bodyIsFormData
+        ? { "Content-Type": "application/json" }
+        : {}),
+      ...(init?.headers ?? {}),
+    },
+  });
+  if (!response.ok) {
+    throw await parseError(response);
+  }
+  return {
+    data: (await response.json()) as T,
+    headers: response.headers,
+  };
+}

--- a/frontend/src/lib/api/dataPlane.ts
+++ b/frontend/src/lib/api/dataPlane.ts
@@ -11,11 +11,12 @@ import type {
   RecoveryDrillScheduleRequest,
   ReplayRecord,
   ReplayRequest,
+  TwCompanyProfile,
   TwDailyReadinessRequest,
   TwDailyReadinessResponse,
 } from "../types";
 
-import { requestJson } from "./client";
+import { requestJson, requestJsonWithHeaders } from "./client";
 
 export const createDataIngestion = (payload: DataIngestionRequest) =>
   requestJson<DataIngestionResponse>("/api/v1/data/ingestions", {
@@ -37,6 +38,59 @@ export const fetchTwDailyReadiness = (payload: TwDailyReadinessRequest) =>
     method: "POST",
     body: JSON.stringify(payload),
   });
+
+const TW_COMPANY_PROFILE_PAGE_SIZE = 5000;
+
+export const fetchTwCompanyProfiles = async (
+  limit = TW_COMPANY_PROFILE_PAGE_SIZE,
+  offset = 0,
+) => {
+  const firstPage = await requestJsonWithHeaders<TwCompanyProfile[]>(
+    `/api/v1/data/tw-company-profiles?limit=${limit}&offset=${offset}`,
+  );
+  const totalCountHeader = firstPage.headers.get("X-Total-Count");
+  const totalCount = totalCountHeader ? Number(totalCountHeader) : null;
+  if (
+    totalCount === null ||
+    !Number.isFinite(totalCount)
+  ) {
+    if (firstPage.data.length < limit) {
+      return firstPage.data;
+    }
+
+    const pages = [firstPage.data];
+    let nextOffset = offset + limit;
+    let nextPage: TwCompanyProfile[];
+    do {
+      nextPage = await requestJson<TwCompanyProfile[]>(
+        `/api/v1/data/tw-company-profiles?limit=${limit}&offset=${nextOffset}`,
+      );
+      pages.push(nextPage);
+      nextOffset += limit;
+    } while (nextPage.length === limit);
+    return pages.flat();
+  }
+
+  if (
+    offset + firstPage.data.length >= totalCount
+  ) {
+    return firstPage.data;
+  }
+
+  const pages = [firstPage.data];
+  for (
+    let nextOffset = offset + Math.max(firstPage.data.length, limit);
+    nextOffset < totalCount;
+    nextOffset += limit
+  ) {
+    pages.push(
+      await requestJson<TwCompanyProfile[]>(
+        `/api/v1/data/tw-company-profiles?limit=${limit}&offset=${nextOffset}`,
+      ),
+    );
+  }
+  return pages.flat();
+};
 
 export const createRecoveryDrill = (payload: RecoveryDrillRequest) =>
   requestJson<RecoveryDrillRecord>("/api/v1/data/recovery-drills", {

--- a/frontend/src/lib/components/Dashboard.svelte
+++ b/frontend/src/lib/components/Dashboard.svelte
@@ -1,20 +1,27 @@
 <script lang="ts">
     import { onMount } from "svelte";
 
-    import { ApiError, fetchTwDailyReadiness } from "../api";
+    import {
+        ApiError,
+        createDataIngestion,
+        fetchTwDailyReadiness,
+    } from "../api";
     import {
         buildCapabilityReadinessMap,
         createDefaultResearchWorkflowDraft,
         parseSymbols,
     } from "../state/researchWorkflow";
     import type {
+        DataIngestionResponse,
         ResearchRunResponse,
         ResearchSubmissionSummary,
+        TwDailyReadinessSymbolStatus,
         TwDailyReadinessResponse,
     } from "../types";
     import OperationsWorkspace from "./OperationsWorkspace.svelte";
     import ResearchWorkspace from "./ResearchWorkspace.svelte";
     import RunReviewWorkspace from "./RunReviewWorkspace.svelte";
+    import SymbolSelector from "./SymbolSelector.svelte";
 
     type SurfaceId = "start" | "builder" | "experiments" | "data_ops";
 
@@ -27,6 +34,47 @@
     let readinessEndDate = builderDefaults.universe.endDate;
     let readinessData: TwDailyReadinessResponse | null = null;
     let readinessLoadError: string | null = null;
+    let syncingSymbols: string[] = [];
+    let syncMessages: Record<string, string> = {};
+    let syncErrors: Record<string, string> = {};
+    let isSyncingAttention = false;
+    let attentionSyncProgress: {
+        current: number;
+        total: number;
+        symbol: string;
+    } | null = null;
+    let readinessSymbolSelector:
+        | { commitPending: () => void }
+        | null = null;
+
+    const setReadinessSymbols = (symbols: string[]) => {
+        readinessSymbolsInput = symbols.join(", ");
+    };
+
+    const removeKey = (record: Record<string, string>, key: string) => {
+        const { [key]: _removed, ...rest } = record;
+        return rest;
+    };
+
+    const formatIngestionSummary = (result: DataIngestionResponse) =>
+        `Backfill ${result.backfill.upserted_rows} rows, daily update ${result.daily_update.upserted_rows} rows, minute supplement ${result.minute_supplement.status}.`;
+
+    const yearsForReadinessRange = () => {
+        if (!readinessStartDate || !readinessEndDate) {
+            return 5;
+        }
+        const start = new Date(readinessStartDate).getTime();
+        const end = new Date(readinessEndDate).getTime();
+        if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) {
+            return 1;
+        }
+        return Math.max(1, Math.ceil((end - start) / 31_536_000_000));
+    };
+
+    const needsDataSync = (symbol: TwDailyReadinessSymbolStatus) =>
+        symbol.status !== "ready" ||
+        symbol.stale_trading_days > 0 ||
+        (symbol.missing_trading_days ?? 0) > 0;
 
     const loadTwDailyReadiness = async () => {
         const symbols = parseSymbols(readinessSymbolsInput);
@@ -36,6 +84,7 @@
             return;
         }
         try {
+            readinessLoadError = null;
             readinessData = await fetchTwDailyReadiness({
                 market: "TW",
                 symbols,
@@ -53,6 +102,68 @@
                 error instanceof ApiError
                     ? `${error.code}: ${error.message}`
                     : "TW daily readiness is unavailable.";
+            readinessData = null;
+        }
+    };
+
+    const refreshReadiness = () => {
+        readinessSymbolSelector?.commitPending();
+        void loadTwDailyReadiness();
+    };
+
+    const syncReadinessSymbol = async (
+        symbol: string,
+        options: { refreshReadiness: boolean } = { refreshReadiness: true },
+    ) => {
+        if (syncingSymbols.includes(symbol)) {
+            return;
+        }
+        syncingSymbols = [...syncingSymbols, symbol];
+        syncErrors = removeKey(syncErrors, symbol);
+        syncMessages = removeKey(syncMessages, symbol);
+        try {
+            const result = await createDataIngestion({
+                symbol,
+                market: "TW",
+                years: yearsForReadinessRange(),
+            });
+            syncMessages = {
+                ...syncMessages,
+                [symbol]: formatIngestionSummary(result),
+            };
+            if (options.refreshReadiness) {
+                await loadTwDailyReadiness();
+            }
+        } catch (error) {
+            syncErrors = {
+                ...syncErrors,
+                [symbol]:
+                    error instanceof ApiError
+                        ? `${error.code}: ${error.message}`
+                        : "Unable to sync market data.",
+            };
+        } finally {
+            syncingSymbols = syncingSymbols.filter((item) => item !== symbol);
+        }
+    };
+
+    const syncAttentionSymbols = async () => {
+        isSyncingAttention = true;
+        attentionSyncProgress = null;
+        try {
+            const symbols = [...attentionSymbols];
+            for (const [index, symbol] of symbols.entries()) {
+                attentionSyncProgress = {
+                    current: index + 1,
+                    total: symbols.length,
+                    symbol,
+                };
+                await syncReadinessSymbol(symbol, { refreshReadiness: false });
+            }
+            await loadTwDailyReadiness();
+        } finally {
+            isSyncingAttention = false;
+            attentionSyncProgress = null;
         }
     };
 
@@ -82,6 +193,10 @@
         missing: 0,
         stale: 0,
     };
+    $: attentionSymbols =
+        readinessData?.symbols
+            .filter(needsDataSync)
+            .map((symbol) => symbol.symbol) ?? [];
 </script>
 
 <div class="dashboard-shell">
@@ -142,13 +257,15 @@
                 </summary>
 
                 <div class="readiness-controls">
-                    <label>
-                        <span>Requested Symbols</span>
-                        <input
-                            bind:value={readinessSymbolsInput}
-                            placeholder="2330, 2317"
-                        />
-                    </label>
+                    <SymbolSelector
+                        bind:this={readinessSymbolSelector}
+                        label="Requested Symbols"
+                        market="TW"
+                        value={parseSymbols(readinessSymbolsInput)}
+                        placeholder="Search 2330 or company name"
+                        on:change={(event) =>
+                            setReadinessSymbols(event.detail.value)}
+                    />
                     <label>
                         <span>Start Date</span>
                         <input type="date" bind:value={readinessStartDate} />
@@ -160,11 +277,31 @@
                     <button
                         type="button"
                         class="secondary"
-                        onclick={() => void loadTwDailyReadiness()}
+                        onclick={refreshReadiness}
                     >
                         Refresh
                     </button>
+                    <button
+                        type="button"
+                        class="submit"
+                        onclick={() => void syncAttentionSymbols()}
+                        disabled={!attentionSymbols.length || isSyncingAttention}
+                    >
+                        {isSyncingAttention
+                            ? "Syncing..."
+                            : "Sync Attention Symbols"}
+                    </button>
                 </div>
+                <p class="muted readiness-message">
+                    Warnings mean some requested trading days are missing. A run
+                    may still work if enough model-ready rows remain.
+                </p>
+                {#if attentionSyncProgress}
+                    <p class="muted readiness-message">
+                        Syncing {attentionSyncProgress.current}/{attentionSyncProgress.total}:
+                        {attentionSyncProgress.symbol}
+                    </p>
+                {/if}
                 {#if readinessLoadError}
                     <p class="muted readiness-message">{readinessLoadError}</p>
                 {/if}
@@ -188,6 +325,44 @@
                                         Latest daily row: {symbol.latest_daily_date ?? "unavailable"}
                                     {/if}
                                 </p>
+                                <div class="readiness-row__meta">
+                                    <span>
+                                        {symbol.covered_trading_days ?? 0}/{symbol.requested_trading_days ?? 0}
+                                        days covered
+                                    </span>
+                                    <span>
+                                        Latest: {symbol.latest_daily_date ?? "N/A"}
+                                    </span>
+                                </div>
+                                {#if needsDataSync(symbol)}
+                                    <button
+                                        type="button"
+                                        class="secondary"
+                                        onclick={() =>
+                                            void syncReadinessSymbol(
+                                                symbol.symbol,
+                                            )}
+                                        disabled={syncingSymbols.includes(
+                                            symbol.symbol,
+                                        )}
+                                    >
+                                        {syncingSymbols.includes(symbol.symbol)
+                                            ? "Syncing..."
+                                            : "Sync Data"}
+                                    </button>
+                                {/if}
+                                {#if syncMessages[symbol.symbol]}
+                                    <p class="muted readiness-message">
+                                        {syncMessages[symbol.symbol]}
+                                    </p>
+                                {/if}
+                                {#if syncErrors[symbol.symbol]}
+                                    <p
+                                        class="muted readiness-message readiness-message--error"
+                                    >
+                                        {syncErrors[symbol.symbol]}
+                                    </p>
+                                {/if}
                             </article>
                         {/each}
                     </div>
@@ -385,7 +560,7 @@
     .readiness-controls {
         display: grid;
         gap: var(--space-3);
-        grid-template-columns: minmax(0, 1.4fr) repeat(2, minmax(0, 1fr)) auto;
+        grid-template-columns: minmax(280px, 1.4fr) repeat(2, minmax(0, 1fr)) auto auto;
         align-items: end;
     }
 
@@ -401,6 +576,10 @@
 
     .readiness-message {
         margin: 0;
+    }
+
+    .readiness-message--error {
+        color: #ffb4c1;
     }
 
     .readiness-details {
@@ -440,6 +619,12 @@
     .readiness-row p {
         color: var(--muted);
         line-height: 1.45;
+    }
+
+    .readiness-row__meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
     }
 
     .readiness-row--warning {

--- a/frontend/src/lib/components/OperationsWorkspace.svelte
+++ b/frontend/src/lib/components/OperationsWorkspace.svelte
@@ -8,12 +8,12 @@
 
     const sections = [
         {
-            title: "Ingestion Recovery",
-            detail: "Manual catch-up and scheduled recovery stay here so the research flow does not turn into an operator console.",
+            title: "Market Data Sync",
+            detail: "Manual symbol sync and scheduled recovery stay here so the research flow does not turn into an operator console.",
         },
         {
             title: "Replay Diagnostics",
-            detail: "Raw replay remains available for ingestion troubleshooting without exposing low-level archival internals.",
+            detail: "Raw replay remains available for sync troubleshooting without exposing low-level archival internals.",
         },
         {
             title: "Lifecycle Repair",
@@ -55,11 +55,11 @@
         <section class="surface">
             <div class="surface-header surface-header--stack">
                 <div>
-                    <p class="eyebrow">Ingestion Recovery</p>
-                    <h3>Repair missing or stale market data</h3>
+                    <p class="eyebrow">Market Data Sync</p>
+                    <h3>Sync missing or stale market data</h3>
                 </div>
                 <p class="muted">
-                    Manual ingestions and recovery drills stay available when
+                    Manual market-data sync and recovery drills stay available when
                     automated acquisition needs intervention.
                 </p>
             </div>

--- a/frontend/src/lib/components/ResearchWorkspace.svelte
+++ b/frontend/src/lib/components/ResearchWorkspace.svelte
@@ -42,6 +42,7 @@
         ResearchWorkflowStageId,
         ResearchRunResponse,
     } from "../types";
+    import SymbolSelector from "./SymbolSelector.svelte";
     import WorkspaceSection from "./layout/WorkspaceSection.svelte";
 
     export let capabilityReadiness: Record<
@@ -76,6 +77,9 @@
     let submitError: AppError | null = null;
     let activeStage: ResearchWorkflowStageId = "universe";
     let lastSubmittedSummary: ResearchSubmissionSummary | null = null;
+    let universeSymbolSelector:
+        | { commitPending: () => void }
+        | null = null;
 
     const optionLabels: Record<string, string> = {
         runtime_compatibility_mode: "Manual Threshold Mode",
@@ -212,6 +216,7 @@
     };
 
     const moveStage = (direction: -1 | 1) => {
+        universeSymbolSelector?.commitPending();
         const currentIndex = stageOrder.indexOf(activeStage);
         const nextIndex = currentIndex + direction;
         if (nextIndex < 0 || nextIndex >= stageOrder.length) {
@@ -221,10 +226,22 @@
     };
 
     const openStage = (stageId: ResearchWorkflowStageId) => {
+        universeSymbolSelector?.commitPending();
         activeStage = stageId;
     };
 
+    const updateUniverseSymbols = (symbols: string[]) => {
+        draft = {
+            ...draft,
+            universe: {
+                ...draft.universe,
+                symbolsInput: symbols.join(", "),
+            },
+        };
+    };
+
     const submitWorkflow = () => {
+        universeSymbolSelector?.commitPending();
         const nextErrors = validateResearchWorkflow(draft, capabilityReadiness);
         errors = nextErrors;
 
@@ -378,6 +395,81 @@
                     </button>
                 {/each}
             </div>
+
+            <div class="workflow-action-bar">
+                {#if activeStage === "universe"}
+                    <button
+                        type="button"
+                        class="submit"
+                        onclick={() => moveStage(1)}
+                    >
+                        Continue to Features
+                    </button>
+                {:else if activeStage === "signal_sources"}
+                    <button
+                        type="button"
+                        class="secondary"
+                        onclick={() => moveStage(-1)}
+                    >
+                        Back
+                    </button>
+                    <button
+                        type="button"
+                        class="submit"
+                        onclick={() => moveStage(1)}
+                    >
+                        Continue to Model
+                    </button>
+                {:else if activeStage === "model_family"}
+                    <button
+                        type="button"
+                        class="secondary"
+                        onclick={() => moveStage(-1)}
+                    >
+                        Back
+                    </button>
+                    <button
+                        type="button"
+                        class="submit"
+                        onclick={() => moveStage(1)}
+                    >
+                        Continue to Validation
+                    </button>
+                {:else if activeStage === "evaluation"}
+                    <button
+                        type="button"
+                        class="secondary"
+                        onclick={() => moveStage(-1)}
+                    >
+                        Back
+                    </button>
+                    <button
+                        type="button"
+                        class="submit"
+                        onclick={() => moveStage(1)}
+                    >
+                        Continue to Review
+                    </button>
+                {:else}
+                    <button
+                        type="button"
+                        class="secondary"
+                        onclick={() => moveStage(-1)}
+                    >
+                        Back
+                    </button>
+                    <button
+                        type="button"
+                        class="submit"
+                        onclick={submitWorkflow}
+                        disabled={mutation.isPending}
+                    >
+                        {mutation.isPending
+                            ? "Running Research..."
+                            : "Run Research Workflow"}
+                    </button>
+                {/if}
+            </div>
         </section>
 
         {#if submitError}
@@ -426,16 +518,20 @@
                         <span>Market</span>
                         <input value="TW" disabled />
                     </label>
-                    <label class="form-grid__wide">
-                        <span>Symbols</span>
-                        <input
-                            bind:value={draft.universe.symbolsInput}
-                            placeholder="2330, 2317"
+                    <div class="form-grid__wide">
+                        <SymbolSelector
+                            bind:this={universeSymbolSelector}
+                            label="Symbols"
+                            market={draft.universe.market}
+                            value={parseSymbols(draft.universe.symbolsInput)}
+                            placeholder="Search 2330 or company name"
+                            on:change={(event) =>
+                                updateUniverseSymbols(event.detail.value)}
                         />
                         {#if errors.symbolsInput}<small
                                 >{errors.symbolsInput}</small
                             >{/if}
-                    </label>
+                    </div>
                     <label>
                         <span>Start Date</span>
                         <input
@@ -475,7 +571,7 @@
 
                 {#if errors.dateRange}<small>{errors.dateRange}</small>{/if}
 
-                <div class="stage-actions">
+                <div class="stage-actions stage-actions--bottom">
                     <button
                         type="button"
                         class="submit"
@@ -612,7 +708,7 @@
                     </div>
                 </div>
 
-                <div class="stage-actions">
+                <div class="stage-actions stage-actions--bottom">
                     <button
                         type="button"
                         class="secondary"
@@ -761,7 +857,7 @@
                     </div>
                 </details>
 
-                <div class="stage-actions">
+                <div class="stage-actions stage-actions--bottom">
                     <button
                         type="button"
                         class="secondary"
@@ -889,7 +985,7 @@
                     </label>
                 </details>
 
-                <div class="stage-actions">
+                <div class="stage-actions stage-actions--bottom">
                     <button
                         type="button"
                         class="secondary"
@@ -1018,7 +1114,7 @@
                     </details>
                 </div>
 
-                <div class="stage-actions">
+                <div class="stage-actions stage-actions--bottom">
                     <button
                         type="button"
                         class="secondary"
@@ -1238,11 +1334,25 @@
         gap: 0.35rem;
     }
 
+    .workflow-action-bar {
+        display: flex;
+        justify-content: flex-end;
+        gap: 0.8rem;
+        flex-wrap: wrap;
+        padding-top: var(--space-2);
+        border-top: 1px solid rgba(148, 163, 184, 0.1);
+    }
+
     .stage-actions {
         display: flex;
         justify-content: flex-end;
         gap: 0.8rem;
         flex-wrap: wrap;
+    }
+
+    .stage-actions--bottom {
+        padding-top: var(--space-3);
+        border-top: 1px solid rgba(148, 163, 184, 0.1);
     }
 
     @media (max-width: 1200px) {
@@ -1260,6 +1370,11 @@
     }
 
     @media (max-width: 720px) {
+        .workflow-action-bar {
+            align-items: stretch;
+            flex-direction: column;
+        }
+
         .stage-actions {
             align-items: stretch;
             flex-direction: column;

--- a/frontend/src/lib/components/RunReviewWorkspace.svelte
+++ b/frontend/src/lib/components/RunReviewWorkspace.svelte
@@ -154,6 +154,12 @@
     const formatMetric = (value: number | null | undefined) =>
         value === null || value === undefined ? "N/A" : value.toFixed(4);
 
+    const shortRunId = (runId: string) =>
+        runId.length > 12 ? `${runId.slice(0, 8)}...${runId.slice(-4)}` : runId;
+
+    const formatRunSymbols = (run: ResearchRunRecord) =>
+        run.symbols.length ? run.symbols.join(", ") : "N/A";
+
     const getPayloadArray = (
         payload: Record<string, unknown> | null | undefined,
         key: string,
@@ -734,75 +740,75 @@
             {:else if isRecentRunsLoading && !recentRuns.length}
                 <p class="muted">Loading persisted runs...</p>
             {:else if filteredRuns.length}
-                <div class="table-wrap">
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Select</th>
-                                <th>Run ID</th>
-                                <th>Status</th>
-                                <th>Created</th>
-                                <th>Market</th>
-                                <th>RMSE</th>
-                                <th>Total Return</th>
-                                <th>Eligibility</th>
-                                <th></th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {#each filteredRuns as run}
-                                <tr>
-                                    <td>
-                                        <input
-                                            aria-label={`Compare ${run.run_id}`}
-                                            type="checkbox"
-                                            checked={selectedCompareIds.includes(
-                                                run.run_id,
-                                            )}
-                                            onchange={(event) =>
-                                                compareToggle(
-                                                    run.run_id,
-                                                    (
-                                                        event.currentTarget as HTMLInputElement
-                                                    ).checked,
-                                                )}
-                                        />
-                                    </td>
-                                    <td>{run.run_id}</td>
-                                    <td>{run.status}</td>
-                                    <td
-                                        >{new Date(
-                                            run.created_at,
-                                        ).toLocaleString()}</td
-                                    >
-                                    <td>{run.market ?? "N/A"}</td>
-                                    <td>
-                                        {formatMetric(
-                                            run.model_diagnostics?.rmse,
+                <div class="run-list">
+                    {#each filteredRuns as run}
+                        <article class="run-list-row">
+                            <label class="compare-check">
+                                <input
+                                    aria-label={`Compare ${run.run_id}`}
+                                    type="checkbox"
+                                    checked={selectedCompareIds.includes(
+                                        run.run_id,
+                                    )}
+                                    onchange={(event) =>
+                                        compareToggle(
+                                            run.run_id,
+                                            (
+                                                event.currentTarget as HTMLInputElement
+                                            ).checked,
                                         )}
-                                    </td>
-                                    <td>
-                                        {formatMetric(run.metrics?.total_return)}
-                                    </td>
-                                    <td>
-                                        {formatEligibility(
-                                            run.comparison_eligibility,
-                                        )}
-                                    </td>
-                                    <td>
-                                        <button
-                                            type="button"
-                                            class="secondary"
-                                            onclick={() =>
-                                                (selectedRunId = run.run_id)}
-                                        >
-                                            Review
-                                        </button>
-                                    </td>
-                                </tr>
-                            {/each}
-                        </tbody>
-                    </table>
+                                />
+                                <span>Compare</span>
+                            </label>
+
+                            <div class="run-id-block">
+                                <strong title={run.run_id}
+                                    >{shortRunId(run.run_id)}</strong
+                                >
+                                <span>
+                                    {new Date(run.created_at).toLocaleString()}
+                                </span>
+                            </div>
+
+                            <div class="run-meta">
+                                <span class="status-pill">
+                                    <span class="sr-only">Status </span>
+                                    {run.status}
+                                </span>
+                                <span>
+                                    <span class="sr-only">Market </span>
+                                    {run.market ?? "N/A"}
+                                </span>
+                                <span>
+                                    <span class="sr-only">Symbols </span>
+                                    {formatRunSymbols(run)}
+                                </span>
+                            </div>
+
+                            <div class="run-metrics">
+                                <span>
+                                    RMSE {formatMetric(run.model_diagnostics?.rmse)}
+                                </span>
+                                <span>
+                                    Return {formatMetric(run.metrics?.total_return)}
+                                </span>
+                            </div>
+
+                            <div class="run-eligibility">
+                                <span class="sr-only">Eligibility </span>
+                                {formatEligibility(run.comparison_eligibility)}
+                            </div>
+
+                            <button
+                                type="button"
+                                class="secondary"
+                                aria-label={`Review run ${run.run_id}`}
+                                onclick={() => (selectedRunId = run.run_id)}
+                            >
+                                Review
+                            </button>
+                        </article>
+                    {/each}
                 </div>
             {:else}
                 <p class="muted">No persisted runs match the current filters.</p>
@@ -1130,6 +1136,78 @@
         font-size: 0.8rem;
     }
 
+    .run-list {
+        display: grid;
+        gap: var(--space-2);
+    }
+
+    .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+    }
+
+    .run-list-row {
+        display: grid;
+        grid-template-columns: minmax(90px, 0.55fr) minmax(180px, 1fr) minmax(220px, 1.1fr) minmax(220px, 1fr) minmax(180px, 0.9fr) auto;
+        gap: var(--space-3);
+        align-items: center;
+        padding: 0.85rem 0.95rem;
+        border-radius: var(--radius-md);
+        border: 1px solid rgba(148, 163, 184, 0.12);
+        background: rgba(6, 18, 30, 0.78);
+    }
+
+    .compare-check {
+        display: flex;
+        align-items: center;
+        gap: 0.55rem;
+        color: var(--muted);
+        font-size: 0.82rem;
+    }
+
+    .run-id-block,
+    .run-meta,
+    .run-metrics {
+        display: flex;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+        align-items: center;
+    }
+
+    .run-id-block {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    .run-id-block span,
+    .run-meta span,
+    .run-metrics span,
+    .run-eligibility {
+        color: var(--muted);
+        font-size: 0.82rem;
+    }
+
+    .run-id-block strong {
+        color: var(--text-primary);
+    }
+
+    .run-meta span:not(.status-pill),
+    .run-metrics span {
+        display: inline-flex;
+        align-items: center;
+        min-height: 2rem;
+        padding: 0.2rem 0.65rem;
+        border-radius: 999px;
+        background: rgba(15, 35, 54, 0.72);
+    }
+
     .summary-card,
     .governance-card {
         display: grid;
@@ -1230,7 +1308,8 @@
     @media (max-width: 1200px) {
         .summary-grid,
         .governance-grid,
-        .registry-controls {
+        .registry-controls,
+        .run-list-row {
             grid-template-columns: 1fr;
         }
     }

--- a/frontend/src/lib/components/SymbolSelector.svelte
+++ b/frontend/src/lib/components/SymbolSelector.svelte
@@ -1,0 +1,290 @@
+<script lang="ts">
+    import { createEventDispatcher, onMount } from "svelte";
+
+    import { ApiError } from "../api";
+    import { loadTwCompanyProfiles } from "../state/twCompanyProfiles";
+    import type { MarketCode, TwCompanyProfile } from "../types";
+
+    export let label = "Symbols";
+    export let market: MarketCode = "TW";
+    export let value: string[] = [];
+    export let placeholder = "Search by symbol or company name";
+    export let maxSelections: number | null = null;
+
+    const dispatch = createEventDispatcher<{
+        change: { value: string[] };
+    }>();
+
+    let query = "";
+    let profiles: TwCompanyProfile[] = [];
+    let isLoading = false;
+    let loadError: string | null = null;
+    let loadedMarket: MarketCode | null = null;
+    let profileMarket: MarketCode | null = null;
+    let inputElement: HTMLInputElement;
+    const inputId = `symbol-selector-${Math.random().toString(36).slice(2)}`;
+
+    const normalizeSymbol = (symbol: string) => symbol.trim().toUpperCase();
+
+    const emitValue = (nextValue: string[]) => {
+        dispatch("change", { value: nextValue });
+    };
+
+    const addSymbols = (symbols: string[]) => {
+        const normalized = symbols.map(normalizeSymbol).filter(Boolean);
+        if (!normalized.length) {
+            return;
+        }
+        const next = [...new Set([...value, ...normalized])];
+        emitValue(maxSelections === null ? next : next.slice(-maxSelections));
+        query = "";
+        if (inputElement) {
+            inputElement.value = "";
+        }
+    };
+
+    export const commitPending = () => {
+        if (query.trim()) {
+            addSymbols([query]);
+        }
+    };
+
+    const removeSymbol = (symbol: string) => {
+        emitValue(value.filter((item) => item !== symbol));
+    };
+
+    const loadProfiles = async () => {
+        if (market !== "TW" || loadedMarket === market || isLoading) {
+            return;
+        }
+        isLoading = true;
+        try {
+            profiles = await loadTwCompanyProfiles();
+            loadedMarket = market;
+            loadError = null;
+        } catch (error) {
+            profiles = [];
+            loadedMarket = null;
+            loadError =
+                error instanceof ApiError
+                    ? `${error.code}: ${error.message}`
+                    : "Symbol list is unavailable.";
+        } finally {
+            isLoading = false;
+        }
+    };
+
+    const handleInput = (event: Event) => {
+        const input = event.currentTarget as HTMLInputElement;
+        query = input.value;
+        if (query.includes(",")) {
+            addSymbols(query.split(","));
+        }
+    };
+
+    const handleKeydown = (event: KeyboardEvent) => {
+        if (event.key === "Enter" && query.trim()) {
+            event.preventDefault();
+            commitPending();
+        }
+        if (event.key === "Backspace" && !query && value.length) {
+            removeSymbol(value[value.length - 1]);
+        }
+    };
+
+    const matchesQuery = (profile: TwCompanyProfile, normalizedQuery: string) =>
+        profile.symbol.includes(normalizedQuery) ||
+        profile.company_name.toUpperCase().includes(normalizedQuery) ||
+        (profile.industry_category ?? "").toUpperCase().includes(
+            normalizedQuery,
+        );
+
+    onMount(() => {
+        void loadProfiles();
+    });
+
+    $: if (market !== profileMarket) {
+        profileMarket = market;
+        loadedMarket = null;
+        profiles = [];
+        loadError = null;
+        void loadProfiles();
+    }
+
+    $: normalizedQuery = query.trim().toUpperCase();
+    $: filteredProfiles =
+        market === "TW" && normalizedQuery
+            ? profiles
+                  .filter((profile) => matchesQuery(profile, normalizedQuery))
+                  .slice(0, 8)
+            : [];
+    $: showManualHint =
+        !isLoading && (market !== "TW" || Boolean(loadError) || !profiles.length);
+</script>
+
+<div class="symbol-selector">
+    <label class="selector-label" for={inputId}>{label}</label>
+    <div class="selector-control">
+        {#each value as symbol}
+            <button
+                type="button"
+                class="symbol-chip"
+                aria-label={`Remove ${symbol}`}
+                onclick={() => removeSymbol(symbol)}
+            >
+                {symbol}
+                <span aria-hidden="true">x</span>
+            </button>
+        {/each}
+        <input
+            bind:this={inputElement}
+            id={inputId}
+            value={query}
+            placeholder={value.length ? "" : placeholder}
+            oninput={handleInput}
+            onkeydown={handleKeydown}
+        />
+    </div>
+
+    {#if isLoading}
+        <small>Loading symbol list...</small>
+    {:else if normalizedQuery && filteredProfiles.length}
+        <div class="symbol-options">
+            {#each filteredProfiles as profile}
+                <button
+                    type="button"
+                    class="symbol-option"
+                    onclick={() => addSymbols([profile.symbol])}
+                >
+                    <strong>{profile.symbol}</strong>
+                    <span>
+                        {profile.company_name} · {profile.exchange}
+                        {#if profile.industry_category}
+                            · {profile.industry_category}
+                        {/if}
+                    </span>
+                </button>
+            {/each}
+        </div>
+    {:else if normalizedQuery}
+        <button
+            type="button"
+            class="manual-option"
+            onclick={() => addSymbols([query])}
+        >
+            Add "{normalizeSymbol(query)}"
+        </button>
+    {/if}
+
+    {#if showManualHint}
+        <small>
+            {market === "TW"
+                ? "TW symbol list is unavailable; manual symbol entry still works."
+                : "US lookup is not connected yet; enter tickers manually."}
+            {#if loadError}
+                <button
+                    type="button"
+                    class="retry-link"
+                    onclick={() => void loadProfiles()}
+                >
+                    Retry symbol list
+                </button>
+            {/if}
+        </small>
+    {/if}
+</div>
+
+<style lang="scss">
+    .symbol-selector {
+        display: grid;
+        gap: 0.45rem;
+    }
+
+    .selector-label,
+    small {
+        color: var(--muted);
+    }
+
+    .selector-control {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 0.45rem;
+        min-height: 3.05rem;
+        padding: 0.42rem;
+        border: 1px solid rgba(148, 163, 184, 0.18);
+        border-radius: var(--radius-sm);
+        background: rgba(4, 14, 24, 0.88);
+    }
+
+    .selector-control:focus-within {
+        border-color: rgba(125, 211, 252, 0.48);
+        box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.16);
+    }
+
+    .selector-control input {
+        flex: 1 1 12rem;
+        min-width: 9rem;
+        border: 0;
+        padding: 0.35rem 0.4rem;
+        background: transparent;
+        box-shadow: none;
+    }
+
+    .selector-control input:hover,
+    .selector-control input:focus {
+        border: 0;
+        outline: 0;
+        transform: none;
+    }
+
+    .symbol-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.45rem;
+        padding: 0.38rem 0.55rem;
+        border-radius: 999px;
+        background: rgba(20, 184, 166, 0.15);
+        border-color: rgba(45, 212, 191, 0.34);
+        color: #ccfbf1;
+        font-weight: 700;
+    }
+
+    .symbol-chip span {
+        color: var(--muted);
+    }
+
+    .retry-link {
+        margin-left: 0.5rem;
+        padding: 0;
+        border: 0;
+        background: transparent;
+        color: var(--accent-primary);
+        font: inherit;
+        text-decoration: underline;
+    }
+
+    .symbol-options {
+        display: grid;
+        gap: 0.45rem;
+        padding: 0.45rem;
+        border-radius: var(--radius-md);
+        border: 1px solid rgba(148, 163, 184, 0.12);
+        background: rgba(5, 15, 26, 0.96);
+    }
+
+    .symbol-option,
+    .manual-option {
+        display: grid;
+        gap: 0.2rem;
+        text-align: left;
+        padding: 0.7rem 0.8rem;
+        border-radius: var(--radius-sm);
+        background: rgba(10, 25, 40, 0.92);
+    }
+
+    .symbol-option span {
+        color: var(--muted);
+        line-height: 1.35;
+    }
+</style>

--- a/frontend/src/lib/components/data-plane/DataIngestionPanel.svelte
+++ b/frontend/src/lib/components/data-plane/DataIngestionPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { ApiError, createDataIngestion } from "../../api";
     import type { DataIngestionResponse, MarketCode } from "../../types";
+    import SymbolSelector from "../SymbolSelector.svelte";
 
     let form: {
         symbol: string;
@@ -15,8 +16,17 @@
     };
     let result: DataIngestionResponse | null = null;
     let errorMessage: string | null = null;
+    let symbolSelector: { commitPending: () => void } | null = null;
+
+    const setSymbol = (symbols: string[]) => {
+        form.symbol = symbols[0] ?? "";
+    };
+
+    const formatSummary = (data: DataIngestionResponse) =>
+        `Backfill ${data.backfill.upserted_rows} rows, daily update ${data.daily_update.upserted_rows} rows, minute supplement ${data.minute_supplement.status}.`;
 
     const submit = async () => {
+        symbolSelector?.commitPending();
         try {
             result = await createDataIngestion({
                 symbol: form.symbol.trim(),
@@ -38,12 +48,20 @@
     <div class="surface-header">
         <div>
             <p class="eyebrow">Data Plane</p>
-            <h3>Ingestions</h3>
+            <h3>Sync Market Data</h3>
         </div>
     </div>
 
     <div class="form-grid">
-        <label><span>Symbol</span><input bind:value={form.symbol} /></label>
+        <SymbolSelector
+            bind:this={symbolSelector}
+            label="Symbol"
+            market={form.market}
+            value={form.symbol ? [form.symbol] : []}
+            placeholder="Search 2330 or enter ticker"
+            maxSelections={1}
+            on:change={(event) => setSymbol(event.detail.value)}
+        />
         <label>
             <span>Market</span>
             <select bind:value={form.market}>
@@ -66,9 +84,24 @@
         >
     </div>
 
-    <button type="button" onclick={submit}>Create Ingestion</button>
+    <button type="button" class="submit" onclick={submit}>
+        Sync Market Data
+    </button>
     {#if errorMessage}<p class="muted">{errorMessage}</p>{/if}
-    {#if result}<pre>{JSON.stringify(result, null, 2)}</pre>{/if}
+    {#if result}
+        <div class="sync-summary">
+            <strong>{formatSummary(result)}</strong>
+            <span>
+                Raw payloads:
+                {result.backfill.raw_payload_id ?? "N/A"} /
+                {result.daily_update.raw_payload_id ?? "N/A"}
+            </span>
+        </div>
+        <details>
+            <summary>Advanced sync payload</summary>
+            <pre>{JSON.stringify(result, null, 2)}</pre>
+        </details>
+    {/if}
 </div>
 
 <style lang="scss">
@@ -127,6 +160,26 @@
         word-break: break-word;
         font-family: var(--mono);
         font-size: 0.78rem;
+    }
+    .sync-summary {
+        display: grid;
+        gap: 0.35rem;
+        padding: 0.9rem;
+        border-radius: var(--radius-md);
+        background: rgba(20, 184, 166, 0.12);
+        border: 1px solid rgba(45, 212, 191, 0.22);
+    }
+    .sync-summary span,
+    details summary {
+        color: var(--muted);
+    }
+    details {
+        display: grid;
+        gap: 0.75rem;
+    }
+    details summary {
+        cursor: pointer;
+        font-weight: 600;
     }
     @media (max-width: 720px) {
         .form-grid {

--- a/frontend/src/lib/state/twCompanyProfiles.ts
+++ b/frontend/src/lib/state/twCompanyProfiles.ts
@@ -1,0 +1,20 @@
+import { fetchTwCompanyProfiles } from "../api";
+import type { TwCompanyProfile } from "../types";
+
+let cachedProfiles: TwCompanyProfile[] | null = null;
+let inFlightProfiles: Promise<TwCompanyProfile[]> | null = null;
+
+export const loadTwCompanyProfiles = async () => {
+  if (cachedProfiles) {
+    return cachedProfiles;
+  }
+
+  inFlightProfiles = inFlightProfiles ?? fetchTwCompanyProfiles();
+  try {
+    cachedProfiles = await inFlightProfiles;
+    return cachedProfiles;
+  } catch (error) {
+    inFlightProfiles = null;
+    throw error;
+  }
+};

--- a/frontend/src/lib/types/dataPlane.ts
+++ b/frontend/src/lib/types/dataPlane.ts
@@ -35,6 +35,40 @@ export interface DataIngestionResponse {
   market: string;
   backfill: IngestionStageSummary;
   daily_update: IngestionStageSummary;
+  minute_supplement: MinuteSupplementSummary;
+}
+
+export interface MinuteSupplementSummary {
+  status: string;
+  window_start: string | null;
+  window_end: string | null;
+  segment_count: number;
+  segments_succeeded: number;
+  segments_failed: number;
+  covered_trading_days: number;
+  input_rows: number;
+  upserted_rows: number;
+  duplicates_removed: number;
+  skipped_reason: string | null;
+}
+
+export interface TwCompanyProfile {
+  id: number;
+  symbol: string;
+  market: MarketCode;
+  exchange: string;
+  board: string;
+  company_name: string;
+  isin_code: string | null;
+  industry_category: string | null;
+  listing_date: string | null;
+  trading_status: string;
+  source_name: string;
+  raw_payload_id: number | null;
+  archive_object_reference: string | null;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
 }
 
 export interface TwDailyReadinessRequest {


### PR DESCRIPTION
## Summary
- add a searchable SymbolSelector with shared TW company-profile caching and manual fallback
- expose TW company profile pagination through X-Total-Count and CORS for complete symbol lookup
- add readiness-driven Sync Data actions, market data sync copy, minute supplement summaries, and Run Review card layout polish

## Validation
- bun x tsc -p frontend/tsconfig.json --noEmit
- cd frontend && bun run build
- git diff --check
- sub-agent follow-up read-only review: reasonable, no findings

## Risks / manual checks
- UI interaction was not browser-click verified in this pass
- verify typing 2330 then pressing Refresh / Sync Market Data / Continue commits the pending symbol
- verify typing a partial query then leaving the field does not auto-add it