### PR TITLE
docs: add product strategy routing skill

### DIFF
--- a/.codex/skills/quant-product-strategy-review/SKILL.md
+++ b/.codex/skills/quant-product-strategy-review/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: quant-product-strategy-review
+description: "Review product direction for this quant research-to-opinion workbench. Use when the user asks for roadmap, phase planning, product direction, scope review, next-stage prioritization, CEO/PM review, or docs drift. Avoid for ordinary implementation, bugfixes, tests, commits, or code review unless product strategy is explicitly in scope."
+compatibility: [codex, claude, gemini]
+metadata:
+  version: "0.1.1"
+---
+
+# Quant Product Strategy Review
+
+## Purpose
+
+Keep product planning anchored on a CEO/PM view of the workbench: convert quant
+research artifacts into decision-useful model opinions without drifting back
+into maintenance-only hardening or jumping prematurely into broker/live
+execution.
+
+This is a project-local strategy skill. It interprets long repository docs
+through the product compass before proposing roadmap, phase, or scope decisions.
+
+## Use When
+
+- The user asks for product direction, product strategy, roadmap, phase
+  planning, or next-stage prioritization.
+- The user asks whether the project, docs, or a proposed feature is drifting.
+- The user asks for a CEO/PM-style review of this repository.
+- The task is to choose between product directions or define a Phase proposal.
+
+## Avoid When
+
+- The task is a normal implementation, bugfix, test, commit, or code review.
+- The user only asks for a focused engineering change with stable requirements.
+- A narrower skill owns the work, such as `change-sanity-review` for current
+  diffs or `conventional-git-flow` for commits and PRs.
+
+## Workflow
+
+1. Load `references/product-compass.md` first.
+2. Inspect only the project docs needed to verify the specific question. Treat
+   README, goals, specs, plans, status, gates, and decision docs as evidence,
+   not as a fresh source of product identity on every turn.
+3. State the active product frame as defined in
+   `references/product-compass.md` before recommending work. Do not restate or
+   maintain a second product-frame definition in this file.
+4. Challenge the proposal with the anti-drift checks defined in
+   `references/product-compass.md` before giving a plan.
+5. If logic is not closed, ask targeted questions before proposing a phase or
+   PR sequence. If a reasonable assumption is safe, state it explicitly.
+6. When proposing work, require the output to describe product value,
+   decision-usefulness value, scope risk, minimum PR shape, and manual
+   verification.
+7. If existing docs conflict with the product compass, flag the docs drift and
+   name the docs that should be updated. Do not silently override docs or let
+   conservative v1 wording erase the product direction.
+
+## Tool And Side-Effect Boundaries
+
+- Prefer read-only inspection for strategy review.
+- Do not edit files unless the user explicitly asks for implementation.
+- Do not propose new dependencies, DB migrations, broker execution, live-order
+  semantics, or platform-control surfaces unless the user explicitly changes
+  the product direction.
+- Do not invent stable numeric thresholds for model quality, confidence, risk,
+  or investability. Prototype thresholds must be labeled as provisional and
+  later replaced by versioned policy.
+- Do not turn model opinions into personalized investment advice. The product
+  boundary is model opinion with manual adoption.
+
+## Output
+
+For product strategy requests, return:
+
+- `understanding`: current product frame and the user's goal.
+- `challenge`: contradictions, missing decisions, and anti-drift findings.
+- `recommendation`: the recommended direction and why alternatives are weaker.
+- `phase_or_pr_plan`: phase proposal or minimum PR slices when the logic is
+  closed.
+- `manual_verification`: checklist focused on product decision value.
+
+## Version History
+
+- v0.1.1 (2026-05-18): Make the product compass the single source of truth for
+  the active product frame and anti-drift checks.
+- v0.1.0 (2026-05-18): Initial project-local CEO/PM strategy review skill.
+
+## References
+
+- `references/product-compass.md` - Product identity, phase direction,
+  boundaries, anti-drift checks, and output expectations.

