### PR TITLE
fix: harden research run artifact comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ promotes them deliberately.
 For the fuller implementation inventory, use
 [`docs/implementation-status.md`](docs/implementation-status.md). That file may
 include lower-level or advanced foundations that are not v1 product commitments.
+Retained backend foundations and metadata fields are compatibility or internal
+diagnostic surfaces unless a future roadmap promotes them.
 
 ## Implemented Today
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository is a research-first workbench for TW daily quantitative ML
 experiments. The v1 product is intentionally narrow: help a researcher create a
 baseline study, inspect model quality, review the resulting strategy backtest,
 and compare persisted experiments without treating the app as an execution or
-operations platform.
+data-control suite.
 
 ## V1 Product Flow
 
@@ -38,7 +38,7 @@ research workflow shape.
 - adaptive or RL workflows
 - peer inference, factor expansion, external-signal breadth, or tick archive UX
   as main-flow requirements
-- multi-user productization or operations-console completeness
+- multi-user productization or admin-console completeness
 
 Those advanced capabilities may exist as backend foundations or internal
 diagnostics, but they are hidden from the v1 research path unless a future plan
@@ -52,8 +52,8 @@ promotes them deliberately.
 | TW daily data readiness | implemented with diagnostics | ingestion, replay, lifecycle, important-event, and recovery surfaces support data trust checks |
 | Baseline experiment builder | implemented | a researcher can start from the baseline workflow without editing API payloads |
 | Regression diagnostics | implemented | successful regression runs return and reload model-quality artifacts before strategy interpretation |
-| Persisted artifact reload | verified | new successful runs reload request config, diagnostics, equity, signals, baselines, warnings, and runtime metadata |
-| Experiment comparison | usable for v1 loop | search, load, and compare work for complete research-review runs; non-comparable reason labels still need taxonomy hardening |
+| Persisted artifact reload | verified | new successful runs reload request config, diagnostics, equity, signals, baselines, warnings, runtime metadata, and artifact completeness summaries |
+| Experiment comparison | usable for v1 loop | search, load, and compare work for complete research-review runs; metadata-only and partial records expose backend caveats before comparison |
 | Advanced/platform modules | hidden advanced | execution, adaptive, peer, factor, and tick archive capabilities are not v1 main-flow surfaces |
 
 For the fuller implementation inventory, use
@@ -81,13 +81,13 @@ diagnostic surfaces unless a future roadmap promotes them.
   - check data readiness
 - Experiment Builder for the baseline TW daily research workflow
 - Experiments surface for persisted run lookup, review, and comparison
-- Data Ops as a secondary diagnostic surface, not the default research path
+- Data Support as a secondary diagnostic surface, not the default research path
 
 ## Still Partial Or Deferred
 
 - classification is specified but not implemented in the first code pass
-- comparison reason taxonomy still needs hardening for runs that should not be
-  compared, but the core persisted comparison loop is usable
+- richer pairwise comparison explanations can still improve review workflow, but
+  incomplete artifacts and backend comparison caveats now block optimistic compare
 - execution, adaptive, peer, factor, and tick archive modules are deferred from
   the v1 main workflow
 

--- a/backend/app/application.py
+++ b/backend/app/application.py
@@ -44,7 +44,7 @@ logger = logging.getLogger(__name__)
 
 app = FastAPI(
     title="TW Daily Quant ML Research Workbench API",
-    description="Public v1 API for TW daily baseline research, experiment review, and data readiness operations.",
+    description="Public v1 API for TW daily baseline research, experiment review, and data readiness support.",
     version="1.0.0",
 )
 

--- a/backend/research/contracts/runs.py
+++ b/backend/research/contracts/runs.py
@@ -31,6 +31,10 @@ from backend.shared.contracts.common import (
     StrategyType,
     ValidationMethod,
 )
+from backend.research.domain.artifact_summary import (
+    ArtifactCompleteness,
+    ReviewArtifactName,
+)
 
 from .runtime_metadata import (
     ConfigSources,
@@ -262,11 +266,26 @@ class RegressionDiagnostics(BaseModel):
     feature_importance: List[FeatureImportancePoint] = Field(default_factory=list)
 
 
+class ComparisonCaveat(BaseModel):
+    code: str
+    label: str
+    severity: Literal["blocker", "note"] = "blocker"
+
+
+class ReviewArtifactSummaryMixin(BaseModel):
+    artifact_completeness: ArtifactCompleteness = "metadata_only"
+    present_artifacts: List[ReviewArtifactName] = Field(default_factory=list)
+    missing_artifacts: List[ReviewArtifactName] = Field(default_factory=list)
+    not_required_artifacts: List[ReviewArtifactName] = Field(default_factory=list)
+    comparison_caveats: List[ComparisonCaveat] = Field(default_factory=list)
+
+
 class ResearchRunResponse(
     VersionPackMixin,
     P3SummaryMixin,
     GovernanceMetadataMixin,
     FoundationMetadataMixin,
+    ReviewArtifactSummaryMixin,
 ):
     run_id: str
     metrics: Metrics
@@ -288,6 +307,7 @@ class ResearchRunRecordResponse(
     P3SummaryMixin,
     GovernanceMetadataMixin,
     FoundationMetadataMixin,
+    ReviewArtifactSummaryMixin,
 ):
     run_id: str
     request_id: Optional[str] = None

--- a/backend/research/domain/artifact_summary.py
+++ b/backend/research/domain/artifact_summary.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+ReviewArtifactName = Literal[
+    "metrics",
+    "model_diagnostics",
+    "equity_curve",
+    "signals",
+    "validation",
+    "baselines",
+]
+ArtifactCompleteness = Literal["complete", "partial", "metadata_only"]
+ComparisonCaveatSeverity = Literal["blocker", "note"]
+
+CORE_REVIEW_ARTIFACTS: tuple[ReviewArtifactName, ...] = (
+    "metrics",
+    "model_diagnostics",
+    "equity_curve",
+    "signals",
+)
+CONDITIONAL_REVIEW_ARTIFACTS: tuple[ReviewArtifactName, ...] = (
+    "validation",
+    "baselines",
+)
+REVIEW_ARTIFACTS: tuple[ReviewArtifactName, ...] = (
+    *CORE_REVIEW_ARTIFACTS,
+    *CONDITIONAL_REVIEW_ARTIFACTS,
+)
+SUCCESS_STATUS = "succeeded"
+
+
+def _requests_validation(request_payload: dict[str, Any] | None) -> bool | None:
+    if request_payload is None:
+        return None
+    return request_payload.get("validation") is not None
+
+
+def _requests_baselines(request_payload: dict[str, Any] | None) -> bool | None:
+    if request_payload is None:
+        return None
+    baselines = request_payload.get("baselines")
+    return isinstance(baselines, list) and len(baselines) > 0
+
+
+def _required_artifacts(
+    request_payload: dict[str, Any] | None,
+) -> tuple[ReviewArtifactName, ...]:
+    required = list(CORE_REVIEW_ARTIFACTS)
+    validation_requested = _requests_validation(request_payload)
+    baselines_requested = _requests_baselines(request_payload)
+
+    if validation_requested is not False:
+        required.append("validation")
+    if baselines_requested is not False:
+        required.append("baselines")
+    return tuple(required)
+
+
+def _not_required_artifacts(
+    request_payload: dict[str, Any] | None,
+) -> tuple[ReviewArtifactName, ...]:
+    not_required: list[ReviewArtifactName] = []
+    if _requests_validation(request_payload) is False:
+        not_required.append("validation")
+    if _requests_baselines(request_payload) is False:
+        not_required.append("baselines")
+    return tuple(not_required)
+
+
+def _comparison_caveat(
+    code: str,
+    label: str,
+    severity: ComparisonCaveatSeverity = "blocker",
+) -> dict[str, str]:
+    return {"code": code, "label": label, "severity": severity}
+
+
+def build_review_artifact_summary(
+    *,
+    status: str | None,
+    request_payload: dict[str, Any] | None,
+    artifact_presence: dict[ReviewArtifactName, bool],
+    comparison_eligibility: str | None,
+) -> dict[str, Any]:
+    required_artifacts = _required_artifacts(request_payload)
+    not_required_artifacts = list(_not_required_artifacts(request_payload))
+    present_artifacts = [
+        artifact
+        for artifact in REVIEW_ARTIFACTS
+        if artifact_presence.get(artifact) and artifact not in not_required_artifacts
+    ]
+    missing_artifacts = [
+        artifact
+        for artifact in required_artifacts
+        if not artifact_presence.get(artifact)
+    ]
+    present_required_artifacts = [
+        artifact
+        for artifact in required_artifacts
+        if artifact_presence.get(artifact)
+    ]
+
+    if not missing_artifacts:
+        completeness: ArtifactCompleteness = "complete"
+    elif present_required_artifacts:
+        completeness = "partial"
+    else:
+        completeness = "metadata_only"
+
+    caveats: list[dict[str, str]] = []
+    if status != SUCCESS_STATUS:
+        caveats.append(
+            _comparison_caveat(
+                "ARTIFACTS_NOT_EVALUATED",
+                "Review artifacts were not evaluated for this run status.",
+            )
+        )
+    if completeness == "metadata_only":
+        caveats.append(
+            _comparison_caveat(
+                "METADATA_ONLY_RECORD",
+                "Saved record has metadata only.",
+            )
+        )
+    elif completeness == "partial":
+        caveats.append(
+            _comparison_caveat(
+                "REVIEW_ARTIFACTS_MISSING",
+                "Review artifacts are missing.",
+            )
+        )
+
+    if comparison_eligibility == "comparison_metadata_only":
+        caveats.append(
+            _comparison_caveat(
+                "COMPARISON_METADATA_ONLY",
+                "Comparison metadata is incomplete.",
+            )
+        )
+    elif comparison_eligibility == "sample_window_pending":
+        caveats.append(
+            _comparison_caveat(
+                "SAMPLE_WINDOW_PENDING",
+                "Sample window is pending.",
+            )
+        )
+    elif comparison_eligibility == "unresolved_event_quarantine":
+        caveats.append(
+            _comparison_caveat(
+                "UNRESOLVED_EVENT_QUARANTINE",
+                "Corporate-event data is unresolved.",
+            )
+        )
+    elif comparison_eligibility is None:
+        caveats.append(
+            _comparison_caveat(
+                "COMPARISON_ELIGIBILITY_UNAVAILABLE",
+                "Comparison eligibility is unavailable.",
+            )
+        )
+
+    return {
+        "artifact_completeness": completeness,
+        "present_artifacts": present_artifacts,
+        "missing_artifacts": missing_artifacts,
+        "not_required_artifacts": not_required_artifacts,
+        "comparison_caveats": caveats,
+    }

--- a/backend/research/repositories/runs.py
+++ b/backend/research/repositories/runs.py
@@ -12,6 +12,7 @@ from backend.database import (
     ResearchRunLiquidityCoverage,
     SessionLocal,
 )
+from backend.research.domain.artifact_summary import build_review_artifact_summary
 from backend.research.domain.version_pack import build_version_pack_payload
 from backend.platform.errors import DataAccessError, DataNotFoundError
 from backend.platform.time import utc_now
@@ -99,6 +100,33 @@ def _summarize_model_diagnostics(value: Any) -> dict[str, Any] | None:
     }
 
 
+def _review_artifact_summary_from_row(
+    row: ResearchRun,
+    *,
+    request_payload: dict[str, Any] | None,
+    validation_outcome: Any,
+    model_diagnostics: Any,
+) -> dict[str, Any]:
+    return build_review_artifact_summary(
+        status=row.status,
+        request_payload=request_payload,
+        comparison_eligibility=row.comparison_eligibility,
+        artifact_presence={
+            "metrics": isinstance(json_loads(row.metrics_json, None), dict),
+            "model_diagnostics": _model_diagnostics_from_payload(model_diagnostics)
+            is not None,
+            "equity_curve": row.equity_curve_json is not None
+            and isinstance(json_loads(row.equity_curve_json, None), list),
+            "signals": row.signals_json is not None
+            and isinstance(json_loads(row.signals_json, None), list),
+            "validation": _validation_summary_from_payload(validation_outcome)
+            is not None,
+            "baselines": row.baselines_json is not None
+            and isinstance(json_loads(row.baselines_json, None), dict),
+        },
+    )
+
+
 def _run_row_to_dict(row: ResearchRun, *, include_artifacts: bool = True) -> dict[str, Any]:
     effective_strategy = None
     if row.effective_threshold is not None and row.effective_top_n is not None:
@@ -109,6 +137,7 @@ def _run_row_to_dict(row: ResearchRun, *, include_artifacts: bool = True) -> dic
 
     validation_outcome = json_loads(row.validation_outcome_json, None)
     model_diagnostics = json_loads(row.model_diagnostics_json, None)
+    request_payload = json_loads(row.request_payload_json, None)
     payload = {
         "run_id": row.run_id,
         "request_id": row.request_id,
@@ -124,7 +153,7 @@ def _run_row_to_dict(row: ResearchRun, *, include_artifacts: bool = True) -> dic
         "fallback_audit": json_loads(row.fallback_audit_json, None),
         "validation_outcome": validation_outcome,
         "rejection_reason": row.rejection_reason,
-        "request_payload": json_loads(row.request_payload_json, None),
+        "request_payload": request_payload,
         "metrics": json_loads(row.metrics_json, None),
         "equity_curve": json_loads(row.equity_curve_json, [])
         if include_artifacts
@@ -169,6 +198,14 @@ def _run_row_to_dict(row: ResearchRun, *, include_artifacts: bool = True) -> dic
         "monitor_observation_status": row.monitor_observation_status,
         "created_at": normalize_created_at(row.created_at),
     }