--- a/.codex/skills/quant-product-strategy-review/references/product-compass.md
+++ b/.codex/skills/quant-product-strategy-review/references/product-compass.md
@@ -1,0 +1,122 @@
+# Product Compass
+
+## Product Identity
+
+This project is a market-phased quant research-to-opinion workbench.
+
+It should help a solo investor-researcher turn quantitative research artifacts
+into model-backed opinions that are useful before manual investment decisions.
+It is not only a research artifact viewer, and it is not a broker, live trading,
+or personalized portfolio-advice system.
+
+## Market Sequence
+
+- First implementation lane: TW daily.
+- Future expansion lane: US daily.
+- Product identity: market-phased and market-expandable, not TW-only.
+- Phase 2 work should keep contracts and concepts market-agnostic while proving
+  the loop first on TW daily data.
+
+## Strategic Gap
+
+The v1 usable loop can create, inspect, reload, and compare research runs. The
+remaining product gap is that diagnostics, signals, backtests, baselines, and
+warnings are not yet synthesized into a decision-useful opinion layer.
+
+Avoid mistaking v1 hardening, docs cleanup, or comparison polish for the main
+Phase 2 product advance unless it directly improves opinion quality.
+
+## Phase Direction
+
+### Phase 2: Research Opinion Layer
+
+Phase 2 should produce an action-list opinion brief from existing research
+artifacts.
+
+The brief should include:
+
+- strategy-level viability or no-opinion state
+- buy-candidate list
+- sell/avoid list
+- watch list
+- evidence and risk context for each list item
+- invalidation notes explaining when the opinion should not be adopted
+
+Minimum row fields:
+
+- symbol
+- model score
+- strategy-derived weight or position signal
+- evidence reason
+- risk or warning
+- invalidation note
+
+The system does not need to know the user's holdings in Phase 2. A sell/avoid
+list is a model opinion about symbols, not a statement that the user owns those
+symbols or an instruction to place orders.
+
+### Phase 3 North Star
+
+Tracked portfolio ledger is a later product north star. It can close the loop
+around adoption, holdings, forward outcomes, and portfolio impact, but it should
+not be required for the Phase 2 opinion brief unless the user explicitly
+reprioritizes the roadmap.
+
+## Opinion Boundary
+
+The product may use direct action-language labels when useful, but the boundary
+is:
+
+- model opinion, not personalized investment advice
+- manual adoption, not broker instruction
+- next-session planning from daily data, not intraday execution judgment
+
+When evidence is insufficient, the product must be allowed to output
+`no-opinion` or `do-not-adopt` instead of forcing a buy list.
+
+## Threshold Policy
+
+During prototype validation, provisional thresholds are allowed only when they
+are clearly labeled as provisional.
+
+Stable thresholds must eventually become versioned, explainable policy. Do not
+invent permanent RMSE, IC, drawdown, turnover, confidence, or investability
+thresholds without user approval and evidence.
+
+## Success Model
+
+Primary product success:
+
+- decision usefulness: the tool helps the solo investor-researcher form a
+  clearer model opinion faster.
+
+Feedback validation:
+
+- forward outcome versus baseline after the opinion date.
+
+This means the product should eventually evaluate whether opinions helped, but
+Phase 2 can start with the opinion artifact before building the Phase 3 ledger.
+
+## Docs Conflict Rule
+
+Existing docs are evidence and constraints. They are not allowed to erase this
+product direction through length or conservative v1 wording.
+
+If long docs imply that the project should remain research-only forever, flag
+that as docs drift. If a proposal ignores current v1 boundaries and jumps to
+broker/live execution, flag that as execution creep.
+
+## Anti-Drift Checks
+
+Before recommending roadmap, phase, or scope work, check:
+
+- Is TW-first being misread as TW-only?
+- Is Phase 2 being reduced to maintenance, hardening, or docs cleanup?
+- Is the proposal jumping to broker execution, live orders, or platform-control
+  surfaces too early?
+- Is model opinion being turned into personalized investment advice?
+- Are thresholds or confidence scores being invented without a provisional
+  label or versioned policy?
+- Is the system forcing buy/sell output when evidence should produce
+  no-opinion?
+- Does the proposal improve decision usefulness for a solo investor-researcher?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+# AGENTS.md - Baseline Rules
+
+These rules apply to all tasks in this repo unless a more specific policy or
+skill overrides them.
+
+- Language: chat in Traditional Chinese; repo artifacts in English; never
+  translate identifiers or config; Chinese UI copy only if a specific policy
+  requires it.
+- Ambiguity: ask when requirements are unclear or conflicting; do not guess.
+- Execution: do not run programs or add tests unless asked or required; include
+  a manual verification checklist; note runtime risks/assumptions when relevant.
+- Changes and output: keep changes minimal; no refactors, public API renames, or
+  new dependencies unless asked; provide a concise change summary plus
+  env/config or migration notes when relevant.
+- Review routing: when the user asks to review current changes or whether
+  current changes are reasonable without explicitly requesting a full code
+  review, use `change-sanity-review`; keep it read-only, bounded, and
+  diff-centered. Do not invoke provider-native review commands, broad test
+  suites, or domain skills unless explicitly requested or clearly required by
+  the focused risk.
+
+## Product Strategy Routing
+
+Codex does not reliably auto-discover project-local skill files under
+`.codex/skills/`. This section is the Codex bridge for the
+`quant-product-strategy-review` skill.
+
+Use the project-local `quant-product-strategy-review` skill before reading long
+project docs when the user asks for any of the following:
+
+- product direction or product strategy
+- roadmap, phase planning, or next-stage prioritization
+- scope review or whether a proposal is drifting
+- CEO/PM-style product review
+- whether docs and implementation direction still match the intended product
+
+For those tasks, load
+`.codex/skills/quant-product-strategy-review/references/product-compass.md`
+first, then use README, goals, specs, plans, status, and decision docs as
+evidence. Do not start by flattening every long markdown file into a new product
+interpretation.
+
+Do not force this skill onto ordinary implementation, bugfix, test, commit, or
+code-review tasks unless the user explicitly asks for product strategy review.
+
+## Routing Model
+
+- Rules: apply baseline behavior, language, safety, and output constraints.
+- Skills: use reusable policies and workflows when the request matches a skill
+  description or explicitly names a skill.
+- Agents: suggest sub-agents only when the split is concrete, useful, and worth
+  the coordination/token cost; keep high-cost roles such as `oracle` explicit.
+- Hooks: treat hooks as deterministic guardrails only; they do not replace
+  rules, skills, agents, sandboxing, or permission prompts.


### PR DESCRIPTION
## Summary
- add repo-level AGENTS routing so product strategy tasks load the product compass before long docs
- add the project-local quant-product-strategy-review skill
- add the product compass for market-phased research-to-opinion planning

## Validation
- not run; documentation and skill routing changes only

## Notes
- Codex does not reliably auto-discover project-local skill files, so AGENTS.md acts as the bridge for product strategy routing.