+    payload.update(
+        _review_artifact_summary_from_row(
+            row,
+            request_payload=request_payload,
+            validation_outcome=validation_outcome,
+            model_diagnostics=model_diagnostics,
+        )
+    )
     payload.update(
         build_version_pack_payload(
             {

--- a/backend/research/services/runs.py
+++ b/backend/research/services/runs.py
@@ -5,6 +5,7 @@ from typing import Any, Callable
 from uuid import uuid4
 
 from backend.platform.errors import BacktestError, DataAccessError
+from backend.research.domain.artifact_summary import build_review_artifact_summary
 from backend.research.repositories.runs import (
     get_research_run_record,
     list_research_run_records,
@@ -24,6 +25,26 @@ from backend.research.services.registry import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _response_with_artifact_summary(
+    response: ResearchRunResponse,
+    request: ResearchRunCreateRequest,
+) -> ResearchRunResponse:
+    summary = build_review_artifact_summary(
+        status="succeeded",
+        request_payload=request.model_dump(mode="json"),
+        comparison_eligibility=response.comparison_eligibility,
+        artifact_presence={
+            "metrics": True,
+            "model_diagnostics": response.model_diagnostics is not None,
+            "equity_curve": True,
+            "signals": True,
+            "validation": response.validation is not None,
+            "baselines": isinstance(response.baselines, dict),
+        },
+    )
+    return response.model_copy(update=summary)
 
 
 def _record_registry_event(
@@ -58,6 +79,7 @@ def create_research_run(
         )
         artifacts = execute_research_run(run_id=run_id, request=request)
         runtime_context = artifacts.runtime_context
+        response = _response_with_artifact_summary(artifacts.response, request)
         _record_registry_event(
             record_success,
             raise_on_failure=True,
@@ -65,11 +87,11 @@ def create_research_run(
             request_id=request_id,
             request=request,
             runtime_context=runtime_context,
-            response=artifacts.response,
+            response=response,
             validation_summary=artifacts.validation_summary,
             warnings=artifacts.warnings,
         )
-        return artifacts.response
+        return response
     except BacktestError as exc:
         # Preserve the original rejection even if audit persistence fails.
         _record_registry_event(

--- a/docs/decision-register.md
+++ b/docs/decision-register.md
@@ -33,13 +33,14 @@ stable across multiple implementation tasks.
 | `DEC-V1-009` | advanced APIs remain available as internal foundations | accepted | advanced routes may stay reachable for diagnostics and legacy tooling, but they must stay out of v1 navigation and baseline workflow requirements |
 | `DEC-V1-010` | v1 baseline builder defaults to Extra Trees | accepted | the default research loop avoids requiring the XGBoost native runtime while keeping XGBoost and Random Forest selectable variants |
 | `DEC-V1-011` | retained platform-era code is internal foundation inventory | accepted | code, metadata fields, and docs may mention execution, adaptive, peer, factor, external-signal, or tick foundations only as compatibility or future-promoted surfaces, not as v1 product commitments |
+| `DEC-V1-012` | artifact completeness is derived, not migrated | accepted | run review and compare use `artifact_completeness`, artifact lists, and backend caveats derived from existing row JSON fields |
 
 ## Open V1 Decisions
 
 | ID | Topic | Owner area | Blocks | Next action |
 | --- | --- | --- | --- | --- |
 | `TBD-V1-002` | persisted artifact retention and size bounds | research persistence | long-running experiment history, not the current usable loop | define whether diagnostic samples, signals, and equity curves are stored fully or bounded per run |
-| `TBD-V1-003` | comparison reason hardening | experiments UX | richer comparison explanations, not basic compare usability | define stable reason labels for metadata-only, missing artifacts, sample-window mismatch, target mismatch, and feature/model mismatch |
+| `TBD-V1-003` | comparison reason hardening | experiments UX | richer pairwise explanations, not basic compare usability | extend backend caveats beyond artifact completeness and keep UI-derived assumption mismatch labels aligned |
 
 ## Deferred Platform Decisions
 

--- a/docs/decision-register.md
+++ b/docs/decision-register.md
@@ -32,13 +32,14 @@ stable across multiple implementation tasks.
 | `DEC-V1-008` | v1 readiness denominator is requested-symbol coverage | accepted | readiness reports requested symbols over the requested date range using currently known TW daily market dates; exchange-calendar authority is deferred |
 | `DEC-V1-009` | advanced APIs remain available as internal foundations | accepted | advanced routes may stay reachable for diagnostics and legacy tooling, but they must stay out of v1 navigation and baseline workflow requirements |
 | `DEC-V1-010` | v1 baseline builder defaults to Extra Trees | accepted | the default research loop avoids requiring the XGBoost native runtime while keeping XGBoost and Random Forest selectable variants |
+| `DEC-V1-011` | retained platform-era code is internal foundation inventory | accepted | code, metadata fields, and docs may mention execution, adaptive, peer, factor, external-signal, or tick foundations only as compatibility or future-promoted surfaces, not as v1 product commitments |
 
 ## Open V1 Decisions
 
 | ID | Topic | Owner area | Blocks | Next action |
 | --- | --- | --- | --- | --- |
-| `TBD-V1-002` | persisted artifact retention and size bounds | research persistence | long-running experiment history | define whether diagnostic samples, signals, and equity curves are stored fully or bounded per run |
-| `TBD-V1-003` | comparison eligibility reason taxonomy | experiments UX | richer comparison explanations | define stable reason labels for metadata-only, missing artifacts, sample-window mismatch, target mismatch, and feature/model mismatch |
+| `TBD-V1-002` | persisted artifact retention and size bounds | research persistence | long-running experiment history, not the current usable loop | define whether diagnostic samples, signals, and equity curves are stored fully or bounded per run |
+| `TBD-V1-003` | comparison reason hardening | experiments UX | richer comparison explanations, not basic compare usability | define stable reason labels for metadata-only, missing artifacts, sample-window mismatch, target mismatch, and feature/model mismatch |
 
 ## Deferred Platform Decisions
 

--- a/docs/deferred-feature-plan.md
+++ b/docs/deferred-feature-plan.md
@@ -28,7 +28,7 @@ Some code and metadata from that period remains intentionally:
 
 Those retained foundations are not current v1 commitments. They should not be
 used to justify adding execution, adaptive, peer, factor, external-signal, tick
-archive, or operations-console workflows back into Start, Builder, or
+archive, or broad data-control workflows back into Start, Builder, or
 Experiments.
 
 ## Promotion Rule
@@ -56,7 +56,7 @@ or Experiments workflow.
 | Broad factor catalog expansion | deferred | Which factors are required for the baseline TW daily task family? |
 | External-signal breadth | deferred | Which signal timing and audit rules make it research-safe? |
 | Tick archive and intraday strategy UX | deferred | Is intraday analysis part of a future product, or only a data-foundation tool? |
-| Operations-console completeness | deferred | Which operational controls are needed for the workbench user, not platform admins? |
+| Data-control completeness | deferred | Which controls are needed for the workbench user, not platform admins? |
 
 ## Current Todo
 

--- a/docs/deferred-feature-plan.md
+++ b/docs/deferred-feature-plan.md
@@ -11,6 +11,26 @@ developer operations guide.
   requirements
 - define the minimum bar before a deferred feature can re-enter active planning
 
+## Historical Context
+
+The repository originally carried broader platform and operations ambitions.
+During the v1 workbench refocus, parts of that surface were removed from the
+main user journey or rewritten as secondary diagnostics because they made the
+product direction hard to read.
+
+Some code and metadata from that period remains intentionally:
+
+- to preserve compatibility with existing persisted records and migrations
+- to keep internal diagnostics available while TW daily research data is made
+  reliable
+- to avoid deleting foundations that may become future work after a promotion
+  decision
+
+Those retained foundations are not current v1 commitments. They should not be
+used to justify adding execution, adaptive, peer, factor, external-signal, tick
+archive, or operations-console workflows back into Start, Builder, or
+Experiments.
+
 ## Promotion Rule
 
 A deferred feature can move into `docs/plan.md` only after it has:

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -145,10 +145,16 @@ After DB, migrations, backend, frontend, and data are ready, verify:
 - Start shows TW daily readiness context for the requested symbol
 - Builder opens from the baseline task and defaults to Extra Trees
 - Run creates a successful research record
-- Review shows diagnostics, equity, validation, baselines, and signals
-- Reload plus Load restores the persisted result
-- Compare can select two complete runs and shows dataset, target, feature,
-  model, cost-basis, metrics, baseline delta, and caveat fields
+- Review shows diagnostics, equity, signals, plus validation and baselines when
+  requested
+- Reload restores the persisted result and shows whether review artifacts are
+  complete, partial, metadata-only, not requested, or unavailable on the record
+- Compare two complete runs and confirm dataset, target, feature, model,
+  cost-basis, metrics, baseline delta, and caveat fields are visible
+- Compare complete versus partial or old metadata-only records and confirm the
+  compare status blocks optimistic interpretation
+- Compare assumption mismatch cases and confirm the table flags dataset, target,
+  cost, price-basis, or missing-feature policy differences
 
 ## Frontend
 

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -15,7 +15,7 @@ in the v1 product navigation.
 
 ## Status Scope
 
-- status date: `2026-05-13`
+- status date: `2026-05-14`
 - status terms:
   - `implemented`: behavior exists and is usable in the current codebase
   - `partial`: meaningful foundation exists, but the v1 product expectation is
@@ -77,6 +77,24 @@ Hidden advanced paths may remain reachable for internal diagnostics or legacy
 tooling, but they should not be required to start, understand, or compare a
 baseline experiment.
 
+## Code Reading Notes
+
+The current codebase still contains names, metadata fields, and service modules
+from the earlier platform-oriented design. That is expected historical context,
+not a signal that v1 has returned to an execution or operations platform.
+
+- data-plane repair, replay, lifecycle, and event endpoints support TW daily
+  research data readiness; they are not the primary product loop
+- execution, simulation, adaptive, peer, factor, external-signal, and tick
+  archive code remains as compatibility or internal foundation inventory
+- version-pack and foundation metadata may appear on research-run records so
+  old records and future-promoted capabilities remain explainable
+- Start, Experiment Builder, Experiments, and secondary Data Ops remain the
+  v1 information architecture for user-facing work
+
+When reading code, treat advanced routes or metadata as retained foundations
+unless `docs/plan.md` explicitly promotes them into a v1 milestone.
+
 ## Implemented Foundations
 
 ### Research Run Core
@@ -112,6 +130,8 @@ These foundations are implementation inventory, not v1 product scope.
 ### Documentation
 
 - v1 direction is current after the usable-loop verification
+- docs should keep the historical context visible: retained platform-era code
+  exists, but the current product contract is workbench-first
 - developer-facing docs should keep the local data-prep caveat visible: a clean
   DB needs TW daily data loaded before the run path is useful
 - future edits must keep advanced/platform modules out of the default research
@@ -119,18 +139,21 @@ These foundations are implementation inventory, not v1 product scope.
 
 ### Frontend
 
-- legacy `PredictionStudio` and `MaintenanceWorkspace` should be removed once
-  the current workbench surfaces fully replace them
+- legacy or platform-era component names should be cleaned up only after the
+  current workbench surfaces fully replace them
 - residual diagnostics now have a dedicated sample section in the persisted run
   review surface
 - comparison UI supports the v1 complete-run path; reason labels still need
-  hardening for non-comparable or metadata-only runs
+  hardening so pairwise caveats are easier to interpret
 
 ### Backend
 
 - classification remains specification-only
-- comparison caveat labels still need deeper hardening for non-comparable runs,
-  such as sample-window, target, feature, and cost-basis mismatch cases
+- comparison caveat labels and reason codes still need deeper hardening for
+  non-comparable runs, such as sample-window, target, feature, and cost-basis
+  mismatch cases
+- artifact retention and payload sizing need a long-running-history policy, but
+  this does not block the currently verified usable loop
 - hidden advanced foundations may stay reachable for diagnostics and legacy
   tooling, but should not return to the v1 navigation without a roadmap
   decision
@@ -192,13 +215,13 @@ These foundations are implementation inventory, not v1 product scope.
 
 ## Next Recommended Stage
 
-Move from usable-loop verification to documentation and comparison cleanup:
+Move from usable-loop verification to cleanup and hardening:
 
 1. harden comparison caveats for non-comparable runs across sample-window,
    target, feature, and cost-basis mismatch cases
-2. keep Data Ops secondary to the main research loop, and remove any remaining
-   advanced/platform language from the default path
+2. keep Data Ops secondary to the main research loop, and keep retained
+   platform-era foundations labeled as internal or deferred
 3. document a clean-environment data-prep checklist for v1 demos and manual
    verification
-4. deprecate or remove legacy frontend surfaces once the replacement flow is
-   confirmed
+4. clean up legacy naming only where it improves readability without widening
+   v1 scope

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -28,11 +28,11 @@ in the v1 product navigation.
 | Area | Status | Current reading |
 | --- | --- | --- |
 | Workbench product direction | implemented | README, goals, plan, spec, and gates describe the v1 workbench direction |
-| Start / Builder / Experiments / Data Ops shell | implemented | frontend shell uses task-oriented surfaces instead of the old platform-first navigation |
+| Start / Builder / Experiments / Data Support shell | implemented | frontend shell uses task-oriented surfaces instead of the old platform-first navigation |
 | Baseline TW daily experiment builder | implemented | baseline workflow creates research runs from dataset, features, model, validation, and backtest settings |
 | Regression diagnostics contract | implemented | backend, frontend types, and review UI include `model_diagnostics`, including residual samples |
-| Persisted result artifacts | verified | new successful runs reload request config, diagnostics, equity curve, signals, baselines, metrics, warnings, and runtime metadata; old metadata-only records show explicit fallback copy |
-| Experiments comparison | implemented | search, sort, load, and compare work for complete research-review runs; deeper non-comparable reason taxonomy still needs hardening |
+| Persisted result artifacts | verified | new successful runs reload request config, diagnostics, equity curve, signals, baselines, metrics, warnings, runtime metadata, and artifact completeness summaries; old metadata-only records show explicit fallback copy |
+| Experiments comparison | implemented | search, sort, load, and compare work for complete research-review runs; backend caveats block metadata-only, partial, and unfinished records |
 | Classification | contract-defined | task and diagnostics are specified, but implementation is deferred |
 | Data readiness | implemented | start surface uses requested-symbol TW daily readiness with ready/warning/missing-stale counts |
 | Advanced/platform modules | hidden advanced | execution, adaptive, peer, factor, external-signal, and tick-archive surfaces remain code foundations, not v1 main-flow commitments |
@@ -48,7 +48,7 @@ in the v1 product navigation.
   - currently regression-first; classification remains a documented future task
 - `Experiments`
   - persisted run lookup, result review, filtering, sorting, and comparison
-- `Data Ops`
+- `Data Support`
   - secondary diagnostic surface for data readiness and repair workflows
 
 Legacy components such as `PredictionStudio` and `MaintenanceWorkspace` may
@@ -81,7 +81,7 @@ baseline experiment.
 
 The current codebase still contains names, metadata fields, and service modules
 from the earlier platform-oriented design. That is expected historical context,
-not a signal that v1 has returned to an execution or operations platform.
+not a signal that v1 has returned to an execution or admin surface.
 
 - data-plane repair, replay, lifecycle, and event endpoints support TW daily
   research data readiness; they are not the primary product loop
@@ -89,7 +89,7 @@ not a signal that v1 has returned to an execution or operations platform.
   archive code remains as compatibility or internal foundation inventory
 - version-pack and foundation metadata may appear on research-run records so
   old records and future-promoted capabilities remain explainable
-- Start, Experiment Builder, Experiments, and secondary Data Ops remain the
+- Start, Experiment Builder, Experiments, and secondary Data Support remain the
   v1 information architecture for user-facing work
 
 When reading code, treat advanced routes or metadata as retained foundations
@@ -219,7 +219,7 @@ Move from usable-loop verification to cleanup and hardening:
 
 1. harden comparison caveats for non-comparable runs across sample-window,
    target, feature, and cost-basis mismatch cases
-2. keep Data Ops secondary to the main research loop, and keep retained
+2. keep Data Support secondary to the main research loop, and keep retained
    platform-era foundations labeled as internal or deferred
 3. document a clean-environment data-prep checklist for v1 demos and manual
    verification

--- a/docs/research-spec.md
+++ b/docs/research-spec.md
@@ -228,6 +228,19 @@ Old runs that lack persisted artifacts must show an explicit fallback message.
 The UI must not imply that missing diagnostics, signals, equity, or baselines
 were evaluated.
 
+Persisted run responses expose an additive artifact summary derived from the
+saved row and request payload:
+
+- `artifact_completeness`: `complete`, `partial`, or `metadata_only`
+- `present_artifacts`
+- `missing_artifacts`
+- `not_required_artifacts`
+- `comparison_caveats`
+
+Validation and baselines are `not_required` when they were not requested.
+Missing values mean the artifact is unavailable on that saved record, not that
+the study evaluated the artifact and produced an empty result.
+
 ### SPEC-RUN-003: Runtime metadata
 
 Every run must persist:
@@ -284,6 +297,10 @@ can explain their shared and differing assumptions. At minimum, compare:
 
 Comparison eligibility helps the researcher avoid invalid claims. It must not
 hide model diagnostics or persisted artifacts.
+
+Artifact completeness caveats are blocking comparison context. A run that is
+`partial` or `metadata_only`, or a run that did not finish successfully, must
+not be treated as a complete comparable result.
 
 ## Hidden Advanced Modules
 

--- a/docs/validation-gates.md
+++ b/docs/validation-gates.md
@@ -57,8 +57,9 @@ drive the default workbench workflow.
 - Artifact rule: a successful new run is incomplete for v1 review if persisted
   reload cannot show the same core diagnostics and backtest artifacts as the
   in-session response.
-- Old-run fallback rule: older records without artifacts pass only when the UI
-  clearly labels missing artifacts as unavailable.
+- Old-run fallback rule: older records without artifacts pass only when the API
+  marks them `metadata_only` or `partial` and the UI clearly labels missing
+  artifacts as unavailable on the record.
 
 ## KPI Dictionary
 
@@ -68,7 +69,7 @@ drive the default workbench workflow.
 | --- | --- | --- | --- |
 | `KPI-DATA-001` | daily data availability | requested TW symbols have daily OHLCV rows in the requested range after exclusions | report |
 | `KPI-DATA-002` | model-ready row count | rows remaining after feature generation, shifting, target alignment, and null filtering | `> 0` per trained symbol |
-| `KPI-DATA-003` | data warning clarity | missing-data, stale-data, or event exclusions are represented in warnings or diagnostics, including symbol-level warning reasons on Start or Data Ops surfaces | required |
+| `KPI-DATA-003` | data warning clarity | missing-data, stale-data, or event exclusions are represented in warnings or diagnostics, including symbol-level warning reasons on Start or Data Support surfaces | required |
 
 ### Model Diagnostics
 
@@ -84,7 +85,7 @@ drive the default workbench workflow.
 | --- | --- | --- | --- |
 | `KPI-RESEARCH-001` | request persistence | persisted record includes the original request config | required |
 | `KPI-RESEARCH-002` | strategy artifact persistence | persisted record includes metrics, equity curve, signals, baselines, warnings, and runtime metadata | required for new runs |
-| `KPI-RESEARCH-003` | old-run fallback clarity | historical records lacking artifacts show explicit fallback copy | required |
+| `KPI-RESEARCH-003` | old-run fallback clarity | historical records lacking artifacts expose artifact completeness and explicit fallback copy | required |
 
 ### Comparison
 

--- a/frontend/src/lib/components/OperationsWorkspace.svelte
+++ b/frontend/src/lib/components/OperationsWorkspace.svelte
@@ -9,7 +9,7 @@
     const sections = [
         {
             title: "Market Data Sync",
-            detail: "Manual symbol sync and scheduled recovery stay here so the research flow does not turn into an operator console.",
+            detail: "Manual symbol sync and scheduled recovery stay here as data support for the research flow.",
         },
         {
             title: "Replay Diagnostics",
@@ -24,9 +24,9 @@
 
 <WorkspaceSection
     id="operations-workspace"
-    eyebrow="Operations"
+    eyebrow="Data Support"
     title="Keep repair, replay, and correction workflows out of the main research path."
-    description="Operations is intentionally narrow in v1. This surface is only for TW daily data repair, raw replay, and market-state correction."
+    description="This secondary surface is intentionally narrow in v1: TW daily data repair, raw replay, and market-state correction."
 >
     <div class="operations-shell">
         <section class="surface surface--overview">
@@ -36,7 +36,7 @@
                     <h3>What still belongs here</h3>
                 </div>
                 <p class="muted">
-                    Use this area only when the workflow needs a data-plane fix.
+                    Use this area only when the workflow needs a data fix.
                     Research setup and capability expansion now stay inside the
                     primary research experience.
                 </p>
@@ -77,8 +77,8 @@
                     <h3>Verify raw payload replay and restoration</h3>
                 </div>
                 <p class="muted">
-                    Replay operations remain separate so the research flow does
-                    not become a maintenance console.
+                    Replay diagnostics remain separate so the research flow stays
+                    focused on study setup, review, and comparison.
                 </p>
             </div>
 

--- a/frontend/src/lib/components/RunReviewWorkspace.svelte
+++ b/frontend/src/lib/components/RunReviewWorkspace.svelte
@@ -12,7 +12,9 @@
     import type {
         CapabilityReadinessState,
         ComparisonEligibility,
+        ComparisonCaveat,
         ResearchCapabilityId,
+        ReviewArtifactName,
         ResearchRunRecord,
         ResearchRunResponse,
         ResearchSubmissionSummary,
@@ -69,6 +71,14 @@
         strategy_pair_comparable: "Comparable",
         research_only_comparable: "Comparable for research",
         unresolved_event_quarantine: "Quarantined",
+    };
+    const artifactLabels: Record<ReviewArtifactName, string> = {
+        metrics: "strategy metrics",
+        model_diagnostics: "model diagnostics",
+        equity_curve: "equity curve",
+        signals: "signals",
+        validation: "validation",
+        baselines: "baselines",
     };
 
     let recentRuns: ResearchRunRecord[] = [];
@@ -144,12 +154,43 @@
         }).length;
 
     const hasCompleteArtifacts = (run: ReviewRun | null) =>
+        run?.artifact_completeness === "complete";
+
+    const formatArtifactList = (artifacts: ReviewArtifactName[]) =>
+        artifacts.map((artifact) => artifactLabels[artifact]).join(", ");
+
+    const isArtifactNotRequired = (
+        run: ReviewRun | null | undefined,
+        artifact: ReviewArtifactName,
+    ) => Boolean(run?.not_required_artifacts?.includes(artifact));
+
+    const hasArtifact = (
+        run: ReviewRun | null | undefined,
+        artifact: ReviewArtifactName,
+    ) => Boolean(run?.present_artifacts?.includes(artifact));
+
+    const isArtifactMissing = (
+        run: ReviewRun | null | undefined,
+        artifact: ReviewArtifactName,
+    ) => Boolean(run?.missing_artifacts?.includes(artifact));
+
+    const hasBlockingCaveats = (run: ReviewRun | null | undefined) =>
         Boolean(
-            run?.model_diagnostics ||
-                run?.equity_curve?.length ||
-                run?.signals?.length ||
-                Object.keys(run?.baselines ?? {}).length,
+            run?.comparison_caveats?.some(
+                (caveat) => caveat.severity === "blocker",
+            ),
         );
+
+    const uniqueCaveats = (caveats: ComparisonCaveat[]) => {
+        const seen = new Set<string>();
+        return caveats.filter((caveat) => {
+            if (seen.has(caveat.code)) {
+                return false;
+            }
+            seen.add(caveat.code);
+            return true;
+        });
+    };
 
     const formatMetric = (value: number | null | undefined) =>
         value === null || value === undefined ? "N/A" : value.toFixed(4);
@@ -371,56 +412,18 @@
         const fields = runs.map(getComparisonFields);
         const findings: ComparisonFinding[] = [];
 
-        if (runs.some((run) => !hasCompleteArtifacts(run))) {
-            findings.push({
-                label: "Old record only",
-                detail: "At least one selected run does not have saved diagnostics or backtest artifacts.",
-                severity: "blocker",
-            });
-        }
-        if (
-            runs.some(
-                (run) =>
-                    run.comparison_eligibility === "comparison_metadata_only",
-            )
-        ) {
-            findings.push({
-                label: "Old record only",
-                detail: "At least one selected run only has the old saved record format.",
-                severity: "blocker",
-            });
-        }
-        if (
-            runs.some(
-                (run) => run.comparison_eligibility === "sample_window_pending",
-            )
-        ) {
-            findings.push({
-                label: "Not enough samples yet",
-                detail: "At least one selected run has artifacts, but needs more samples before comparison is strong.",
-                severity: "blocker",
-            });
-        }
-        if (
-            runs.some(
-                (run) =>
-                    run.comparison_eligibility ===
-                    "unresolved_event_quarantine",
-            )
-        ) {
-            findings.push({
-                label: "Event quarantine",
-                detail: "At least one selected run is blocked by unresolved corporate-event data.",
-                severity: "blocker",
-            });
-        }
-        if (runs.some((run) => !run.comparison_eligibility)) {
-            findings.push({
-                label: "Eligibility unavailable",
-                detail: "At least one selected run is missing comparison status.",
-                severity: "blocker",
-            });
-        }
+        uniqueCaveats(runs.flatMap((run) => run.comparison_caveats)).forEach(
+            (caveat) => {
+                findings.push({
+                    label: caveat.label,
+                    detail:
+                        caveat.severity === "blocker"
+                            ? "Backend comparison blocker on at least one selected run."
+                            : "Backend comparison note on at least one selected run.",
+                    severity: caveat.severity,
+                });
+            },
+        );
         const missingDimensions = uniqueValues(
             fields.flatMap((field) => field.missingDimensions),
         );
@@ -493,7 +496,7 @@
 
         return {
             status: blockers.length
-                ? "Compare with caution"
+                ? "Comparison blocked"
                 : findings.length
                   ? "Compare with notes"
                   : "Comparable",
@@ -508,17 +511,20 @@
     };
 
     const getComparableReason = (run: ReviewRun) => {
+        if (hasBlockingCaveats(run)) {
+            return run.comparison_caveats
+                .filter((caveat) => caveat.severity === "blocker")
+                .map((caveat) => caveat.label)
+                .join(" ");
+        }
         if (!hasCompleteArtifacts(run)) {
-            return "Old record only. Saved diagnostics or backtest artifacts are unavailable.";
+            const missing = run.missing_artifacts?.length
+                ? ` Missing: ${formatArtifactList(run.missing_artifacts)}.`
+                : "";
+            return `Review artifacts are ${run.artifact_completeness}.${missing}`;
         }
-        if (run.comparison_eligibility === "comparison_metadata_only") {
-            return "Old record only. Comparison details or artifacts are incomplete.";
-        }
-        if (run.comparison_eligibility === "sample_window_pending") {
-            return "Not enough samples yet.";
-        }
-        if (run.comparison_eligibility === "unresolved_event_quarantine") {
-            return "Blocked by unresolved corporate-event data.";
+        if (run.comparison_caveats?.length) {
+            return run.comparison_caveats.map((caveat) => caveat.label).join(" ");
         }
         if (run.comparison_eligibility === "strategy_pair_comparable") {
             return "Comparable.";
@@ -527,6 +533,16 @@
             return "Comparison status is unavailable.";
         }
         return "Comparable for research.";
+    };
+
+    const getRunCompareStatus = (run: ReviewRun) => {
+        if (hasBlockingCaveats(run)) {
+            const [firstCaveat] = run.comparison_caveats.filter(
+                (caveat) => caveat.severity === "blocker",
+            );
+            return firstCaveat ? `Blocked: ${firstCaveat.label}` : "Blocked";
+        }
+        return formatEligibility(run.comparison_eligibility);
     };
 
     onMount(() => {
@@ -675,7 +691,7 @@
                 <div class="summary-card">
                     <span>Compare Status</span>
                     <strong>
-                        {formatEligibility(activeRun?.comparison_eligibility)}
+                        {activeRun ? getRunCompareStatus(activeRun) : "Unknown"}
                     </strong>
                     <p>{activeRun ? getComparableReason(activeRun as ResearchRunRecord) : "No run selected."}</p>
                 </div>
@@ -732,7 +748,7 @@
 
             <div class="registry-help">
                 <span>Review: use the row button to load one run.</span>
-                <span>Compare: check two or more rows.</span>
+                <span>Compare: check two or more complete compatible rows.</span>
             </div>
 
             {#if recentRunsError}
@@ -796,7 +812,7 @@
 
                             <div class="run-eligibility">
                                 <span class="sr-only">Eligibility </span>
-                                {formatEligibility(run.comparison_eligibility)}
+                                {getRunCompareStatus(run)}
                             </div>
 
                             <button
@@ -850,65 +866,72 @@
                         </p>
                     {/if}
                 </div>
-                <details class="comparison-details">
-                    <summary>Show detailed comparison table</summary>
-                    <div class="table-wrap">
-                        <table>
-                            <thead>
-                                <tr>
-                                    <th>Run ID</th>
-                                    <th>Dataset</th>
-                                    <th>Target</th>
-                                    <th>Features</th>
-                                    <th>Model</th>
-                                    <th>Cost Basis</th>
-                                    <th>Price Basis</th>
-                                    <th>Missing Policy</th>
-                                    <th>RMSE</th>
-                                    <th>Rank IC</th>
-                                    <th>Total Return</th>
-                                    <th>Baseline Delta</th>
-                                    <th>Caveat</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {#each comparisonRuns as run}
-                                    {@const comparison = getComparisonFields(run)}
-                                    {@const baseline = summarizeBaselineComparison(run)}
+                {#if comparisonAssessment.findings.some((finding) => finding.severity === "blocker")}
+                    <p class="muted">
+                        Detailed comparison is blocked until selected runs have
+                        complete review artifacts and compatible assumptions.
+                    </p>
+                {:else}
+                    <details class="comparison-details">
+                        <summary>Show detailed comparison table</summary>
+                        <div class="table-wrap">
+                            <table>
+                                <thead>
                                     <tr>
-                                        <td>{run.run_id}</td>
-                                        <td>{comparison.datasetLabel}</td>
-                                        <td>{comparison.targetLabel}</td>
-                                        <td>{comparison.featureLabel}</td>
-                                        <td>{comparison.modelLabel}</td>
-                                        <td>{comparison.costLabel}</td>
-                                        <td>{comparison.priceBasisLabel}</td>
-                                        <td>
-                                            {comparison.missingFeaturePolicyLabel}
-                                        </td>
-                                        <td>
-                                            {formatMetric(
-                                                run.model_diagnostics?.rmse,
-                                            )}
-                                        </td>
-                                        <td>
-                                            {formatMetric(
-                                                run.model_diagnostics?.rank_ic,
-                                            )}
-                                        </td>
-                                        <td>
-                                            {formatMetric(
-                                                run.metrics?.total_return,
-                                            )}
-                                        </td>
-                                        <td>{formatMetric(baseline?.delta)}</td>
-                                        <td>{getComparableReason(run)}</td>
+                                        <th>Run ID</th>
+                                        <th>Dataset</th>
+                                        <th>Target</th>
+                                        <th>Features</th>
+                                        <th>Model</th>
+                                        <th>Cost Basis</th>
+                                        <th>Price Basis</th>
+                                        <th>Missing Policy</th>
+                                        <th>RMSE</th>
+                                        <th>Rank IC</th>
+                                        <th>Total Return</th>
+                                        <th>Baseline Delta</th>
+                                        <th>Caveat</th>
                                     </tr>
-                                {/each}
-                            </tbody>
-                        </table>
-                    </div>
-                </details>
+                                </thead>
+                                <tbody>
+                                    {#each comparisonRuns as run}
+                                        {@const comparison = getComparisonFields(run)}
+                                        {@const baseline = summarizeBaselineComparison(run)}
+                                        <tr>
+                                            <td>{run.run_id}</td>
+                                            <td>{comparison.datasetLabel}</td>
+                                            <td>{comparison.targetLabel}</td>
+                                            <td>{comparison.featureLabel}</td>
+                                            <td>{comparison.modelLabel}</td>
+                                            <td>{comparison.costLabel}</td>
+                                            <td>{comparison.priceBasisLabel}</td>
+                                            <td>
+                                                {comparison.missingFeaturePolicyLabel}
+                                            </td>
+                                            <td>
+                                                {formatMetric(
+                                                    run.model_diagnostics?.rmse,
+                                                )}
+                                            </td>
+                                            <td>
+                                                {formatMetric(
+                                                    run.model_diagnostics?.rank_ic,
+                                                )}
+                                            </td>
+                                            <td>
+                                                {formatMetric(
+                                                    run.metrics?.total_return,
+                                                )}
+                                            </td>
+                                            <td>{formatMetric(baseline?.delta)}</td>
+                                            <td>{getComparableReason(run)}</td>
+                                        </tr>
+                                    {/each}
+                                </tbody>
+                            </table>
+                        </div>
+                    </details>
+                {/if}
             </section>
         {/if}
 
@@ -924,13 +947,45 @@
                             <span class="muted">Loading...</span>
                         {/if}
                     </div>
+                    {#if activeRun}
+                        <div
+                            class="artifact-status"
+                            class:artifact-status--limited={activeRun.artifact_completeness !==
+                                "complete"}
+                        >
+                            <strong>
+                                Review artifacts: {activeRun.artifact_completeness}
+                            </strong>
+                            {#if activeRun.missing_artifacts.length}
+                                <span>
+                                    Missing {formatArtifactList(
+                                        activeRun.missing_artifacts,
+                                    )}. These artifacts are unavailable on this
+                                    record.
+                                </span>
+                            {:else if activeRun.not_required_artifacts.length}
+                                <span>
+                                    Not requested: {formatArtifactList(
+                                        activeRun.not_required_artifacts,
+                                    )}.
+                                </span>
+                            {:else}
+                                <span>Required review artifacts are available.</span>
+                            {/if}
+                        </div>
+                    {/if}
                     {#if selectedRunError}
                         <p class="muted">{selectedRunError}</p>
                     {:else if activeRun?.metrics}
                         <ResearchRunMetrics metrics={activeRun.metrics} />
-                    {:else}
+                    {:else if isArtifactMissing(activeRun, "metrics")}
                         <p class="muted">
                             Strategy metrics are unavailable for this record.
+                        </p>
+                    {:else if hasArtifact(activeRun, "metrics")}
+                        <p class="muted">
+                            Strategy metrics are available but contain no values
+                            for this run.
                         </p>
                     {/if}
                 </div>
@@ -949,11 +1004,17 @@
                         </div>
                         <EquityChart points={activeRun.equity_curve} />
                     </div>
-                {:else}
+                {:else if isArtifactMissing(activeRun, "equity_curve")}
                     <div class="surface">
                         <p class="muted">
                             Equity curve is unavailable for this record. This is
                             expected for older saved runs.
+                        </p>
+                    </div>
+                {:else if hasArtifact(activeRun, "equity_curve")}
+                    <div class="surface">
+                        <p class="muted">
+                            No equity curve points were produced for this run.
                         </p>
                     </div>
                 {/if}
@@ -961,6 +1022,11 @@
                 <ResearchRunValidation
                     validation={activeRun?.validation ?? null}
                     warnings={activeRun?.warnings ?? []}
+                    emptyMessage={activeRun?.missing_artifacts.includes(
+                        "validation",
+                    )
+                        ? "Validation is unavailable on this record."
+                        : "Validation was not requested for this run."}
                 />
 
                 {#if Object.keys(activeRun?.baselines ?? {}).length}
@@ -1004,15 +1070,40 @@
                             </table>
                         </div>
                     </div>
+                {:else if activeRun && isArtifactNotRequired(activeRun, "baselines")}
+                    <div class="surface">
+                        <p class="muted">
+                            Baselines were not requested for this run.
+                        </p>
+                    </div>
+                {:else if activeRun?.missing_artifacts.includes("baselines")}
+                    <div class="surface">
+                        <p class="muted">
+                            Baseline metrics are unavailable on this record.
+                        </p>
+                    </div>
+                {:else if activeRun && hasArtifact(activeRun, "baselines")}
+                    <div class="surface">
+                        <p class="muted">
+                            Baseline artifacts are available but contain no rows
+                            for this run.
+                        </p>
+                    </div>
                 {/if}
 
                 {#if activeRun?.signals?.length}
                     <ResearchRunSignals signals={activeRun.signals} />
-                {:else}
+                {:else if isArtifactMissing(activeRun, "signals")}
                     <div class="surface">
                         <p class="muted">
                             Signals are unavailable for this record. This is
                             expected for older saved runs.
+                        </p>
+                    </div>
+                {:else if hasArtifact(activeRun, "signals")}
+                    <div class="surface">
+                        <p class="muted">
+                            No signals were produced for this run.
                         </p>
                     </div>
                 {/if}
@@ -1252,6 +1343,26 @@
     .status-pill--limited {
         border-color: rgba(251, 191, 36, 0.36);
         color: #fde68a;
+    }
+
+    .artifact-status {
+        display: grid;
+        gap: 0.25rem;
+        margin-bottom: var(--space-4);
+        padding: 0.85rem 0.95rem;
+        border-radius: var(--radius-md);
+        border: 1px solid rgba(45, 212, 191, 0.18);
+        background: rgba(15, 35, 54, 0.72);
+    }
+
+    .artifact-status--limited {
+        border-color: rgba(251, 191, 36, 0.22);
+        background: rgba(113, 63, 18, 0.14);
+    }
+
+    .artifact-status span {
+        color: var(--muted);
+        line-height: 1.45;
     }
 
     .comparison-summary {

--- a/frontend/src/lib/components/research-runs/ResearchRunValidation.svelte
+++ b/frontend/src/lib/components/research-runs/ResearchRunValidation.svelte
@@ -3,6 +3,7 @@
 
     export let validation: ValidationSummary | null = null;
     export let warnings: string[] = [];
+    export let emptyMessage = "Validation was not requested for this run.";
 </script>
 
 <div class="validation-grid">
@@ -23,7 +24,7 @@
                 {/each}
             </div>
         {:else}
-            <p class="muted">Validation is disabled for this run.</p>
+            <p class="muted">{emptyMessage}</p>
         {/if}
     </div>
 

--- a/frontend/src/lib/types/common.ts
+++ b/frontend/src/lib/types/common.ts
@@ -40,6 +40,14 @@ export type ComparisonEligibility =
   | "strategy_pair_comparable"
   | "research_only_comparable"
   | "unresolved_event_quarantine";
+export type ReviewArtifactName =
+  | "metrics"
+  | "model_diagnostics"
+  | "equity_curve"
+  | "signals"
+  | "validation"
+  | "baselines";
+export type ArtifactCompleteness = "complete" | "partial" | "metadata_only";
 export type TradabilityState =
   | "execution_ready"
   | "research_only"

--- a/frontend/src/lib/types/researchRuns.ts
+++ b/frontend/src/lib/types/researchRuns.ts
@@ -1,9 +1,11 @@
 import type {
   BaselineName,
   DefaultBundleVersion,
+  ArtifactCompleteness,
   FeatureName,
   ModelType,
   PriceSource,
+  ReviewArtifactName,
   ReturnTarget,
   ResearchMonitorProfileId,
   RunStatus,
@@ -127,8 +129,26 @@ export interface RegressionDiagnostics {
   feature_importance: FeatureImportancePoint[];
 }
 
+export interface ComparisonCaveat {
+  code: string;
+  label: string;
+  severity: "blocker" | "note";
+}
+
+export interface ReviewArtifactSummary {
+  artifact_completeness: ArtifactCompleteness;
+  present_artifacts: ReviewArtifactName[];
+  missing_artifacts: ReviewArtifactName[];
+  not_required_artifacts: ReviewArtifactName[];
+  comparison_caveats: ComparisonCaveat[];
+}
+
 export interface ResearchRunResponse
-  extends VersionPack, P3Summary, GovernanceMetadata, FoundationMetadata {
+  extends VersionPack,
+    P3Summary,
+    GovernanceMetadata,
+    FoundationMetadata,
+    ReviewArtifactSummary {
   run_id: string;
   metrics: Metrics;
   equity_curve: EquityPoint[];
@@ -145,7 +165,11 @@ export interface ResearchRunResponse
 }
 
 export interface ResearchRunRecord
-  extends VersionPack, P3Summary, GovernanceMetadata, FoundationMetadata {
+  extends VersionPack,
+    P3Summary,
+    GovernanceMetadata,
+    FoundationMetadata,
+    ReviewArtifactSummary {
   run_id: string;
   request_id: string | null;
   status: RunStatus;

--- a/tests/research/test_run_repository.py
+++ b/tests/research/test_run_repository.py
@@ -55,6 +55,21 @@ def test_research_run_repository_roundtrip(monkeypatch):
             "max_drawdown": -0.08,
             "turnover": 0.3,
         },
+        "equity_curve": [{"date": "2024-01-02", "equity": 1.0}],
+        "signals": [
+            {"date": "2024-01-02", "symbol": "2330", "score": 0.01, "position": 1.0}
+        ],
+        "model_diagnostics": {
+            "task": "regression",
+            "sample_count": 2,
+            "rmse": 0.1,
+            "mae": 0.08,
+            "rank_ic": 0.2,
+            "linear_ic": 0.1,
+            "actual_vs_predicted": [],
+            "residuals": [],
+            "feature_importance": [],
+        },
         "warnings": [],
         "tradability_state": "execution_ready",
         "tradability_contract_version": "p3_tradability_monitoring_v1",
@@ -126,6 +141,198 @@ def test_research_run_repository_roundtrip(monkeypatch):
     assert loaded["tradability_contract_version"] == "p3_tradability_monitoring_v1"
     assert loaded["liquidity_bucket_coverages"][0]["bucket_key"] == "50m_to_200m"
     assert loaded["monitor_observation_status"] == "persisted"
+    assert loaded["artifact_completeness"] == "complete"
+    assert loaded["missing_artifacts"] == []
+    assert loaded["not_required_artifacts"] == ["validation", "baselines"]
+
+
+def test_research_run_repository_classifies_metadata_only_old_row(monkeypatch):
+    engine = create_engine("sqlite:///:memory:")
+    testing_session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(
+        bind=engine,
+        tables=[
+            ResearchRun.__table__,
+            ResearchRunLiquidityCoverage.__table__,
+            MicrostructureObservation.__table__,
+        ],
+    )
+    monkeypatch.setattr(research_run_repository, "SessionLocal", testing_session_local)
+
+    with testing_session_local() as session:
+        row = ResearchRun(run_id="run_old")
+        row.request_id = "req_old"
+        row.status = "succeeded"
+        row.market = "TW"
+        row.symbols_json = '["2330"]'
+        row.strategy_type = "research_v1"
+        row.request_payload_json = research_run_repository.json_dumps(
+            {"symbols": ["2330"], "baselines": []}
+        )
+        row.comparison_eligibility = "comparison_metadata_only"
+        row.warnings_json = "[]"
+        session.add(row)
+        session.commit()
+
+    loaded = research_run_repository.get_research_run_record("run_old")
+
+    assert loaded["artifact_completeness"] == "metadata_only"
+    assert loaded["present_artifacts"] == []
+    assert loaded["missing_artifacts"] == [
+        "metrics",
+        "model_diagnostics",
+        "equity_curve",
+        "signals",
+    ]
+    assert loaded["not_required_artifacts"] == ["validation", "baselines"]
+    assert {item["code"] for item in loaded["comparison_caveats"]} >= {
+        "METADATA_ONLY_RECORD",
+        "COMPARISON_METADATA_ONLY",
+    }
+
+
+def test_research_run_repository_classifies_partial_artifacts(monkeypatch):
+    engine = create_engine("sqlite:///:memory:")
+    testing_session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(
+        bind=engine,
+        tables=[
+            ResearchRun.__table__,
+            ResearchRunLiquidityCoverage.__table__,
+            MicrostructureObservation.__table__,
+        ],
+    )
+    monkeypatch.setattr(research_run_repository, "SessionLocal", testing_session_local)
+
+    with testing_session_local() as session:
+        row = ResearchRun(run_id="run_partial")
+        row.request_id = "req_partial"
+        row.status = "succeeded"
+        row.market = "TW"
+        row.symbols_json = '["2330"]'
+        row.strategy_type = "research_v1"
+        row.request_payload_json = research_run_repository.json_dumps(
+            {"symbols": ["2330"], "baselines": []}
+        )
+        row.metrics_json = research_run_repository.json_dumps(
+            {
+                "total_return": 0.12,
+                "sharpe": 1.1,
+                "max_drawdown": -0.08,
+                "turnover": 0.3,
+            }
+        )
+        row.comparison_eligibility = "research_only_comparable"
+        row.warnings_json = "[]"
+        session.add(row)
+        session.commit()
+
+    loaded = research_run_repository.get_research_run_record("run_partial")
+
+    assert loaded["artifact_completeness"] == "partial"
+    assert loaded["present_artifacts"] == ["metrics"]
+    assert loaded["missing_artifacts"] == [
+        "model_diagnostics",
+        "equity_curve",
+        "signals",
+    ]
+    assert {item["code"] for item in loaded["comparison_caveats"]} == {
+        "REVIEW_ARTIFACTS_MISSING"
+    }
+
+
+def test_research_run_repository_marks_running_artifacts_not_evaluated(monkeypatch):
+    engine = create_engine("sqlite:///:memory:")
+    testing_session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(
+        bind=engine,
+        tables=[
+            ResearchRun.__table__,
+            ResearchRunLiquidityCoverage.__table__,
+            MicrostructureObservation.__table__,
+        ],
+    )
+    monkeypatch.setattr(research_run_repository, "SessionLocal", testing_session_local)
+
+    with testing_session_local() as session:
+        row = ResearchRun(run_id="run_running")
+        row.request_id = "req_running"
+        row.status = "running"
+        row.market = "TW"
+        row.symbols_json = '["2330"]'
+        row.strategy_type = "research_v1"
+        row.request_payload_json = research_run_repository.json_dumps(
+            {"symbols": ["2330"], "baselines": []}
+        )
+        row.comparison_eligibility = "comparison_metadata_only"
+        row.warnings_json = "[]"
+        session.add(row)
+        session.commit()
+
+    loaded = research_run_repository.get_research_run_record("run_running")
+
+    assert loaded["artifact_completeness"] == "metadata_only"
+    assert {item["code"] for item in loaded["comparison_caveats"]} >= {
+        "ARTIFACTS_NOT_EVALUATED",
+        "METADATA_ONLY_RECORD",
+    }
+
+
+def test_list_research_run_records_keeps_summary_without_heavy_artifacts(monkeypatch):
+    engine = create_engine("sqlite:///:memory:")
+    testing_session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(
+        bind=engine,
+        tables=[
+            ResearchRun.__table__,
+            ResearchRunLiquidityCoverage.__table__,
+            MicrostructureObservation.__table__,
+        ],
+    )
+    monkeypatch.setattr(research_run_repository, "SessionLocal", testing_session_local)
+
+    payload = {
+        "run_id": "run_list",
+        "request_id": "req_list",
+        "status": "succeeded",
+        "market": "TW",
+        "symbols": ["2330"],
+        "strategy_type": "research_v1",
+        "request_payload": {"symbols": ["2330"], "baselines": []},
+        "metrics": {
+            "total_return": 0.12,
+            "sharpe": 1.1,
+            "max_drawdown": -0.08,
+            "turnover": 0.3,
+        },
+        "equity_curve": [{"date": "2024-01-02", "equity": 1.0}],
+        "signals": [
+            {"date": "2024-01-02", "symbol": "2330", "score": 0.01, "position": 1.0}
+        ],
+        "model_diagnostics": {
+            "task": "regression",
+            "sample_count": 2,
+            "rmse": 0.1,
+            "mae": 0.08,
+            "rank_ic": 0.2,
+            "linear_ic": 0.1,
+            "actual_vs_predicted": [],
+            "residuals": [],
+            "feature_importance": [],
+        },
+        "warnings": [],
+        "comparison_eligibility": "research_only_comparable",
+    }
+
+    research_run_repository.persist_research_run_record(payload)
+    listed = research_run_repository.list_research_run_records()
+
+    assert listed[0]["run_id"] == "run_list"
+    assert listed[0]["artifact_completeness"] == "complete"
+    assert listed[0]["missing_artifacts"] == []
+    assert listed[0]["equity_curve"] == []
+    assert listed[0]["signals"] == []
+    assert listed[0]["model_diagnostics"]["actual_vs_predicted"] == []
 
 
 def test_research_run_repository_reassigns_existing_observation_run_id(monkeypatch):

--- a/tests/research/test_runs.py
+++ b/tests/research/test_runs.py
@@ -47,6 +47,17 @@ def make_response(run_id: str = "run_123") -> ResearchRunResponse:
             {"date": "2024-01-02", "symbol": "2330", "score": 0.01, "position": 1.0}
         ],
         validation=None,
+        model_diagnostics={
+            "task": "regression",
+            "sample_count": 2,
+            "rmse": 0.1,
+            "mae": 0.08,
+            "rank_ic": 0.2,
+            "linear_ic": 0.1,
+            "actual_vs_predicted": [],
+            "residuals": [],
+            "feature_importance": [],
+        },
         baselines={},
         warnings=[],
         runtime_mode="runtime_compatibility_mode",
@@ -68,7 +79,7 @@ def make_response(run_id: str = "run_123") -> ResearchRunResponse:
                 "threshold_policy_version": "static_absolute_gross_label_v1",
                 "price_basis_version": "label_open_to_open__entry_ohlc_default__exit_ohlc_default__benchmark_unset_v1",
                 "benchmark_comparability_gate": False,
-                "comparison_eligibility": "comparison_metadata_only",
+                "comparison_eligibility": "research_only_comparable",
                 "scoring_factor_ids": [],
             }
         ),
@@ -157,4 +168,6 @@ def test_create_research_run_records_started_before_execute(monkeypatch):
     )
 
     assert response.run_id == "run_started"
+    assert response.artifact_completeness == "complete"
+    assert response.not_required_artifacts == ["validation", "baselines"]
     assert call_order == ["started", "executed", "success"]


### PR DESCRIPTION
## Summary
- add derived review artifact completeness and comparison caveats to research run responses
- update Experiments reload/compare UI to distinguish complete, partial, metadata-only, not-requested, and unavailable artifacts
- clean v1 Data Support copy and refresh docs/tests for the usable research loop

## Validation
- .venv/bin/python -m pytest -q
- bun x tsc -p frontend/tsconfig.json --noEmit
- bun run build
- git diff --check
- sub-agent review pass after fixes

## Notes
- No DB migration or new dependency.
- Branch includes the existing local commit e8be229 docs: clarify retained platform foundations because it was already ahead of origin/main before this commit.