### PR TITLE
feat: add research opinion review artifact

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,54 @@
+language: zh-TW
+
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  path_filters:
+    - "!**/.venv/**"
+    - "!**/node_modules/**"
+    - "!**/frontend/dist/**"
+    - "!**/.svelte-kit/**"
+    - "!**/dist/**"
+    - "!**/build/**"
+    - "!**/.pytest_cache/**"
+    - "!**/.mypy_cache/**"
+    - "!**/.ruff_cache/**"
+    - "!**/coverage/**"
+  path_instructions:
+    - path: "**/*"
+      instructions: >
+        Respond in Traditional Chinese. Keep reviews bounded and diff-centered.
+        Prefer minimal changes. Ask when requirements are unclear. Do not suggest
+        public API renames, new dependencies, broad refactors, or broad test-suite
+        execution unless the diff clearly requires it.
+
+    - path: "backend/**"
+      instructions: >
+        Treat backend code as Python 3.12+ FastAPI-style code. Pay attention to
+        API contracts, DB/session boundaries, migrations, data integrity, and
+        deterministic research artifact reload behavior.
+
+    - path: "backend/research/**"
+      instructions: >
+        Preserve the research-to-opinion boundary. Do not suggest broker/live
+        order execution, portfolio auto-control, US market provider work, crypto
+        trading integration, or adaptive/RL runtime behavior unless the PR
+        explicitly targets that deferred scope.
+
+    - path: "frontend/**"
+      instructions: >
+        Treat frontend code as Svelte 5 + Vite + TypeScript. Pay attention to
+        backend API/type alignment, user-facing research workflow regressions,
+        and build/typecheck risks.
+
+    - path: "frontend/src/lib/internal/legacy/**"
+      instructions: >
+        This is legacy UI code and is not part of the v1 information architecture.
+        Avoid broad comments unless the PR intentionally changes legacy behavior.
+
+    - path: "docs/**"
+      instructions: >
+        Keep repository documentation in English. Preserve document ownership and
+        product boundaries; do not turn focused docs edits into product redesign.

--- a/GOAL.md
+++ b/GOAL.md
@@ -325,10 +325,12 @@ List/summary responses:
   caveats, diagnostic samples, or source text
 - evaluated check results and hidden-derived counts must be omitted or replaced
   with omission-only placeholders
-- default safe behavior for `include_artifacts=False`: action lists are empty,
-  `state` is `no-opinion`, and `state_reason` or `evidence_limitations`
-  explains that detail artifacts are omitted and detail reload is required for
-  row-level opinion review
+- default safe behavior for `include_artifacts=False` on a successful run:
+  action lists are empty, `state` is `no-opinion`, and `state_reason` or
+  `evidence_limitations` explains that detail artifacts are omitted and detail
+  reload is required for row-level opinion review
+- non-successful summary responses retain the downgrade matrix state
+  `do-not-adopt` while also explaining that detail artifacts are omitted
 
 ### Required Local Methods
 
@@ -344,6 +346,9 @@ Latest signal definition for all Jesse-style checks and viable action rows:
   differ.
 - A row without a parseable `date` must not satisfy row-specific
   latest-date traceability for a viable populated opinion row.
+- `invalid_row_count` includes rows without a symbol, rows without a parseable
+  date, rows outside an available declared run universe, and selected latest
+  rows without a finite numeric `score` or `position`.
 - Focused tests must include unsorted multi-date signal rows for the same
   symbol and prove older rows do not drive action rows, bucket counts, or
   `parameter_sensitivity`.

--- a/GOAL.md
+++ b/GOAL.md
@@ -32,19 +32,15 @@ External projects are reference material only:
 They must not become runtime dependencies, trading frameworks, broker adapters,
 provider SDKs, or proof that deferred features belong in this goal.
 
-### Current State
+### Implementation Baseline
 
-As of 2026-07-07, docs define Phase 2 opinion requirements and reference
-promotion criteria. The current uncommitted backend attempt adds an
-`opinion_artifact` and `review_checks`, but it is only a partial scaffold.
+Phase 2 backend work extends persisted research-run artifacts with an
+`opinion_artifact` and structured `review_checks` results. Completion is
+governed by the acceptance criteria and verification evidence below.
 
-Known incomplete behavior that must be fixed before this goal can be complete:
+Required behavior before this goal can be complete:
 
 - adding `review_checks` names and statuses alone is not enough
-- `review_checks.result` is not yet a contract field in the current code
-- current repo state has required new files outside the tracked diff:
-  `GOAL.md` and `backend/research/domain/opinion.py` are untracked and must
-  not be omitted from review or completion evidence
 - latest signal selection must be by each symbol's latest persisted `date`;
   list order or last-write-wins replacement is not acceptable
 - `parameter_sensitivity` always returning `not_evaluated` is not enough when
@@ -117,8 +113,8 @@ Rejected Evidence:
 
 ### Validation Lineage
 
-- Current stage: Phase 2 backend opinion expansion, starting from the current
-  uncommitted `opinion_artifact` scaffold.
+- Current stage: Phase 2 backend opinion expansion over persisted V1
+  research-run artifacts and the structured opinion contract.
 - Direct dependency predecessor: persisted successful V1 research-run artifacts
   and the existing research-run create/reload/list API paths.
 - Relevant prior final labels: V1 usable loop is described as verified in
@@ -483,7 +479,7 @@ Latest signal definition for all Jesse-style checks and viable action rows:
     `risk_or_warning`, row `invalidation_note`, and review-check copy.
   - Negative tests must cover wording variants in opinion-facing text,
     including `execution-ready`, `order routing`, `automatic rebalance` or
-    `automatic rebalancing`, `broker`, `account control`, and
+    `automatic rebalancing`, `broker routing`, `account control`, and
     `personalized investment advice`.
 
 - `insufficient_evidence_gate`
@@ -633,7 +629,7 @@ Self-review failures must affect `state`, `state_reason`, or
   Given opinion-facing text fields are produced
   When `manual_adoption_boundary` is evaluated
   Then the check fails if any field implies execution, order routing, automatic
-  rebalancing, broker/account control, or personalized investment advice,
+  rebalancing, broker routing/account control, or personalized investment advice,
   including review-check copy and wording variants such as `execution-ready`
   Evidence: focused negative tests plus manual diff review
 

--- a/GOAL.md
+++ b/GOAL.md
@@ -1,0 +1,795 @@
+# Goal Brief: Phase 2 Backend Opinion Expansion
+
+## Context
+
+### Background
+
+This project is a market-phased quant research-to-opinion workbench. It helps a
+solo investor-researcher turn persisted quantitative research artifacts into
+model-backed opinions before manual investment decisions.
+
+V1 can create, persist, reload, and compare TW daily research runs. Phase 2 must
+turn those artifacts into a decision-useful backend opinion artifact. This is
+an expansion of the backend opinion layer, not a replacement of existing
+research-run artifacts and not a broker, live-order, or portfolio-control
+feature.
+
+External projects are reference material only:
+
+- `Jesse`: strategy lifecycle, signal-to-position translation, robustness
+  checks, parameter sensitivity, and backtest-report discipline.
+- `UZI-Skill`: multi-angle report structure, self-review gates,
+  evidence/risk/invalidation sections, and compact stock-analysis brief
+  patterns.
+- `a-stock-data` and `OpenBB`: source/provider audit concepts, raw-source
+  traceability, parser/source metadata, and future market-aware provider
+  contracts.
+- `FinGPT`: traceable evidence extraction, report summarization, risk, warning,
+  and invalidation support.
+- `FinRL`: train/test/trade separation and policy evaluation for a later
+  adaptive phase.
+
+They must not become runtime dependencies, trading frameworks, broker adapters,
+provider SDKs, or proof that deferred features belong in this goal.
+
+### Current State
+
+As of 2026-07-07, docs define Phase 2 opinion requirements and reference
+promotion criteria. The current uncommitted backend attempt adds an
+`opinion_artifact` and `review_checks`, but it is only a partial scaffold.
+
+Known incomplete behavior that must be fixed before this goal can be complete:
+
+- adding `review_checks` names and statuses alone is not enough
+- `review_checks.result` is not yet a contract field in the current code
+- current repo state has required new files outside the tracked diff:
+  `GOAL.md` and `backend/research/domain/opinion.py` are untracked and must
+  not be omitted from review or completion evidence
+- latest signal selection must be by each symbol's latest persisted `date`;
+  list order or last-write-wins replacement is not acceptable
+- `parameter_sensitivity` always returning `not_evaluated` is not enough when
+  persisted signals and effective strategy inputs exist
+- `robustness` passing only because a `validation` object exists is not enough
+- `source_artifact_audit` must not imply raw/provider/parser audit coverage
+  when only config or fallback metadata exists
+- `source_artifact_audit` must name missing `config_sources` and
+  `fallback_audit` inputs when neither is present
+- row evidence, risk, and invalidation must be row-specific for viable rows;
+  shared generic payload references and static boilerplate are not enough
+- UZI self-review gates must evaluate the actual row fields and references;
+  a check must not pass merely because at least one row exists
+- `manual_adoption_boundary` must inspect review-check copy as well as
+  `state_reason` and row text, and must catch execution/advice wording variants
+- list/read-summary paths must not expose action rows or prose derived from
+  hidden heavy artifacts when those artifacts are omitted from the response
+- tests that only check field presence, check names, or status values are not
+  sufficient
+
+Normative acceptance comes from:
+
+- `docs/research-spec.md`
+- `docs/validation-gates.md`
+- `docs/decision-register.md`
+- `docs/deferred-feature-plan.md`
+
+`docs/implementation-status.md` is descriptive context only.
+
+### Claim Boundary
+
+Accepted Scope:
+
+- preserve the existing backend `opinion_artifact` action-list slice
+- extend `opinion_artifact.review_checks` with concrete local method results
+- implement response/reload-time derived opinion checks from existing persisted
+  research-run artifacts
+- add focused backend tests that would fail against the current shallow
+  implementation
+- keep the work backend-first and research-only
+
+Non-Claims:
+
+- no frontend workflow
+- no broker routing or live orders
+- no personalized investment advice
+- no automatic rebalancing or account-level portfolio control
+- no US daily provider implementation
+- no market-agnostic provider abstraction
+- no TW/US comparison semantics
+- no adaptive/RL control workflow
+- no crypto trading behavior
+- no Jesse, UZI-Skill, a-stock-data, OpenBB, FinGPT, FinRL, Hummingbot, or
+  Freqtrade runtime dependency
+- no DB migration unless deterministic reconstruction from existing persisted
+  artifacts is proven impossible and the tradeoff is explicitly reported
+
+Rejected Evidence:
+
+- latest in-session response only
+- metadata-only or partial records as proof of a valid opinion
+- generic LLM confidence
+- untraceable report prose
+- imported external project behavior
+- broad manual judgment without named evidence
+- tests that only verify action-list shape, `review_checks` names, or statuses
+- a `pass` status with an empty or unstable `result`
+- config/fallback metadata treated as raw/provider/parser audit coverage
+- list/summary action rows derived from hidden full `signals`
+
+### Validation Lineage
+
+- Current stage: Phase 2 backend opinion expansion, starting from the current
+  uncommitted `opinion_artifact` scaffold.
+- Direct dependency predecessor: persisted successful V1 research-run artifacts
+  and the existing research-run create/reload/list API paths.
+- Relevant prior final labels: V1 usable loop is described as verified in
+  `docs/implementation-status.md`; Phase 2 opinion expansion is not complete.
+- Required input artifacts: request payload, effective strategy,
+  config/fallback metadata, version/policy metadata, metrics, model
+  diagnostics, signals, validation, baselines, warnings, artifact completeness,
+  missing artifacts, and comparison caveats already persisted or present on
+  research-run responses.
+- Regeneration/reproduction path: use focused backend tests under
+  `tests/research/`; no external provider, broker, frontend, or runtime setup is
+  required.
+- Retry/turn ceiling: continue narrow fixes until acceptance evidence passes;
+  report blocked only when the same blocker repeats for three consecutive
+  attempts, focused tests cannot run after one environment/tooling retry, or
+  completion requires forbidden scope.
+- Runtime gate evidence: exact test commands, exit codes, reached/skipped
+  attempt ledger, and focused output excerpts must be surfaced in the
+  conversation.
+- Result evidence sources: code diff, focused test output, `git diff --check`,
+  and manual source review against the normative docs.
+
+### Relevant Sources
+
+- `docs/project-goals.md`
+- `docs/plan.md`
+- `docs/research-spec.md`
+- `docs/validation-gates.md`
+- `docs/decision-register.md`
+- `docs/deferred-feature-plan.md`
+- `docs/implementation-status.md`
+- `backend/research/contracts/runs.py`
+- `backend/research/domain/opinion.py`
+- `backend/research/services/runs.py`
+- `backend/research/repositories/runs.py`
+- `tests/research/test_runs.py`
+- `tests/research/test_research_api.py`
+- `tests/research/test_run_repository.py`
+
+### Constraints
+
+- Repository artifacts stay in English.
+- Keep edits minimal and backend-scoped.
+- Prefer extending existing `opinion_artifact` over adding new top-level API
+  fields.
+- Prefer deterministic reconstruction from persisted run artifacts over adding
+  persistence.
+- Do not add new dependencies.
+- Do not add a DB migration unless deterministic reconstruction is impossible
+  and the reason is reported.
+- Do not weaken existing research-run reload, comparison caveat, or hidden
+  advanced-module boundaries.
+- Do not infer unavailable data, provider metadata, source text, holdings, or
+  live execution state.
+
+### Non-Goals
+
+- Frontend UI for opinions.
+- Broker integration or live-order execution.
+- Paper/live execution loop.
+- Portfolio auto-control or automatic rebalancing.
+- Manual adoption ledger or holdings-aware portfolio feedback loop.
+- US daily provider implementation.
+- Market provider abstraction or TW/US comparison policy.
+- RL/adaptive control workflow.
+- Personalized investment advice.
+- Importing or wrapping Jesse, UZI-Skill, a-stock-data, OpenBB, FinGPT, FinRL,
+  Hummingbot, or Freqtrade runtimes.
+
+### Open Questions
+
+- None block this goal. If a reference concept cannot be computed from existing
+  persisted artifacts, expose the limitation in the artifact and completion
+  evidence instead of widening scope.
+
+## Goal
+
+### Objective
+
+Complete the Phase 2 backend opinion expansion so a persisted research run can
+return a reloadable `opinion_artifact` that preserves action lists and adds
+decision-useful local method results, self-review gates, source/provider audit
+summaries, and traceable evidence summaries derived from existing artifacts.
+
+The goal is not complete if the implementation merely labels reference concepts
+as represented. Computable reference concepts must produce concrete results
+that affect the opinion state, limitations, row evidence, or review-check
+output.
+
+### Deliverables
+
+- Updated backend opinion contract where `OpinionReviewCheck` includes a
+  stable `result` object.
+- Deterministic opinion artifact builder that derives full detail/reload
+  opinions from persisted research-run artifacts.
+- Safe list/summary behavior that does not expose action rows or prose derived
+  from omitted heavy artifacts.
+- Focused tests covering contract, domain/service, repository reload/list, and
+  API response paths.
+- Completion report with test evidence, diff evidence, manual source audit, and
+  no-scope-creep statement.
+
+### Metric Type
+
+`evidence_review`.
+
+Completion requires named artifacts and checks: focused backend tests,
+`git diff --check`, and manual review against `SPEC-OPINION-*`,
+`GATE-P2-*`, accepted/deferred decisions, and this Goal Brief. Generic model
+confidence, broad manual judgment, conversation memory, and field-presence-only
+tests are insufficient.
+
+### Evaluator Contract
+
+Completion can be claimed only when the final response surfaces all of this
+evidence:
+
+- files changed
+- selected schema and reload path
+- exact focused test commands and exit codes
+- the new or revised test that would fail against the current shallow
+  implementation, with the behavior it protects
+- `git diff --check` result
+- acceptance status for every AC below
+- manual audit against `docs/research-spec.md`, `docs/validation-gates.md`,
+  `docs/decision-register.md`, and `docs/deferred-feature-plan.md`
+- explicit statement that no frontend, broker/live execution, portfolio
+  auto-control, US provider implementation, provider abstraction, adaptive/RL
+  workflow, crypto trading behavior, or external runtime dependency was added
+
+The evaluator must not assume hidden tool output, provider memory, unsurfaced
+local state, or latest in-session response content.
+
+### Contract Shape
+
+Preserve the existing top-level `opinion_artifact` fields:
+
+- `artifact_version`
+- `state`
+- `state_reason`
+- `manual_adoption_only`
+- `evidence_limitations`
+- `buy_candidates`
+- `sell_or_avoid`
+- `watch`
+- `review_checks`
+
+Preserve populated action-list row fields:
+
+- `symbol`
+- `model_score`
+- `position_signal`
+- `evidence_reason`
+- `risk_or_warning`
+- `invalidation_note`
+- `source_artifact_references`
+
+Extend each `review_checks` item with one API contract field:
+
+- `result`: an object containing the concrete local result for that check
+
+Keep existing `review_checks` fields:
+
+- `check`
+- `category`
+- `status`
+- `evidence_reason`
+- `risk_or_warning`
+- `source_artifact_references`
+
+Allowed `status` values:
+
+- `pass`
+- `warning`
+- `fail`
+- `not_evaluated`
+
+`review_checks.result` rules:
+
+- `result` is a response/reload-time derived API field.
+- Do not add a DB column for `result` unless deterministic reconstruction is
+  proven impossible.
+- If `status != "not_evaluated"`, `result` must be non-empty and use stable
+  keys for that check.
+- If `status == "not_evaluated"`, `result` may be empty only when
+  `evidence_reason` names the unavailable input.
+- Tests must assert stable result keys and at least one non-trivial value for
+  every evaluated check.
+
+### Response Surface Rules
+
+Detail/reload responses:
+
+- may reconstruct full action rows from persisted artifacts
+- may reconstruct full `review_checks.result`
+- may include traceable text summaries derived from persisted warnings,
+  caveats, or explicitly persisted run text fields already serialized on that
+  same response surface
+
+List/summary responses:
+
+- must be summary-only when heavy artifacts are omitted
+- must not expose `buy_candidates`, `sell_or_avoid`, or `watch` rows derived
+  from omitted full `signals`
+- must not expose derived text prose from omitted warnings, caveats, diagnostic
+  samples, or source text
+- must not expose any value derived from omitted signals, warnings, comparison
+  caveats, diagnostic samples, or source text
+- evaluated check results and hidden-derived counts must be omitted or replaced
+  with omission-only placeholders
+- default safe behavior for `include_artifacts=False`: action lists are empty,
+  `state` is `no-opinion`, and `state_reason` or `evidence_limitations`
+  explains that detail artifacts are omitted and detail reload is required for
+  row-level opinion review
+
+### Required Local Methods
+
+Implement these checks locally. Do not import external runtimes.
+
+#### Jesse-style checks
+
+Latest signal definition for all Jesse-style checks and viable action rows:
+
+- The latest persisted signal row is selected per symbol by the maximum
+  parseable `date` value in persisted `signals`.
+- Persisted list order must not decide which signal row is latest when dates
+  differ.
+- A row without a parseable `date` must not satisfy row-specific
+  latest-date traceability for a viable populated opinion row.
+- Focused tests must include unsorted multi-date signal rows for the same
+  symbol and prove older rows do not drive action rows, bucket counts, or
+  `parameter_sensitivity`.
+
+- `strategy_lifecycle`
+  - Must verify request/effective strategy, diagnostics, signals, metrics, and
+    opinion generation are present or explicitly limited.
+  - `result` must include these fixed boolean keys:
+    `request_present`, `effective_strategy_present`, `diagnostics_present`,
+    `signals_present`, `metrics_present`,
+    `opinion_rows_emitted_or_limited`.
+  - `pass` requires all result booleans to be `true`.
+
+- `signal_to_position`
+  - Must inspect latest persisted signal rows.
+  - Must classify latest symbol rows by positive, negative, or flat position.
+  - Must verify rows used for action lists have numeric `score` and `position`.
+  - `result` must include:
+    `checked_symbol_count`, `positive_count`, `negative_count`, `flat_count`,
+    `invalid_row_count`.
+
+- `backtest_report_discipline`
+  - Missing `metrics` must `fail`.
+  - Preserve means the check result reports comparison caveat count, references
+    the comparison caveat artifact family when caveats exist, reports
+    `threshold_policy_version_present` and `price_basis_version_present`, and
+    reports whether the research-only boundary is present.
+  - Research-only boundary means the artifact remains `manual_adoption_only`
+    and does not contain execution or personalized-advice language.
+  - If `threshold_policy_version_present`, `price_basis_version_present`, or
+    `research_only_boundary_present` is false, status must not be `pass`.
+  - `result` must include:
+    `metric_keys`, `caveat_count`,
+    `threshold_policy_version_present`, `price_basis_version_present`,
+    `research_only_boundary_present`.
+
+- `robustness`
+  - Must inspect validation metrics, baselines, warnings, and comparison
+    caveats.
+  - Validation object presence alone must not `pass`.
+  - Validation present with empty metrics must not `pass`.
+  - Any blocker comparison caveat must not `pass`.
+  - For this check, blocker caveat means any persisted caveat tied to
+    non-success status, `artifact_completeness != "complete"`, or an explicit
+    blocking/non-comparable marker.
+  - Missing baselines must be visible as `warning` or `not_evaluated`; it must
+    not be hidden under `pass`.
+  - `result` must include:
+    `validation_metric_keys`, `baseline_keys`, `warning_count`,
+    `blocker_caveat_count`.
+
+- `parameter_sensitivity`
+  - Must compute provisional local sensitivity scenarios when persisted signals
+    include at least one latest symbol row with numeric `score` and `position`,
+    and either persisted `threshold > 0` or persisted `top_n >= 1` exists.
+  - If persisted signals exist but no latest symbol row has numeric `score` and
+    numeric `position`, status must be `not_evaluated` and `evidence_reason`
+    must name the invalid signal rows.
+  - Base candidate symbols are the latest persisted signal rows whose
+    `position > 0`.
+  - Scenario outputs are observational only. They must not change `state`,
+    `buy_candidates`, `sell_or_avoid`, or `watch`; they may appear only in
+    `review_checks.result` unless another independent gate downgrades the
+    opinion.
+  - Threshold scenarios:
+    - strict threshold = persisted `threshold * 1.25`
+    - loose threshold = persisted `threshold * 0.75`
+    - skip threshold scenarios with reason when `threshold` is missing or
+      `threshold <= 0`
+  - Top-n scenarios:
+    - `top_n - 1` only when `top_n > 1`
+    - `top_n + 1` capped by available latest-symbol count
+    - top-n scenarios select symbols by descending latest numeric `score`
+    - skip top-n scenarios with reason when `top_n` is missing
+  - If only threshold or only `top_n` exists, compute the available scenario
+    family and list skipped scenarios.
+  - It may be `not_evaluated` only in these cases:
+    - signal artifact is missing or the persisted signal list is empty
+    - persisted signals exist, but no latest row has numeric `score` and
+      numeric `position`
+    - at least one latest numeric signal row exists, but (`threshold` is
+      missing or `threshold <= 0`) and (`top_n` is missing or `top_n < 1`)
+  - Any other partial input state must compute the available scenario family
+    and list the unavailable scenario family under `skipped_scenarios`.
+  - `result` must include:
+    `base_candidate_symbols`, `scenario_candidate_counts`,
+    `stable_symbols`, `changed_symbols`, `provisional_policy`,
+    `skipped_scenarios`.
+
+#### UZI-style self-review gates
+
+- `evidence_traceability`
+  - A viable populated row must include row-specific `evidence_reason` plus at
+    least one row-driving signal reference for that row's symbol and selected
+    latest date.
+  - If `source_artifact_references` remain artifact/field only, shared
+    family-level references may support traceability but do not alone satisfy
+    traceability for viable rows.
+  - Status must be computed from the actual row references. It must not be
+    `pass` only because `rows` is non-empty.
+
+- `risk_present`
+  - A generic research-only disclaimer is insufficient for viable rows.
+  - Each viable row's `risk_or_warning` must be one of these exact evidence
+    categories:
+    - persisted warning/caveat, naming the warning text or caveat code/severity
+      and referencing `warnings` or `comparison_caveats`
+    - persisted artifact risk, naming the artifact family and observed risk
+      value, such as stale freshness risk, blocker caveat, unavailable source
+      audit, or missing validation/baseline evidence
+    - checked no-warning result, stating that persisted `warnings` and
+      `comparison_caveats` were checked and both counts are zero, while still
+      preserving the manual-adoption boundary
+  - Status must be computed from each viable row's `risk_or_warning` and
+    supporting references. It must not be `pass` only because `rows` is
+    non-empty.
+
+- `invalidation_present`
+  - A static invalidation template reused for every row is insufficient for
+    viable rows.
+  - Each viable row must name at least one concrete invalidation family visible
+    in persisted artifacts, such as newer data/run availability, warnings,
+    caveats, staleness, or missing supporting artifacts.
+  - Status must be computed from each viable row's `invalidation_note` and
+    supporting references. It must not be `pass` only because `rows` is
+    non-empty.
+
+- `manual_adoption_boundary`
+  - Must pass only when `manual_adoption_only` is true and opinion-facing text
+    does not imply execution, order routing, automatic rebalancing, account
+    control, or personalized advice.
+  - Must inspect `state_reason`, row `evidence_reason`, row
+    `risk_or_warning`, row `invalidation_note`, and review-check copy.
+  - Negative tests must cover wording variants in opinion-facing text,
+    including `execution-ready`, `order routing`, `automatic rebalance` or
+    `automatic rebalancing`, `broker`, `account control`, and
+    `personalized investment advice`.
+
+- `insufficient_evidence_gate`
+  - Stale means persisted freshness-risk fields or explicit freshness caveats
+    are present.
+  - Required row-driving artifacts for a viable row are:
+    - latest persisted signal row for that row's symbol and selected latest
+      date
+    - numeric signal `score`
+    - numeric signal `position`
+    - present metrics artifact
+    - present model diagnostics artifact
+    - `artifact_completeness == "complete"`
+    - every artifact family named by that row's `evidence_reason`,
+      `risk_or_warning`, `invalidation_note`, or `source_artifact_references`
+  - Downgrade matrix:
+    - non-successful run -> `do-not-adopt`
+    - successful run with `artifact_completeness != "complete"` ->
+      `no-opinion`
+    - successful run with stale evidence as defined above -> `no-opinion`
+    - successful run missing required row-driving artifacts as defined above ->
+      `no-opinion`
+    - any row that depends on an unavailable or `not_evaluated` required
+      artifact must not be emitted as viable
+
+Self-review failures must affect `state`, `state_reason`, or
+`evidence_limitations`; they must not be informational labels only.
+
+#### a-stock/OpenBB-style source audit
+
+- `source_artifact_audit`
+  - Must distinguish these evidence families:
+    - config/fallback metadata present
+    - raw-source/provider/parser audit metadata unavailable
+  - This goal must not add new raw-source/provider/parser persistence fields.
+  - For this goal, raw-source/provider/parser audit metadata is always
+    unavailable because current persisted research-run fields do not expose
+    provider/source name, parser version, fetch status, fetch timestamp, or a
+    stable persisted raw-ingest audit reference.
+  - `config_sources` and `fallback_audit` count only as config/fallback
+    metadata. They must not be treated as raw/provider/parser audit coverage.
+  - `source_artifact_audit` must not `pass` in this goal.
+  - If config/fallback metadata exists, status must be `warning` and `result`
+    must mark config/fallback present and raw/provider/parser unavailable.
+  - If neither `config_sources` nor `fallback_audit` is present, status must be
+    `not_evaluated` and `result` must name `config_sources` and
+    `fallback_audit` as missing inputs.
+  - Do not add provider abstraction, US daily provider selection, or TW/US
+    comparison semantics. Future US daily boundaries may appear only as
+    limitation/audit wording until `TBD-PHASE-005` is accepted.
+
+#### FinGPT-style evidence summary
+
+- `text_evidence_summary`
+  - May summarize only persisted warnings, comparison caveats, or explicitly
+    persisted run text fields already serialized on that same response surface.
+  - Must be `not_evaluated` when no traceable source text exists.
+  - Must not generate trade decisions, advice, or unsupported prose.
+  - `result` must include:
+    `warning_count`, `caveat_count`, `source_text_count`, `summary_text`,
+    `source_artifact_references`.
+  - `summary_text` is allowed only on detail/reload responses.
+  - Every sentence in `summary_text` must be attributable to persisted warning,
+    caveat, or source text that is already present on that response surface.
+  - List/summary responses must not emit derived text evidence prose.
+
+### Acceptance Criteria
+
+- [ ] AC-1: Existing opinion action-list contract is preserved
+  Given a complete successful persisted research run
+  When detail/reload returns `opinion_artifact`
+  Then it includes `state`, `state_reason`, `manual_adoption_only`,
+  `evidence_limitations`, `buy_candidates`, `sell_or_avoid`, `watch`, and
+  `review_checks`
+  Evidence: contract/service/API test plus manual check against
+  `SPEC-OPINION-001`
+
+- [ ] AC-2: Populated action rows remain traceable
+  Given a detail/reload opinion artifact with populated action rows
+  When each row is inspected
+  Then each row includes `symbol`, `model_score`, `position_signal`,
+  `evidence_reason`, `risk_or_warning`, `invalidation_note`, and non-empty
+  row-specific `source_artifact_references`
+  Evidence: focused domain/API test plus manual check against
+  `SPEC-OPINION-002`
+
+- [ ] AC-3: `review_checks.result` is a stable API contract field
+  Given any produced `review_checks` item
+  When `status != "not_evaluated"`
+  Then `result` is non-empty, serialized by API responses, and contains stable
+  keys for that check
+  Evidence: contract/API/repository test
+
+- [ ] AC-4: Jesse `strategy_lifecycle` has fixed result semantics
+  Given complete persisted request, strategy, diagnostics, signals, and metrics
+  When `strategy_lifecycle` is evaluated
+  Then its result includes all fixed lifecycle booleans and can `pass` only when
+  they are all true
+  Evidence: focused domain test
+
+- [ ] AC-5: Jesse `signal_to_position` computes bucket counts
+  Given persisted unsorted multi-date signal rows with positive, negative,
+  flat, and invalid latest rows
+  When `signal_to_position` is evaluated
+  Then its result reports checked, positive, negative, flat, and invalid counts
+  from each symbol's latest persisted `date`, without using older rows or
+  emitting invalid rows as viable action rows
+  Evidence: focused domain/repository test
+
+- [ ] AC-6: Jesse `backtest_report_discipline` validates metrics and policy
+  context
+  Given persisted metrics, caveats, and version/policy metadata
+  When `backtest_report_discipline` is evaluated
+  Then its result reports metric keys, caveat count, threshold policy presence,
+  price basis presence, and research-only boundary presence; missing metrics or
+  missing required policy/boundary metadata prevents `pass`
+  Evidence: focused domain test
+
+- [ ] AC-7: Jesse `robustness` does not false-pass
+  Given validation is present but metrics are empty, baselines are missing, or a
+  blocker caveat exists
+  When `robustness` is evaluated
+  Then validation presence alone does not produce `pass`, and the limitation is
+  reflected in status and result
+  Evidence: focused test covering validation-present-but-caveated behavior
+
+- [ ] AC-8: Jesse `parameter_sensitivity` is computed when inputs exist
+  Given persisted unsorted multi-date signals plus effective threshold or
+  `top_n`
+  When `parameter_sensitivity` is evaluated
+  Then available provisional scenarios are computed, skipped scenarios include
+  reasons, latest rows are selected by each symbol's maximum persisted `date`,
+  and `not_evaluated` is used only for the three method-defined no-input cases
+  Evidence: focused domain/repository test
+
+- [ ] AC-9: UZI row evidence, risk, and invalidation gates affect viability
+  Given a viable-looking populated row lacks row-specific evidence, concrete
+  risk, or concrete invalidation family
+  When self-review gates are evaluated
+  Then the relevant check fails or warns from the actual row fields and the
+  artifact does not remain silently `viable`; `state`, `state_reason`, or
+  `evidence_limitations` changes
+  Evidence: negative focused tests for missing row-specific signal reference,
+  generic risk disclaimer, and static invalidation template
+
+- [ ] AC-10: Manual adoption boundary scans opinion-facing text
+  Given opinion-facing text fields are produced
+  When `manual_adoption_boundary` is evaluated
+  Then the check fails if any field implies execution, order routing, automatic
+  rebalancing, broker/account control, or personalized investment advice,
+  including review-check copy and wording variants such as `execution-ready`
+  Evidence: focused negative tests plus manual diff review
+
+- [ ] AC-11: Insufficient evidence uses the downgrade matrix
+  Given a non-successful run, partial/metadata-only/stale artifacts, missing
+  row-driving evidence, or a row depending on unavailable required artifacts
+  When `opinion_artifact` is produced
+  Then the artifact follows the documented downgrade matrix and does not emit a
+  viable row from unavailable evidence
+  Evidence: focused repository/domain tests
+
+- [ ] AC-12: Source/provider audit is honest
+  Given only `config_sources` or `fallback_audit` exists, or neither exists
+  When `source_artifact_audit` is evaluated
+  Then raw-source/provider/parser audit is marked unavailable and the check does
+  not `pass`; when neither exists, `result` names missing `config_sources` and
+  `fallback_audit`; this goal does not add new raw-source/provider/parser
+  persistence fields to make the check pass
+  Evidence: focused test plus manual check against a-stock/OpenBB promotion
+  criteria
+
+- [ ] AC-13: Text evidence summary stays traceable
+  Given persisted warnings or comparison caveats exist on a detail/reload
+  response
+  When `text_evidence_summary` is evaluated
+  Then result counts and any summary text are traceable to those persisted
+  warning, caveat, or explicitly persisted run-text artifacts on that same
+  response surface
+  Evidence: focused test
+
+- [ ] AC-14: No source text means text evidence is not evaluated
+  Given no persisted warnings, caveats, or source text exist on the response
+  surface
+  When `text_evidence_summary` is evaluated
+  Then status is `not_evaluated`, result does not invent prose, and the reason
+  names the missing input; non-detail/non-reload surfaces omit or empty
+  `summary_text`
+  Evidence: focused test
+
+- [ ] AC-15: Detail reload reconstructs full opinion sections
+  Given a research run has already been persisted
+  When the detail/reload path returns the run
+  Then action lists and all evaluated `review_checks.result` values are
+  reconstructed from persisted artifacts without latest-response memory
+  Evidence: repository/API roundtrip test
+
+- [ ] AC-16: List/summary responses do not leak hidden heavy artifacts
+  Given `include_artifacts=False` omits full signals, diagnostic samples, or
+  source text
+  When the list/summary path returns `opinion_artifact`
+  Then action lists are empty, hidden-derived prose is absent, hidden-derived
+  counts and evaluated check results are omitted or omission-only, and the state
+  or limitations explain that detail reload is required for row-level opinion
+  review
+  Evidence: repository/API list test replacing the current shallow expectation
+
+- [ ] AC-17: Current shallow implementation would fail new or revised tests
+  Given the current shallow implementation that only emits names/statuses
+  When the new or revised focused tests are considered
+  Then at least one test would fail before the fix, and the completion report
+  names that test and protected behavior
+  Evidence: test name and assertion summary in final report
+
+- [ ] AC-18: No execution or dependency creep
+  Given backend opinion expansion is implemented
+  When API contracts, code paths, dependencies, and touched docs are inspected
+  Then they do not add or imply frontend workflow expansion, broker routing,
+  live orders, automatic rebalancing, account control, personalized investment
+  advice, US provider implementation, provider abstraction, adaptive/RL control,
+  crypto trading behavior, or external runtime adoption
+  Evidence: manual diff/dependency review against `GATE-P2-004`,
+  `GATE-P2-005`, and `docs/deferred-feature-plan.md`
+
+- [ ] AC-19: Required new files are visible in completion evidence
+  Given the implementation adds or depends on a new source or goal file
+  When completion evidence is reported
+  Then `git status --short` is reviewed and every required new file, including
+  `backend/research/domain/opinion.py` and `GOAL.md` if still present, is either
+  tracked by git or explicitly listed as an untracked required file in the
+  final files-touched report
+  Evidence: `git status --short`, `git ls-files` or equivalent file-status
+  inspection, and final files-touched summary
+
+### Verification Plan
+
+Run the narrowest focused backend checks that cover the changed contract,
+domain/service, repository, and API paths:
+
+```bash
+.venv/bin/python -m pytest \
+  tests/research/test_runs.py \
+  tests/research/test_run_repository.py \
+  tests/research/test_research_api.py
+```
+
+Also run:
+
+```bash
+git diff --check
+```
+
+Runtime completion check:
+
+- the focused pytest command exits `0`
+- `git diff --check` exits `0`
+- file-status audit confirms no required new file is omitted from completion
+  evidence
+- manual audit confirms AC-1 through AC-19 and scope boundaries
+
+Durable runtime evidence required:
+
+- exact commands
+- exit codes
+- reached/skipped attempt ledger
+- focused output excerpts sufficient to prove the decisive result
+- file-status output or equivalent statement covering required new files
+
+Completion audit source:
+
+- current repo diff
+- focused test output
+- `docs/research-spec.md`
+- `docs/validation-gates.md`
+- `docs/decision-register.md`
+- `docs/deferred-feature-plan.md`
+- this `GOAL.md`
+
+### Stop Or Report Blocked
+
+Stop and report blocked if:
+
+- the implementation cannot preserve the existing `opinion_artifact`
+  action-list contract
+- computed method results require artifacts that are not currently persisted
+  and cannot be reconstructed safely
+- deterministic reload requires a DB migration whose tradeoff is not justified
+  by the docs
+- focused tests cannot run after one environment/tooling retry
+- the same blocker repeats for three consecutive attempts
+- completion would require frontend, broker/live execution, portfolio control,
+  US provider work, provider abstraction, adaptive/RL control, crypto runtime
+  behavior, or an external dependency
+- checked docs conflict about acceptance or scope
+
+If a method cannot be evaluated from current artifacts, do not invent data.
+Return `not_evaluated` with a specific reason and ensure the acceptance
+criteria state whether that blocks completion.
+
+### Done Condition
+
+The goal is complete only when backend code and tests satisfy AC-1 through
+AC-19, the implementation preserves existing action-list behavior,
+`review_checks.result` is a stable response/reload contract, method checks
+produce concrete results where inputs exist, self-review gates affect
+viability, source/provider audit is honest, text evidence stays traceable,
+list/detail artifact boundaries are safe, focused verification evidence is
+surfaced, required new files are visible in completion evidence,
+`git diff --check` passes, and the final manual audit confirms the change stays
+within backend-only Phase 2 opinion expansion.

--- a/backend/research/contracts/runs.py
+++ b/backend/research/contracts/runs.py
@@ -35,6 +35,10 @@ from backend.research.domain.artifact_summary import (
     ArtifactCompleteness,
     ReviewArtifactName,
 )
+from backend.research.domain.opinion import (
+    OpinionReviewCheckCategory,
+    OpinionReviewCheckName,
+)
 
 from .runtime_metadata import (
     ConfigSources,
@@ -320,8 +324,8 @@ class OpinionRow(BaseModel):
 
 
 class OpinionReviewCheck(BaseModel):
-    check: str
-    category: str
+    check: OpinionReviewCheckName
+    category: OpinionReviewCheckCategory
     status: OpinionReviewCheckStatus
     evidence_reason: str
     risk_or_warning: str

--- a/backend/research/contracts/runs.py
+++ b/backend/research/contracts/runs.py
@@ -272,6 +272,79 @@ class ComparisonCaveat(BaseModel):
     severity: Literal["blocker", "note"] = "blocker"
 
 
+OpinionArtifactState = Literal["viable", "no-opinion", "do-not-adopt"]
+OpinionSourceArtifactName = Literal[
+    "request_payload",
+    "config_sources",
+    "fallback_audit",
+    "version_pack",
+    "model_diagnostics",
+    "signals",
+    "metrics",
+    "baselines",
+    "validation",
+    "warnings",
+    "artifact_completeness",
+    "comparison_caveats",
+]
+OpinionReviewCheckStatus = Literal["pass", "warning", "fail", "not_evaluated"]
+
+
+def _default_opinion_artifact() -> "OpinionArtifact":
+    return OpinionArtifact(
+        state="no-opinion",
+        state_reason="Opinion artifact has not been built from persisted research artifacts.",
+        buy_candidates=[],
+        sell_or_avoid=[],
+        watch=[],
+    )
+
+
+class OpinionSourceArtifactReference(BaseModel):
+    artifact: OpinionSourceArtifactName
+    field: str
+    symbol: Optional[str] = None
+    date: Optional[str] = None
+
+
+class OpinionRow(BaseModel):
+    symbol: str
+    model_score: float
+    position_signal: float
+    evidence_reason: str
+    risk_or_warning: str
+    invalidation_note: str
+    source_artifact_references: List[OpinionSourceArtifactReference] = Field(
+        default_factory=list,
+        min_length=1,
+    )
+
+
+class OpinionReviewCheck(BaseModel):
+    check: str
+    category: str
+    status: OpinionReviewCheckStatus
+    evidence_reason: str
+    risk_or_warning: str
+    source_artifact_references: List[OpinionSourceArtifactReference] = Field(
+        default_factory=list,
+        min_length=1,
+    )
+    result: Dict[str, object] = Field(default_factory=dict)
+
+
+class OpinionArtifact(BaseModel):
+    artifact_version: str = "phase2_opinion_artifact_v1"
+    state: OpinionArtifactState
+    state_reason: str
+    manual_adoption_only: Literal[True] = True
+    evidence_limitations: List[str] = Field(default_factory=list)
+    buy_candidates: List[OpinionRow] = Field(default_factory=list)
+    sell_or_avoid: List[OpinionRow] = Field(default_factory=list)
+    watch: List[OpinionRow] = Field(default_factory=list)
+    review_checks: List[OpinionReviewCheck] = Field(default_factory=list)
+
+
 class ReviewArtifactSummaryMixin(BaseModel):
     artifact_completeness: ArtifactCompleteness = "metadata_only"
     present_artifacts: List[ReviewArtifactName] = Field(default_factory=list)
@@ -295,6 +368,9 @@ class ResearchRunResponse(
     model_diagnostics: Optional[RegressionDiagnostics] = None
     baselines: Dict[str, Dict[str, float]] = Field(default_factory=dict)
     warnings: List[str] = Field(default_factory=list)
+    opinion_artifact: OpinionArtifact = Field(
+        default_factory=_default_opinion_artifact
+    )
     runtime_mode: RuntimeMode
     default_bundle_version: Optional[DefaultBundleVersion] = None
     effective_strategy: EffectiveStrategyConfig
@@ -331,4 +407,7 @@ class ResearchRunRecordResponse(
     model_diagnostics: Optional[RegressionDiagnostics] = None
     baselines: Dict[str, Dict[str, float]] = Field(default_factory=dict)
     warnings: List[str] = Field(default_factory=list)
+    opinion_artifact: OpinionArtifact = Field(
+        default_factory=_default_opinion_artifact
+    )
     created_at: datetime

--- a/backend/research/contracts/runs.py
+++ b/backend/research/contracts/runs.py
@@ -315,7 +315,6 @@ class OpinionRow(BaseModel):
     risk_or_warning: str
     invalidation_note: str
     source_artifact_references: List[OpinionSourceArtifactReference] = Field(
-        default_factory=list,
         min_length=1,
     )
 
@@ -327,7 +326,6 @@ class OpinionReviewCheck(BaseModel):
     evidence_reason: str
     risk_or_warning: str
     source_artifact_references: List[OpinionSourceArtifactReference] = Field(
-        default_factory=list,
         min_length=1,
     )
     result: Dict[str, object] = Field(default_factory=dict)

--- a/backend/research/contracts/runs.py
+++ b/backend/research/contracts/runs.py
@@ -349,6 +349,12 @@ class OpinionReviewCheck(BaseModel):
     )
     result: Dict[str, object] = Field(default_factory=dict)
 
+    @model_validator(mode="after")
+    def require_result_for_evaluated_check(self) -> "OpinionReviewCheck":
+        if self.status != "not_evaluated" and not self.result:
+            raise ValueError("evaluated review checks require a non-empty result")
+        return self
+
 
 class OpinionArtifact(BaseModel):
     artifact_version: str = "phase2_opinion_artifact_v1"

--- a/backend/research/contracts/runs.py
+++ b/backend/research/contracts/runs.py
@@ -35,11 +35,6 @@ from backend.research.domain.artifact_summary import (
     ArtifactCompleteness,
     ReviewArtifactName,
 )
-from backend.research.domain.opinion import (
-    OpinionReviewCheckCategory,
-    OpinionReviewCheckName,
-)
-
 from .runtime_metadata import (
     ConfigSources,
     EffectiveStrategyConfig,
@@ -277,6 +272,26 @@ class ComparisonCaveat(BaseModel):
 
 
 OpinionArtifactState = Literal["viable", "no-opinion", "do-not-adopt"]
+OpinionReviewCheckName = Literal[
+    "strategy_lifecycle",
+    "signal_to_position",
+    "backtest_report_discipline",
+    "robustness",
+    "parameter_sensitivity",
+    "evidence_traceability",
+    "risk_present",
+    "invalidation_present",
+    "manual_adoption_boundary",
+    "insufficient_evidence_gate",
+    "source_artifact_audit",
+    "text_evidence_summary",
+]
+OpinionReviewCheckCategory = Literal[
+    "method",
+    "self_review",
+    "source_provider_audit",
+    "evidence_summary",
+]
 OpinionSourceArtifactName = Literal[
     "request_payload",
     "config_sources",

--- a/backend/research/domain/opinion.py
+++ b/backend/research/domain/opinion.py
@@ -63,12 +63,13 @@ def _signal_ref(field: str, signal: Mapping[str, Any]) -> dict[str, str]:
     return ref
 
 
-def _risk_context(payload: Mapping[str, Any]) -> tuple[str, list[dict[str, str]]]:
+def _risk_context(payload: Mapping[str, Any]) -> tuple[str, list[dict[str, str]], str]:
     warnings = [str(item) for item in _as_list(payload.get("warnings"))]
     if warnings:
         return (
             f"Persisted warning: {warnings[0]}",
             _refs(("warnings", "warnings")),
+            "warning",
         )
 
     caveats = [_as_mapping(item) for item in _as_list(payload.get("comparison_caveats"))]
@@ -79,15 +80,17 @@ def _risk_context(payload: Mapping[str, Any]) -> tuple[str, list[dict[str, str]]
         return (
             f"Persisted caveat {code} with severity {severity}.",
             _refs(("comparison_caveats", "comparison_caveats")),
+            "caveat",
         )
 
     return (
         BOUNDARY_RISK,
         _refs(("warnings", "warnings"), ("comparison_caveats", "comparison_caveats")),
+        "checked_no_warning",
     )
 
 
-def _invalidation_context(payload: Mapping[str, Any]) -> tuple[str, list[dict[str, str]]]:
+def _invalidation_context(payload: Mapping[str, Any]) -> tuple[str, list[dict[str, str]], str]:
     if payload.get("stale_mark_days_with_open_positions") or payload.get(
         "stale_risk_share"
     ):
@@ -97,15 +100,18 @@ def _invalidation_context(payload: Mapping[str, Any]) -> tuple[str, list[dict[st
                 ("artifact_completeness", "stale_mark_days_with_open_positions"),
                 ("artifact_completeness", "stale_risk_share"),
             ),
+            "stale_freshness",
         )
     if _as_list(payload.get("comparison_caveats")):
         return (
             "Do not adopt if persisted comparison caveats still apply.",
             _refs(("comparison_caveats", "comparison_caveats")),
+            "comparison_caveats",
         )
     return (
         "Do not adopt if a newer persisted run or newer market data supersedes this signal.",
         _refs(("request_payload", "date_range"), ("signals", "date")),
+        "newer_run_or_market_data",
     )
 
 
@@ -154,8 +160,8 @@ def _valid_latest_signals(payload: Mapping[str, Any]) -> list[Mapping[str, Any]]
 
 
 def _action_rows(payload: Mapping[str, Any]) -> list[dict[str, Any]]:
-    risk, risk_refs = _risk_context(payload)
-    invalidation, invalidation_refs = _invalidation_context(payload)
+    risk, risk_refs, _risk_family = _risk_context(payload)
+    invalidation, invalidation_refs, _invalidation_family = _invalidation_context(payload)
     rows: list[dict[str, Any]] = []
     for signal in _valid_latest_signals(payload):
         symbol = str(signal["symbol"])
@@ -311,41 +317,45 @@ def _row_has_traceable_signal(row: Mapping[str, Any]) -> bool:
     return bool(row.get("evidence_reason")) and _row_signal_reference_count(row) > 0
 
 
-def _row_has_concrete_risk(row: Mapping[str, Any]) -> bool:
+def _row_has_concrete_risk(
+    row: Mapping[str, Any],
+    context: tuple[str, list[dict[str, str]], str],
+) -> bool:
     refs = {
         _as_mapping(ref).get("artifact")
         for ref in _as_list(row.get("source_artifact_references"))
     }
-    text = str(row.get("risk_or_warning", "")).lower()
+    text, _context_refs, family = context
+    if row.get("risk_or_warning") != text:
+        return False
     return (
-        ("persisted warning:" in text and "warnings" in refs)
-        or ("persisted caveat" in text and "comparison_caveats" in refs)
+        (family == "warning" and "warnings" in refs)
+        or (family == "caveat" and "comparison_caveats" in refs)
         or (
-            "checked no-warning result" in text
+            family == "checked_no_warning"
             and {"warnings", "comparison_caveats"} <= refs
         )
-        or (
-            "stale" in text
-            and "artifact_completeness" in refs
-        )
     )
 
 
-def _row_has_concrete_invalidation(row: Mapping[str, Any]) -> bool:
+def _row_has_concrete_invalidation(
+    row: Mapping[str, Any],
+    context: tuple[str, list[dict[str, str]], str],
+) -> bool:
     refs = {
         _as_mapping(ref).get("artifact")
         for ref in _as_list(row.get("source_artifact_references"))
     }
-    text = str(row.get("invalidation_note", "")).lower()
-    families = (
-        "newer persisted run",
-        "newer market data",
-        "persisted comparison caveats",
-        "stale freshness risk",
-        "missing",
-    )
-    return bool(row.get("invalidation_note")) and any(item in text for item in families) and bool(
-        refs & {"signals", "comparison_caveats", "artifact_completeness", "request_payload"}
+    text, _context_refs, family = context
+    if not str(row.get("invalidation_note", "")).startswith(f"{text} Row signal date:"):
+        return False
+    return (
+        (family == "stale_freshness" and "artifact_completeness" in refs)
+        or (family == "comparison_caveats" and "comparison_caveats" in refs)
+        or (
+            family == "newer_run_or_market_data"
+            and {"request_payload", "signals"} <= refs
+        )
     )
 
 
@@ -553,10 +563,16 @@ def _review_checks(
         else [],
     }
     sensitivity = _parameter_sensitivity(payload)
+    risk_context = _risk_context(payload)
+    invalidation_context = _invalidation_context(payload)
     traceable_row_count = sum(1 for row in rows if _row_has_traceable_signal(row))
-    concrete_risk_row_count = sum(1 for row in rows if _row_has_concrete_risk(row))
+    concrete_risk_row_count = sum(
+        1 for row in rows if _row_has_concrete_risk(row, risk_context)
+    )
     concrete_invalidation_row_count = sum(
-        1 for row in rows if _row_has_concrete_invalidation(row)
+        1
+        for row in rows
+        if _row_has_concrete_invalidation(row, invalidation_context)
     )
     checks = [
         _check(
@@ -666,9 +682,9 @@ def _review_checks(
             "pass"
             if (rows and concrete_risk_row_count == len(rows)) or limitations
             else "fail",
-            "Rows were checked for concrete warning, caveat, artifact-risk, or no-warning evidence.",
-            _risk_context(payload)[0],
-            _risk_context(payload)[1],
+            "Rows were checked for concrete warning, caveat, or no-warning evidence.",
+            risk_context[0],
+            risk_context[1],
             {
                 "row_count": len(rows),
                 "concrete_risk_row_count": concrete_risk_row_count,
@@ -683,8 +699,8 @@ def _review_checks(
             if (rows and concrete_invalidation_row_count == len(rows)) or limitations
             else "fail",
             "Rows were checked for concrete invalidation families and supporting references.",
-            _invalidation_context(payload)[0],
-            _invalidation_context(payload)[1],
+            invalidation_context[0],
+            invalidation_context[1],
             {
                 "row_count": len(rows),
                 "concrete_invalidation_row_count": concrete_invalidation_row_count,
@@ -860,13 +876,17 @@ def build_opinion_artifact(payload: Mapping[str, Any]) -> dict[str, Any]:
         "sell_or_avoid": sell_or_avoid,
         "watch": watch,
     }
-    artifact["review_checks"] = _review_checks(
+    initial_checks = _review_checks(
         {**payload, "state_reason": artifact["state_reason"]},
         rows,
         "viable",
         [],
     )
-    if any(item["status"] == "fail" for item in artifact["review_checks"]):
+    artifact["review_checks"] = initial_checks
+    failed_checks = {
+        item["check"]: item for item in initial_checks if item["status"] == "fail"
+    }
+    if failed_checks:
         artifact["state"] = "no-opinion"
         artifact["state_reason"] = "Self-review gates blocked a viable opinion."
         artifact["evidence_limitations"] = [
@@ -875,4 +895,14 @@ def build_opinion_artifact(payload: Mapping[str, Any]) -> dict[str, Any]:
         artifact["buy_candidates"] = []
         artifact["sell_or_avoid"] = []
         artifact["watch"] = []
+        final_checks = _review_checks(
+            {**payload, "state_reason": artifact["state_reason"]},
+            rows,
+            artifact["state"],
+            artifact["evidence_limitations"],
+        )
+        for item in final_checks:
+            if item["check"] in failed_checks:
+                item.update(failed_checks[item["check"]])
+        artifact["review_checks"] = final_checks
     return artifact

--- a/backend/research/domain/opinion.py
+++ b/backend/research/domain/opinion.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import re
 from collections.abc import Mapping
 from datetime import date, datetime
@@ -55,7 +56,11 @@ def _as_list(value: Any) -> list[Any]:
 
 
 def _is_number(value: Any) -> bool:
-    return isinstance(value, int | float) and not isinstance(value, bool)
+    return (
+        isinstance(value, int | float)
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+    )
 
 
 def _has_metrics_evidence(value: Any) -> bool:
@@ -215,8 +220,7 @@ def _latest_signals(payload: Mapping[str, Any]) -> tuple[list[Mapping[str, Any]]
     invalid_count = sum(
         1
         for item in latest
-        if _signal_date_key(item) is None
-        or not _is_number(item.get("score"))
+        if not _is_number(item.get("score"))
         or not _is_number(item.get("position"))
     )
     return latest, invalid_count
@@ -884,14 +888,14 @@ def _review_checks(
                     "Caveats, missing policy metadata, or boundary wording prevent a clean pass."
                 )
             if (
-                item["result"]["metric_keys"]
+                metrics_present
                 and item["result"]["threshold_policy_version_present"]
                 and item["result"]["price_basis_version_present"]
                 and boundary_present
                 and item["result"]["caveat_count"] == 0
             ):
                 item["status"] = "pass"
-            elif item["result"]["metric_keys"]:
+            elif metrics_present:
                 item["status"] = "warning"
             else:
                 item["status"] = "fail"

--- a/backend/research/domain/opinion.py
+++ b/backend/research/domain/opinion.py
@@ -99,7 +99,7 @@ def _signal_date_key(signal: Mapping[str, Any]) -> str | None:
         return value.isoformat()
     if isinstance(value, str):
         try:
-            return date.fromisoformat(value).isoformat()
+            return datetime.fromisoformat(value).date().isoformat()
         except ValueError:
             return None
     return None
@@ -319,13 +319,11 @@ def _string_values(value: Any) -> list[str]:
 def _manual_boundary_present(*texts: str) -> bool:
     forbidden = (
         "broker routing",
-        "broker",
-        "execution-ready",
         "execution ready",
         "live order",
-        "live orders",
         "automatic rebalance",
         "automatic rebalancing",
+        "portfolio control",
         "account control",
         "personalized investment advice",
         "personalized advice",
@@ -333,7 +331,8 @@ def _manual_boundary_present(*texts: str) -> bool:
         "order routing",
         "execution route",
     )
-    haystack = " ".join(texts).lower()
+    haystack = re.sub(r"[-_/]+", " ", " ".join(texts).lower())
+    haystack = " ".join(haystack.split())
     return not any(term in haystack for term in forbidden)
 
 
@@ -938,8 +937,11 @@ def build_opinion_artifact(payload: Mapping[str, Any]) -> dict[str, Any]:
     limitations: list[str] = []
     status = payload.get("status")
     completeness = payload.get("artifact_completeness")
-    if status is not None and status != "succeeded":
-        limitations.append(f"Run status is {status}; artifacts are not adoptable.")
+    if status != "succeeded":
+        status_label = status if status is not None else "unavailable"
+        limitations.append(
+            f"Run status is {status_label}; artifacts are not adoptable."
+        )
     if completeness != "complete":
         missing = [str(item) for item in _as_list(payload.get("missing_artifacts"))]
         detail = f" Missing artifacts: {', '.join(missing)}." if missing else ""
@@ -953,7 +955,7 @@ def build_opinion_artifact(payload: Mapping[str, Any]) -> dict[str, Any]:
     if payload.get("stale_mark_days_with_open_positions") or payload.get("stale_risk_share"):
         limitations.append("Stale mark risk is present in persisted artifacts.")
 
-    if status is not None and status != "succeeded":
+    if status != "succeeded":
         return _empty_artifact(
             "do-not-adopt",
             "Research run did not complete successfully.",

--- a/backend/research/domain/opinion.py
+++ b/backend/research/domain/opinion.py
@@ -195,10 +195,12 @@ def _latest_signals(
     latest_dates: dict[str, str] = {}
     unexpected_symbols: set[str] = set()
     unexpected_signal_count = 0
+    malformed_signal_count = 0
     for item in _as_list(payload.get("signals")):
         signal = _as_mapping(item)
         symbol = signal.get("symbol")
         if not symbol:
+            malformed_signal_count += 1
             continue
         symbol_key = str(symbol)
         if allowed_symbols and symbol_key not in allowed_symbols:
@@ -207,6 +209,7 @@ def _latest_signals(
             continue
         signal_date = _signal_date_key(signal)
         if signal_date is None:
+            malformed_signal_count += 1
             continue
         if (
             symbol_key not in latest_dates
@@ -221,7 +224,11 @@ def _latest_signals(
         if not _is_number(item.get("score"))
         or not _is_number(item.get("position"))
     )
-    return latest, invalid_count + unexpected_signal_count, sorted(unexpected_symbols)
+    return (
+        latest,
+        invalid_count + unexpected_signal_count + malformed_signal_count,
+        sorted(unexpected_symbols),
+    )
 
 
 def _valid_latest_signals(payload: Mapping[str, Any]) -> list[Mapping[str, Any]]:
@@ -950,13 +957,25 @@ def _empty_artifact(
 
 
 def build_opinion_artifact(payload: Mapping[str, Any]) -> dict[str, Any]:
+    status = payload.get("status")
     if payload.get("summary_only"):
+        limitations = [OMITTED_DETAIL_LIMITATION]
+        if status != "succeeded":
+            status_label = status if status is not None else "unavailable"
+            limitations.insert(
+                0,
+                f"Run status is {status_label}; artifacts are not adoptable.",
+            )
         return {
             "artifact_version": OPINION_ARTIFACT_VERSION,
-            "state": "no-opinion",
-            "state_reason": OMITTED_DETAIL_LIMITATION,
+            "state": "no-opinion" if status == "succeeded" else "do-not-adopt",
+            "state_reason": (
+                OMITTED_DETAIL_LIMITATION
+                if status == "succeeded"
+                else "Research run did not complete successfully."
+            ),
             "manual_adoption_only": True,
-            "evidence_limitations": [OMITTED_DETAIL_LIMITATION],
+            "evidence_limitations": limitations,
             "buy_candidates": [],
             "sell_or_avoid": [],
             "watch": [],
@@ -964,7 +983,6 @@ def build_opinion_artifact(payload: Mapping[str, Any]) -> dict[str, Any]:
         }
 
     limitations: list[str] = []
-    status = payload.get("status")
     completeness = payload.get("artifact_completeness")
     if status != "succeeded":
         status_label = status if status is not None else "unavailable"

--- a/backend/research/domain/opinion.py
+++ b/backend/research/domain/opinion.py
@@ -1,8 +1,30 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping
 from datetime import date, datetime
-from typing import Any
+from typing import Any, Literal
+
+OpinionReviewCheckName = Literal[
+    "strategy_lifecycle",
+    "signal_to_position",
+    "backtest_report_discipline",
+    "robustness",
+    "parameter_sensitivity",
+    "evidence_traceability",
+    "risk_present",
+    "invalidation_present",
+    "manual_adoption_boundary",
+    "insufficient_evidence_gate",
+    "source_artifact_audit",
+    "text_evidence_summary",
+]
+OpinionReviewCheckCategory = Literal[
+    "method",
+    "self_review",
+    "source_provider_audit",
+    "evidence_summary",
+]
 
 OPINION_ARTIFACT_VERSION = "phase2_opinion_artifact_v1"
 OMITTED_DETAIL_LIMITATION = (
@@ -19,8 +41,8 @@ PROVISIONAL_POLICY = (
     "Local sensitivity scenarios are observational only and do not change action lists."
 )
 BOUNDARY_RISK = (
-    "Checked no-warning result: persisted warnings and comparison caveats were checked; "
-    "manual adoption review is still required."
+    "Checked no-warning result: warning_count=0 and caveat_count=0; manual adoption "
+    "review is still required."
 )
 
 
@@ -34,6 +56,34 @@ def _as_list(value: Any) -> list[Any]:
 
 def _is_number(value: Any) -> bool:
     return isinstance(value, int | float) and not isinstance(value, bool)
+
+
+def _has_metrics_evidence(value: Any) -> bool:
+    metrics = _as_mapping(value)
+    return any(
+        _is_number(metrics.get(field))
+        for field in (
+            "total_return",
+            "sharpe",
+            "max_drawdown",
+            "turnover",
+            "max_position_weight",
+        )
+    )
+
+
+def _has_diagnostics_evidence(value: Any) -> bool:
+    diagnostics = _as_mapping(value)
+    sample_count = diagnostics.get("sample_count")
+    return (
+        isinstance(sample_count, int)
+        and not isinstance(sample_count, bool)
+        and sample_count > 0
+        and any(
+            _is_number(diagnostics.get(field))
+            for field in ("rmse", "mae", "rank_ic", "linear_ic")
+        )
+    )
 
 
 def _signal_date_key(signal: Mapping[str, Any]) -> str | None:
@@ -58,18 +108,47 @@ def _signal_ref(field: str, signal: Mapping[str, Any]) -> dict[str, str]:
     ref = {"artifact": "signals", "field": field}
     if signal.get("symbol") is not None:
         ref["symbol"] = str(signal["symbol"])
-    if signal.get("date") is not None:
-        ref["date"] = str(signal["date"])
+    signal_date = _signal_date_key(signal)
+    if signal_date is not None:
+        ref["date"] = signal_date
     return ref
 
 
-def _risk_context(payload: Mapping[str, Any]) -> tuple[str, list[dict[str, str]], str]:
+def _risk_context(
+    payload: Mapping[str, Any],
+    symbol: str | None = None,
+) -> tuple[str, list[dict[str, str]], str]:
     warnings = [str(item) for item in _as_list(payload.get("warnings"))]
     if warnings:
+        if symbol is None:
+            return (
+                "Persisted warnings were evaluated per symbol; unmatched warnings remain "
+                "run-level/unscoped.",
+                _refs(("warnings", "warnings")),
+                "warning_summary",
+            )
+        warning = next(
+            (
+                item
+                for item in warnings
+                if re.search(
+                    rf"(?<![A-Za-z0-9]){re.escape(symbol)}(?![A-Za-z0-9])",
+                    item,
+                    re.IGNORECASE,
+                )
+            ),
+            None,
+        )
+        if warning is not None:
+            return (
+                f"Persisted symbol-scoped warning for {symbol}: {warning}",
+                _refs(("warnings", "warnings")),
+                "warning",
+            )
         return (
-            f"Persisted warning: {warnings[0]}",
+            "Persisted run-level/unscoped warning has no reliable symbol match.",
             _refs(("warnings", "warnings")),
-            "warning",
+            "unscoped_warning",
         )
 
     caveats = [_as_mapping(item) for item in _as_list(payload.get("comparison_caveats"))]
@@ -78,7 +157,8 @@ def _risk_context(payload: Mapping[str, Any]) -> tuple[str, list[dict[str, str]]
         code = str(caveat.get("code", "COMPARISON_CAVEAT"))
         severity = str(caveat.get("severity", "blocker"))
         return (
-            f"Persisted caveat {code} with severity {severity}.",
+            f"Persisted run-level caveat {code} with severity {severity} "
+            "applies to all symbols.",
             _refs(("comparison_caveats", "comparison_caveats")),
             "caveat",
         )
@@ -117,26 +197,20 @@ def _invalidation_context(payload: Mapping[str, Any]) -> tuple[str, list[dict[st
 
 def _latest_signals(payload: Mapping[str, Any]) -> tuple[list[Mapping[str, Any]], int]:
     latest_by_symbol: dict[str, Mapping[str, Any]] = {}
-    latest_date_by_symbol: dict[str, str | None] = {}
+    latest_dates: dict[str, str] = {}
     for item in _as_list(payload.get("signals")):
         signal = _as_mapping(item)
         symbol = signal.get("symbol")
-        if not symbol:
+        signal_date = _signal_date_key(signal)
+        if not symbol or signal_date is None:
             continue
         symbol_key = str(symbol)
-        signal_date = _signal_date_key(signal)
-        if symbol_key not in latest_by_symbol:
-            latest_by_symbol[symbol_key] = signal
-            latest_date_by_symbol[symbol_key] = signal_date
-            continue
-        current_date = latest_date_by_symbol[symbol_key]
-        if signal_date is not None and (
-            current_date is None or signal_date >= current_date
+        if (
+            symbol_key not in latest_dates
+            or signal_date >= latest_dates[symbol_key]
         ):
             latest_by_symbol[symbol_key] = signal
-            latest_date_by_symbol[symbol_key] = signal_date
-        elif signal_date is None and current_date is None:
-            latest_by_symbol[symbol_key] = signal
+            latest_dates[symbol_key] = signal_date
     latest = [latest_by_symbol[symbol] for symbol in sorted(latest_by_symbol)]
     invalid_count = sum(
         1
@@ -160,12 +234,12 @@ def _valid_latest_signals(payload: Mapping[str, Any]) -> list[Mapping[str, Any]]
 
 
 def _action_rows(payload: Mapping[str, Any]) -> list[dict[str, Any]]:
-    risk, risk_refs, _risk_family = _risk_context(payload)
     invalidation, invalidation_refs, _invalidation_family = _invalidation_context(payload)
     rows: list[dict[str, Any]] = []
     for signal in _valid_latest_signals(payload):
         symbol = str(signal["symbol"])
-        signal_date = str(signal["date"])
+        signal_date = _signal_date_key(signal)
+        risk, risk_refs, _risk_family = _risk_context(payload, symbol)
         rows.append(
             {
                 "symbol": symbol,
@@ -253,6 +327,7 @@ def _manual_boundary_present(*texts: str) -> bool:
         "personalized advice",
         "place order",
         "order routing",
+        "execution route",
     )
     haystack = " ".join(texts).lower()
     return not any(term in haystack for term in forbidden)
@@ -284,8 +359,8 @@ def _opinion_texts(
 
 
 def _check(
-    check: str,
-    category: str,
+    check: OpinionReviewCheckName,
+    category: OpinionReviewCheckCategory,
     status: str,
     evidence_reason: str,
     risk_or_warning: str,
@@ -313,8 +388,24 @@ def _row_signal_reference_count(row: Mapping[str, Any]) -> int:
     )
 
 
-def _row_has_traceable_signal(row: Mapping[str, Any]) -> bool:
-    return bool(row.get("evidence_reason")) and _row_signal_reference_count(row) > 0
+def _row_has_traceable_signal(
+    row: Mapping[str, Any],
+    selected_signal_dates: Mapping[str, str],
+) -> bool:
+    symbol = str(row.get("symbol", ""))
+    expected_date = selected_signal_dates.get(symbol)
+    signal_refs = [
+        _as_mapping(ref)
+        for ref in _as_list(row.get("source_artifact_references"))
+        if _as_mapping(ref).get("artifact") == "signals"
+        and _as_mapping(ref).get("symbol") == symbol
+    ]
+    return (
+        bool(row.get("evidence_reason"))
+        and expected_date is not None
+        and bool(signal_refs)
+        and all(ref.get("date") == expected_date for ref in signal_refs)
+    )
 
 
 def _row_has_concrete_risk(
@@ -466,8 +557,13 @@ def _parameter_sensitivity(payload: Mapping[str, Any]) -> dict[str, Any]:
         }
 
     scenario_sets = list(scenarios.values())
-    stable = sorted(set(base).intersection(*scenario_sets)) if base else []
-    changed = sorted(set().union(*scenario_sets).symmetric_difference(set(base)))
+    base_symbols = set(base)
+    stable = sorted(base_symbols.intersection(*scenario_sets)) if base else []
+    changed = sorted(
+        set().union(
+            *(scenario.symmetric_difference(base_symbols) for scenario in scenario_sets)
+        )
+    )
     return {
         "status": "warning" if invalid_count else "pass",
         "reason": "Local provisional sensitivity scenarios were computed.",
@@ -499,20 +595,28 @@ def _review_checks(
     caveats = _as_list(payload.get("comparison_caveats"))
     warnings = _as_list(payload.get("warnings"))
     latest, invalid_signal_count = _latest_signals(payload)
-    positive = sum(1 for item in _valid_latest_signals(payload) if float(item["position"]) > 0)
-    negative = sum(1 for item in _valid_latest_signals(payload) if float(item["position"]) < 0)
-    flat = sum(1 for item in _valid_latest_signals(payload) if float(item["position"]) == 0)
+    valid_latest = _valid_latest_signals(payload)
+    selected_signal_dates = {
+        str(item["symbol"]): signal_date
+        for item in valid_latest
+        if (signal_date := _signal_date_key(item)) is not None
+    }
+    positive = sum(1 for item in valid_latest if float(item["position"]) > 0)
+    negative = sum(1 for item in valid_latest if float(item["position"]) < 0)
+    flat = sum(1 for item in valid_latest if float(item["position"]) == 0)
+    metrics_present = _has_metrics_evidence(metrics)
+    diagnostics_present = _has_diagnostics_evidence(diagnostics)
     boundary_present = _manual_boundary_present(*_opinion_texts(payload, rows))
     lifecycle = {
         "request_present": bool(_as_mapping(payload.get("request_payload"))),
         "effective_strategy_present": bool(_as_mapping(payload.get("effective_strategy"))),
-        "diagnostics_present": bool(diagnostics),
+        "diagnostics_present": diagnostics_present,
         "signals_present": bool(signals),
-        "metrics_present": bool(metrics),
+        "metrics_present": metrics_present,
         "opinion_rows_emitted_or_limited": bool(rows) or bool(limitations),
     }
     backtest_result = {
-        "metric_keys": sorted(metrics),
+        "metric_keys": sorted(key for key, value in metrics.items() if _is_number(value)),
         "caveat_count": len(caveats),
         "threshold_policy_version_present": bool(payload.get("threshold_policy_version")),
         "price_basis_version_present": bool(payload.get("price_basis_version")),
@@ -565,9 +669,16 @@ def _review_checks(
     sensitivity = _parameter_sensitivity(payload)
     risk_context = _risk_context(payload)
     invalidation_context = _invalidation_context(payload)
-    traceable_row_count = sum(1 for row in rows if _row_has_traceable_signal(row))
+    traceable_row_count = sum(
+        1 for row in rows if _row_has_traceable_signal(row, selected_signal_dates)
+    )
     concrete_risk_row_count = sum(
-        1 for row in rows if _row_has_concrete_risk(row, risk_context)
+        1
+        for row in rows
+        if _row_has_concrete_risk(
+            row,
+            _risk_context(payload, str(row.get("symbol", ""))),
+        )
     )
     concrete_invalidation_row_count = sum(
         1
@@ -612,17 +723,17 @@ def _review_checks(
             "backtest_report_discipline",
             "method",
             "pass"
-            if metrics
+            if metrics_present
             and backtest_result["threshold_policy_version_present"]
             and backtest_result["price_basis_version_present"]
             and boundary_present
             and not caveats
             else "warning"
-            if metrics
+            if metrics_present
             else "fail",
             "Metrics, caveat count, version policy, and research-only boundary were checked.",
             "Caveats or missing policy metadata prevent a clean pass."
-            if caveats or not metrics
+            if caveats or not metrics_present
             else "Backtest context is present for research review.",
             _refs(
                 ("metrics", "metrics"),
@@ -829,9 +940,9 @@ def build_opinion_artifact(payload: Mapping[str, Any]) -> dict[str, Any]:
         missing = [str(item) for item in _as_list(payload.get("missing_artifacts"))]
         detail = f" Missing artifacts: {', '.join(missing)}." if missing else ""
         limitations.append(f"Artifact completeness is {completeness}.{detail}")
-    if not _as_mapping(payload.get("metrics")):
+    if not _has_metrics_evidence(payload.get("metrics")):
         limitations.append("Strategy metrics artifact is unavailable.")
-    if not _as_mapping(payload.get("model_diagnostics")):
+    if not _has_diagnostics_evidence(payload.get("model_diagnostics")):
         limitations.append("Model diagnostics artifact is unavailable.")
     if not _as_list(payload.get("signals")):
         limitations.append("Signal artifact is unavailable.")

--- a/backend/research/domain/opinion.py
+++ b/backend/research/domain/opinion.py
@@ -4,28 +4,12 @@ import math
 import re
 from collections.abc import Mapping
 from datetime import date, datetime
-from typing import Any, Literal
+from typing import Any
 
-OpinionReviewCheckName = Literal[
-    "strategy_lifecycle",
-    "signal_to_position",
-    "backtest_report_discipline",
-    "robustness",
-    "parameter_sensitivity",
-    "evidence_traceability",
-    "risk_present",
-    "invalidation_present",
-    "manual_adoption_boundary",
-    "insufficient_evidence_gate",
-    "source_artifact_audit",
-    "text_evidence_summary",
-]
-OpinionReviewCheckCategory = Literal[
-    "method",
-    "self_review",
-    "source_provider_audit",
-    "evidence_summary",
-]
+from backend.research.contracts.runs import (
+    OpinionReviewCheckCategory,
+    OpinionReviewCheckName,
+)
 
 OPINION_ARTIFACT_VERSION = "phase2_opinion_artifact_v1"
 OMITTED_DETAIL_LIMITATION = (
@@ -195,21 +179,35 @@ def _invalidation_context(payload: Mapping[str, Any]) -> tuple[str, list[dict[st
         )
     return (
         "Do not adopt if a newer persisted run or newer market data supersedes this signal.",
-        _refs(("request_payload", "date_range"), ("signals", "date")),
+        [],
         "newer_run_or_market_data",
     )
 
 
-def _latest_signals(payload: Mapping[str, Any]) -> tuple[list[Mapping[str, Any]], int]:
+def _latest_signals(
+    payload: Mapping[str, Any],
+) -> tuple[list[Mapping[str, Any]], int, list[str]]:
+    declared = _as_list(payload.get("symbols")) or _as_list(
+        _as_mapping(payload.get("request_payload")).get("symbols")
+    )
+    allowed_symbols = {str(symbol) for symbol in declared if symbol}
     latest_by_symbol: dict[str, Mapping[str, Any]] = {}
     latest_dates: dict[str, str] = {}
+    unexpected_symbols: set[str] = set()
+    unexpected_signal_count = 0
     for item in _as_list(payload.get("signals")):
         signal = _as_mapping(item)
         symbol = signal.get("symbol")
-        signal_date = _signal_date_key(signal)
-        if not symbol or signal_date is None:
+        if not symbol:
             continue
         symbol_key = str(symbol)
+        if allowed_symbols and symbol_key not in allowed_symbols:
+            unexpected_symbols.add(symbol_key)
+            unexpected_signal_count += 1
+            continue
+        signal_date = _signal_date_key(signal)
+        if signal_date is None:
+            continue
         if (
             symbol_key not in latest_dates
             or signal_date >= latest_dates[symbol_key]
@@ -223,11 +221,11 @@ def _latest_signals(payload: Mapping[str, Any]) -> tuple[list[Mapping[str, Any]]
         if not _is_number(item.get("score"))
         or not _is_number(item.get("position"))
     )
-    return latest, invalid_count
+    return latest, invalid_count + unexpected_signal_count, sorted(unexpected_symbols)
 
 
 def _valid_latest_signals(payload: Mapping[str, Any]) -> list[Mapping[str, Any]]:
-    latest, _ = _latest_signals(payload)
+    latest, _, _ = _latest_signals(payload)
     return [
         item
         for item in latest
@@ -440,6 +438,7 @@ def _row_has_concrete_risk(
 def _row_has_concrete_invalidation(
     row: Mapping[str, Any],
     context: tuple[str, list[dict[str, str]], str],
+    selected_signal_dates: Mapping[str, str],
 ) -> bool:
     refs = {
         _as_mapping(ref).get("artifact")
@@ -448,12 +447,22 @@ def _row_has_concrete_invalidation(
     text, _context_refs, family = context
     if not str(row.get("invalidation_note", "")).startswith(f"{text} Row signal date:"):
         return False
+    symbol = str(row.get("symbol", ""))
+    expected_date = selected_signal_dates.get(symbol)
+    dated_signal_ref_present = any(
+        _as_mapping(ref).get("artifact") == "signals"
+        and _as_mapping(ref).get("field") in {"score", "position"}
+        and _as_mapping(ref).get("symbol") == symbol
+        and _as_mapping(ref).get("date") == expected_date
+        for ref in _as_list(row.get("source_artifact_references"))
+    )
     return (
         (family == "stale_freshness" and "artifact_completeness" in refs)
         or (family == "comparison_caveats" and "comparison_caveats" in refs)
         or (
             family == "newer_run_or_market_data"
-            and {"request_payload", "signals"} <= refs
+            and expected_date is not None
+            and dated_signal_ref_present
         )
     )
 
@@ -488,7 +497,7 @@ def _summary_checks() -> list[dict[str, Any]]:
 
 
 def _parameter_sensitivity(payload: Mapping[str, Any]) -> dict[str, Any]:
-    latest, invalid_count = _latest_signals(payload)
+    latest, invalid_count, _ = _latest_signals(payload)
     valid = _valid_latest_signals(payload)
     threshold = _strategy_threshold(payload)
     top_n = _strategy_top_n(payload)
@@ -602,7 +611,7 @@ def _review_checks(
     baselines = _as_mapping(payload.get("baselines"))
     caveats = _as_list(payload.get("comparison_caveats"))
     warnings = _as_list(payload.get("warnings"))
-    latest, invalid_signal_count = _latest_signals(payload)
+    latest, invalid_signal_count, _ = _latest_signals(payload)
     valid_latest = _valid_latest_signals(payload)
     selected_signal_dates = {
         str(item["symbol"]): signal_date
@@ -677,6 +686,17 @@ def _review_checks(
     sensitivity = _parameter_sensitivity(payload)
     risk_context = _risk_context(payload)
     invalidation_context = _invalidation_context(payload)
+    invalidation_refs = invalidation_context[1]
+    if invalidation_context[2] == "newer_run_or_market_data":
+        invalidation_refs = [
+            dict(_as_mapping(ref))
+            for row in rows
+            for ref in _as_list(row.get("source_artifact_references"))
+            if _as_mapping(ref).get("artifact") == "signals"
+            and _as_mapping(ref).get("field") in {"score", "position"}
+            and _as_mapping(ref).get("symbol")
+            and _as_mapping(ref).get("date")
+        ] or _refs(("signals", "signals"))
     traceable_row_count = sum(
         1 for row in rows if _row_has_traceable_signal(row, selected_signal_dates)
     )
@@ -691,7 +711,11 @@ def _review_checks(
     concrete_invalidation_row_count = sum(
         1
         for row in rows
-        if _row_has_concrete_invalidation(row, invalidation_context)
+        if _row_has_concrete_invalidation(
+            row,
+            invalidation_context,
+            selected_signal_dates,
+        )
     )
     checks = [
         _check(
@@ -819,7 +843,7 @@ def _review_checks(
             else "fail",
             "Rows were checked for concrete invalidation families and supporting references.",
             invalidation_context[0],
-            invalidation_context[1],
+            invalidation_refs,
             {
                 "row_count": len(rows),
                 "concrete_invalidation_row_count": concrete_invalidation_row_count,
@@ -957,6 +981,13 @@ def build_opinion_artifact(payload: Mapping[str, Any]) -> dict[str, Any]:
         limitations.append("Model diagnostics artifact is unavailable.")
     if not _as_list(payload.get("signals")):
         limitations.append("Signal artifact is unavailable.")
+    else:
+        _, _, unexpected_symbols = _latest_signals(payload)
+        if unexpected_symbols:
+            limitations.append(
+                "Signal artifact contains symbols outside the declared run universe: "
+                f"{', '.join(unexpected_symbols)}."
+            )
     if payload.get("stale_mark_days_with_open_positions") or payload.get("stale_risk_share"):
         limitations.append("Stale mark risk is present in persisted artifacts.")
 

--- a/backend/research/domain/opinion.py
+++ b/backend/research/domain/opinion.py
@@ -1,0 +1,878 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import date, datetime
+from typing import Any
+
+OPINION_ARTIFACT_VERSION = "phase2_opinion_artifact_v1"
+OMITTED_DETAIL_LIMITATION = (
+    "Detail artifacts are omitted; reload the run detail for row-level opinion review."
+)
+RAW_PROVIDER_FIELDS = [
+    "provider_source_name",
+    "parser_version",
+    "fetch_status",
+    "fetch_timestamp",
+    "raw_ingest_audit_ref",
+]
+PROVISIONAL_POLICY = (
+    "Local sensitivity scenarios are observational only and do not change action lists."
+)
+BOUNDARY_RISK = (
+    "Checked no-warning result: persisted warnings and comparison caveats were checked; "
+    "manual adoption review is still required."
+)
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _is_number(value: Any) -> bool:
+    return isinstance(value, int | float) and not isinstance(value, bool)
+
+
+def _signal_date_key(signal: Mapping[str, Any]) -> str | None:
+    value = signal.get("date")
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, str):
+        try:
+            return date.fromisoformat(value).isoformat()
+        except ValueError:
+            return None
+    return None
+
+
+def _refs(*items: tuple[str, str]) -> list[dict[str, str]]:
+    return [{"artifact": artifact, "field": field} for artifact, field in items]
+
+
+def _signal_ref(field: str, signal: Mapping[str, Any]) -> dict[str, str]:
+    ref = {"artifact": "signals", "field": field}
+    if signal.get("symbol") is not None:
+        ref["symbol"] = str(signal["symbol"])
+    if signal.get("date") is not None:
+        ref["date"] = str(signal["date"])
+    return ref
+
+
+def _risk_context(payload: Mapping[str, Any]) -> tuple[str, list[dict[str, str]]]:
+    warnings = [str(item) for item in _as_list(payload.get("warnings"))]
+    if warnings:
+        return (
+            f"Persisted warning: {warnings[0]}",
+            _refs(("warnings", "warnings")),
+        )
+
+    caveats = [_as_mapping(item) for item in _as_list(payload.get("comparison_caveats"))]
+    if caveats:
+        caveat = caveats[0]
+        code = str(caveat.get("code", "COMPARISON_CAVEAT"))
+        severity = str(caveat.get("severity", "blocker"))
+        return (
+            f"Persisted caveat {code} with severity {severity}.",
+            _refs(("comparison_caveats", "comparison_caveats")),
+        )
+
+    return (
+        BOUNDARY_RISK,
+        _refs(("warnings", "warnings"), ("comparison_caveats", "comparison_caveats")),
+    )
+
+
+def _invalidation_context(payload: Mapping[str, Any]) -> tuple[str, list[dict[str, str]]]:
+    if payload.get("stale_mark_days_with_open_positions") or payload.get(
+        "stale_risk_share"
+    ):
+        return (
+            "Do not adopt if stale freshness risk remains in persisted run artifacts.",
+            _refs(
+                ("artifact_completeness", "stale_mark_days_with_open_positions"),
+                ("artifact_completeness", "stale_risk_share"),
+            ),
+        )
+    if _as_list(payload.get("comparison_caveats")):
+        return (
+            "Do not adopt if persisted comparison caveats still apply.",
+            _refs(("comparison_caveats", "comparison_caveats")),
+        )
+    return (
+        "Do not adopt if a newer persisted run or newer market data supersedes this signal.",
+        _refs(("request_payload", "date_range"), ("signals", "date")),
+    )
+
+
+def _latest_signals(payload: Mapping[str, Any]) -> tuple[list[Mapping[str, Any]], int]:
+    latest_by_symbol: dict[str, Mapping[str, Any]] = {}
+    latest_date_by_symbol: dict[str, str | None] = {}
+    for item in _as_list(payload.get("signals")):
+        signal = _as_mapping(item)
+        symbol = signal.get("symbol")
+        if not symbol:
+            continue
+        symbol_key = str(symbol)
+        signal_date = _signal_date_key(signal)
+        if symbol_key not in latest_by_symbol:
+            latest_by_symbol[symbol_key] = signal
+            latest_date_by_symbol[symbol_key] = signal_date
+            continue
+        current_date = latest_date_by_symbol[symbol_key]
+        if signal_date is not None and (
+            current_date is None or signal_date >= current_date
+        ):
+            latest_by_symbol[symbol_key] = signal
+            latest_date_by_symbol[symbol_key] = signal_date
+        elif signal_date is None and current_date is None:
+            latest_by_symbol[symbol_key] = signal
+    latest = [latest_by_symbol[symbol] for symbol in sorted(latest_by_symbol)]
+    invalid_count = sum(
+        1
+        for item in latest
+        if _signal_date_key(item) is None
+        or not _is_number(item.get("score"))
+        or not _is_number(item.get("position"))
+    )
+    return latest, invalid_count
+
+
+def _valid_latest_signals(payload: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    latest, _ = _latest_signals(payload)
+    return [
+        item
+        for item in latest
+        if _signal_date_key(item) is not None
+        and _is_number(item.get("score"))
+        and _is_number(item.get("position"))
+    ]
+
+
+def _action_rows(payload: Mapping[str, Any]) -> list[dict[str, Any]]:
+    risk, risk_refs = _risk_context(payload)
+    invalidation, invalidation_refs = _invalidation_context(payload)
+    rows: list[dict[str, Any]] = []
+    for signal in _valid_latest_signals(payload):
+        symbol = str(signal["symbol"])
+        signal_date = str(signal["date"])
+        rows.append(
+            {
+                "symbol": symbol,
+                "model_score": float(signal["score"]),
+                "position_signal": float(signal["position"]),
+                "evidence_reason": (
+                    f"Latest persisted signal for {symbol} on {signal_date} links "
+                    "numeric score to strategy position."
+                ),
+                "risk_or_warning": risk,
+                "invalidation_note": f"{invalidation} Row signal date: {signal_date} for {symbol}.",
+                "source_artifact_references": [
+                    _signal_ref("score", signal),
+                    _signal_ref("position", signal),
+                    *_refs(
+                        ("model_diagnostics", "model_diagnostics"),
+                        ("metrics", "metrics"),
+                        ("artifact_completeness", "artifact_completeness"),
+                    ),
+                    *risk_refs,
+                    *invalidation_refs,
+                ],
+            }
+        )
+    return rows
+
+
+def _blocker_caveat_count(payload: Mapping[str, Any]) -> int:
+    caveats = [_as_mapping(item) for item in _as_list(payload.get("comparison_caveats"))]
+    if payload.get("status") != "succeeded" or payload.get("artifact_completeness") != "complete":
+        return len(caveats)
+    return sum(
+        1
+        for caveat in caveats
+        if caveat.get("severity") == "blocker"
+        or str(caveat.get("code", "")).endswith("_MISSING")
+        or str(caveat.get("code", "")).endswith("_ONLY")
+    )
+
+
+def _strategy_threshold(payload: Mapping[str, Any]) -> float | None:
+    strategy = _as_mapping(payload.get("effective_strategy")) or _as_mapping(
+        _as_mapping(payload.get("request_payload")).get("strategy")
+    )
+    threshold = strategy.get("threshold")
+    return float(threshold) if _is_number(threshold) else None
+
+
+def _strategy_top_n(payload: Mapping[str, Any]) -> int | None:
+    strategy = _as_mapping(payload.get("effective_strategy")) or _as_mapping(
+        _as_mapping(payload.get("request_payload")).get("strategy")
+    )
+    top_n = strategy.get("top_n")
+    return int(top_n) if isinstance(top_n, int) and not isinstance(top_n, bool) else None
+
+
+def _string_values(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, Mapping):
+        strings: list[str] = []
+        for item in value.values():
+            strings.extend(_string_values(item))
+        return strings
+    if isinstance(value, list):
+        strings = []
+        for item in value:
+            strings.extend(_string_values(item))
+        return strings
+    return [str(value)]
+
+
+def _manual_boundary_present(*texts: str) -> bool:
+    forbidden = (
+        "broker routing",
+        "broker",
+        "execution-ready",
+        "execution ready",
+        "live order",
+        "live orders",
+        "automatic rebalance",
+        "automatic rebalancing",
+        "account control",
+        "personalized investment advice",
+        "personalized advice",
+        "place order",
+        "order routing",
+    )
+    haystack = " ".join(texts).lower()
+    return not any(term in haystack for term in forbidden)
+
+
+def _opinion_texts(
+    payload: Mapping[str, Any],
+    rows: list[dict[str, Any]],
+    checks: list[dict[str, Any]] | None = None,
+) -> list[str]:
+    texts = [str(payload.get("state_reason", ""))]
+    for row in rows:
+        texts.extend(
+            str(row.get(field, ""))
+            for field in ("evidence_reason", "risk_or_warning", "invalidation_note")
+        )
+    texts.extend(str(item) for item in _as_list(payload.get("warnings")))
+    for caveat in _as_list(payload.get("comparison_caveats")):
+        texts.extend(_string_values(caveat))
+    for check in checks or []:
+        texts.extend(
+            [
+                str(check.get("evidence_reason", "")),
+                str(check.get("risk_or_warning", "")),
+            ]
+        )
+        texts.extend(_string_values(check.get("result")))
+    return texts
+
+
+def _check(
+    check: str,
+    category: str,
+    status: str,
+    evidence_reason: str,
+    risk_or_warning: str,
+    source_artifact_references: list[dict[str, str]],
+    result: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "check": check,
+        "category": category,
+        "status": status,
+        "evidence_reason": evidence_reason,
+        "risk_or_warning": risk_or_warning,
+        "source_artifact_references": source_artifact_references,
+        "result": result or {},
+    }
+
+
+def _row_signal_reference_count(row: Mapping[str, Any]) -> int:
+    return sum(
+        1
+        for ref in _as_list(row.get("source_artifact_references"))
+        if _as_mapping(ref).get("artifact") == "signals"
+        and _as_mapping(ref).get("symbol") == row.get("symbol")
+        and _as_mapping(ref).get("date")
+    )
+
+
+def _row_has_traceable_signal(row: Mapping[str, Any]) -> bool:
+    return bool(row.get("evidence_reason")) and _row_signal_reference_count(row) > 0
+
+
+def _row_has_concrete_risk(row: Mapping[str, Any]) -> bool:
+    refs = {
+        _as_mapping(ref).get("artifact")
+        for ref in _as_list(row.get("source_artifact_references"))
+    }
+    text = str(row.get("risk_or_warning", "")).lower()
+    return (
+        ("persisted warning:" in text and "warnings" in refs)
+        or ("persisted caveat" in text and "comparison_caveats" in refs)
+        or (
+            "checked no-warning result" in text
+            and {"warnings", "comparison_caveats"} <= refs
+        )
+        or (
+            "stale" in text
+            and "artifact_completeness" in refs
+        )
+    )
+
+
+def _row_has_concrete_invalidation(row: Mapping[str, Any]) -> bool:
+    refs = {
+        _as_mapping(ref).get("artifact")
+        for ref in _as_list(row.get("source_artifact_references"))
+    }
+    text = str(row.get("invalidation_note", "")).lower()
+    families = (
+        "newer persisted run",
+        "newer market data",
+        "persisted comparison caveats",
+        "stale freshness risk",
+        "missing",
+    )
+    return bool(row.get("invalidation_note")) and any(item in text for item in families) and bool(
+        refs & {"signals", "comparison_caveats", "artifact_completeness", "request_payload"}
+    )
+
+
+def _summary_checks() -> list[dict[str, Any]]:
+    result = {"omitted_for_summary": True}
+    return [
+        _check(
+            check,
+            category,
+            "not_evaluated",
+            "Detail artifacts are omitted from this summary response.",
+            "Reload run detail before using opinion checks.",
+            _refs(("artifact_completeness", "artifact_completeness")),
+            result,
+        )
+        for check, category in (
+            ("strategy_lifecycle", "method"),
+            ("signal_to_position", "method"),
+            ("backtest_report_discipline", "method"),
+            ("robustness", "method"),
+            ("parameter_sensitivity", "method"),
+            ("evidence_traceability", "self_review"),
+            ("risk_present", "self_review"),
+            ("invalidation_present", "self_review"),
+            ("manual_adoption_boundary", "self_review"),
+            ("insufficient_evidence_gate", "self_review"),
+            ("source_artifact_audit", "source_provider_audit"),
+            ("text_evidence_summary", "evidence_summary"),
+        )
+    ]
+
+
+def _parameter_sensitivity(payload: Mapping[str, Any]) -> dict[str, Any]:
+    latest, invalid_count = _latest_signals(payload)
+    valid = _valid_latest_signals(payload)
+    threshold = _strategy_threshold(payload)
+    top_n = _strategy_top_n(payload)
+    base = sorted(
+        str(item["symbol"]) for item in valid if float(item["position"]) > 0
+    )
+    skipped: list[str] = []
+    scenarios: dict[str, set[str]] = {}
+
+    if not latest:
+        return {
+            "status": "not_evaluated",
+            "reason": "Signal artifact is missing or empty.",
+            "result": {
+                "base_candidate_symbols": [],
+                "scenario_candidate_counts": {},
+                "stable_symbols": [],
+                "changed_symbols": [],
+                "provisional_policy": PROVISIONAL_POLICY,
+                "skipped_scenarios": ["signals_missing_or_empty"],
+            },
+        }
+    if not valid:
+        return {
+            "status": "not_evaluated",
+            "reason": "Persisted signal rows lack numeric score or position.",
+            "result": {
+                "base_candidate_symbols": [],
+                "scenario_candidate_counts": {},
+                "stable_symbols": [],
+                "changed_symbols": [],
+                "provisional_policy": PROVISIONAL_POLICY,
+                "skipped_scenarios": ["invalid_signal_rows"],
+            },
+        }
+    if threshold is None or threshold <= 0:
+        skipped.append("threshold_missing_or_non_positive")
+    else:
+        scenarios["strict_threshold"] = {
+            str(item["symbol"]) for item in valid if float(item["score"]) >= threshold * 1.25
+        }
+        scenarios["loose_threshold"] = {
+            str(item["symbol"]) for item in valid if float(item["score"]) >= threshold * 0.75
+        }
+
+    ranked = sorted(valid, key=lambda item: float(item["score"]), reverse=True)
+    if top_n is None:
+        skipped.append("top_n_missing")
+    elif top_n < 1:
+        skipped.append("top_n_less_than_one")
+    else:
+        if top_n > 1:
+            scenarios["top_n_minus_1"] = {
+                str(item["symbol"]) for item in ranked[: top_n - 1]
+            }
+        else:
+            skipped.append("top_n_minus_1_requires_top_n_above_one")
+        scenarios["top_n_plus_1"] = {
+            str(item["symbol"]) for item in ranked[: min(top_n + 1, len(ranked))]
+        }
+
+    if not scenarios:
+        return {
+            "status": "not_evaluated",
+            "reason": "No threshold or top_n scenario inputs are available.",
+            "result": {
+                "base_candidate_symbols": base,
+                "scenario_candidate_counts": {},
+                "stable_symbols": [],
+                "changed_symbols": [],
+                "provisional_policy": PROVISIONAL_POLICY,
+                "skipped_scenarios": skipped,
+            },
+        }
+
+    scenario_sets = list(scenarios.values())
+    stable = sorted(set(base).intersection(*scenario_sets)) if base else []
+    changed = sorted(set().union(*scenario_sets).symmetric_difference(set(base)))
+    return {
+        "status": "warning" if invalid_count else "pass",
+        "reason": "Local provisional sensitivity scenarios were computed.",
+        "result": {
+            "base_candidate_symbols": base,
+            "scenario_candidate_counts": {
+                key: len(value) for key, value in scenarios.items()
+            },
+            "stable_symbols": stable,
+            "changed_symbols": changed,
+            "provisional_policy": PROVISIONAL_POLICY,
+            "skipped_scenarios": skipped,
+        },
+    }
+
+
+def _review_checks(
+    payload: Mapping[str, Any],
+    rows: list[dict[str, Any]],
+    state: str,
+    limitations: list[str],
+) -> list[dict[str, Any]]:
+    metrics = _as_mapping(payload.get("metrics"))
+    diagnostics = _as_mapping(payload.get("model_diagnostics"))
+    signals = _as_list(payload.get("signals"))
+    validation = _as_mapping(payload.get("validation"))
+    validation_metrics = _as_mapping(validation.get("metrics"))
+    baselines = _as_mapping(payload.get("baselines"))
+    caveats = _as_list(payload.get("comparison_caveats"))
+    warnings = _as_list(payload.get("warnings"))
+    latest, invalid_signal_count = _latest_signals(payload)
+    positive = sum(1 for item in _valid_latest_signals(payload) if float(item["position"]) > 0)
+    negative = sum(1 for item in _valid_latest_signals(payload) if float(item["position"]) < 0)
+    flat = sum(1 for item in _valid_latest_signals(payload) if float(item["position"]) == 0)
+    boundary_present = _manual_boundary_present(*_opinion_texts(payload, rows))
+    lifecycle = {
+        "request_present": bool(_as_mapping(payload.get("request_payload"))),
+        "effective_strategy_present": bool(_as_mapping(payload.get("effective_strategy"))),
+        "diagnostics_present": bool(diagnostics),
+        "signals_present": bool(signals),
+        "metrics_present": bool(metrics),
+        "opinion_rows_emitted_or_limited": bool(rows) or bool(limitations),
+    }
+    backtest_result = {
+        "metric_keys": sorted(metrics),
+        "caveat_count": len(caveats),
+        "threshold_policy_version_present": bool(payload.get("threshold_policy_version")),
+        "price_basis_version_present": bool(payload.get("price_basis_version")),
+        "research_only_boundary_present": boundary_present,
+    }
+    robust_result = {
+        "validation_metric_keys": sorted(validation_metrics),
+        "baseline_keys": sorted(baselines),
+        "warning_count": len(warnings),
+        "blocker_caveat_count": _blocker_caveat_count(payload),
+    }
+    config_sources_present = bool(_as_mapping(payload.get("config_sources")))
+    fallback_audit_present = bool(_as_mapping(payload.get("fallback_audit")))
+    source_audit_result = {
+        "config_fallback_metadata_present": bool(
+            config_sources_present or fallback_audit_present
+        ),
+        "config_sources_present": config_sources_present,
+        "fallback_audit_present": fallback_audit_present,
+        "raw_provider_parser_audit_available": False,
+        "missing_raw_provider_parser_fields": RAW_PROVIDER_FIELDS,
+        "missing_config_fallback_inputs": [
+            name
+            for name, present in (
+                ("config_sources", config_sources_present),
+                ("fallback_audit", fallback_audit_present),
+            )
+            if not present
+        ],
+    }
+    text_sources = warnings + caveats
+    summary_text = ""
+    if text_sources:
+        first = text_sources[0]
+        if isinstance(first, Mapping):
+            summary_text = str(first.get("label") or first.get("code") or "")
+        else:
+            summary_text = str(first)
+    text_result = {
+        "warning_count": len(warnings),
+        "caveat_count": len(caveats),
+        "source_text_count": len(text_sources),
+        "summary_text": summary_text,
+        "source_artifact_references": _refs(
+            ("warnings", "warnings"), ("comparison_caveats", "comparison_caveats")
+        )
+        if text_sources
+        else [],
+    }
+    sensitivity = _parameter_sensitivity(payload)
+    traceable_row_count = sum(1 for row in rows if _row_has_traceable_signal(row))
+    concrete_risk_row_count = sum(1 for row in rows if _row_has_concrete_risk(row))
+    concrete_invalidation_row_count = sum(
+        1 for row in rows if _row_has_concrete_invalidation(row)
+    )
+    checks = [
+        _check(
+            "strategy_lifecycle",
+            "method",
+            "pass" if all(lifecycle.values()) else "fail",
+            "Request, effective strategy, diagnostics, signals, metrics, and opinion output were checked.",
+            "Missing lifecycle input blocks method confidence."
+            if not all(lifecycle.values())
+            else "Lifecycle inputs are present for research review.",
+            _refs(
+                ("request_payload", "request_payload"),
+                ("model_diagnostics", "model_diagnostics"),
+                ("signals", "signals"),
+                ("metrics", "metrics"),
+            ),
+            lifecycle,
+        ),
+        _check(
+            "signal_to_position",
+            "method",
+            "pass" if latest and invalid_signal_count == 0 else "warning" if latest else "fail",
+            "Latest persisted signal rows were bucketed by position sign.",
+            "Invalid latest signal rows were excluded from action rows."
+            if invalid_signal_count
+            else "Signal buckets are derived from numeric latest rows.",
+            _refs(("signals", "signals")),
+            {
+                "checked_symbol_count": len(latest),
+                "positive_count": positive,
+                "negative_count": negative,
+                "flat_count": flat,
+                "invalid_row_count": invalid_signal_count,
+            },
+        ),
+        _check(
+            "backtest_report_discipline",
+            "method",
+            "pass"
+            if metrics
+            and backtest_result["threshold_policy_version_present"]
+            and backtest_result["price_basis_version_present"]
+            and boundary_present
+            and not caveats
+            else "warning"
+            if metrics
+            else "fail",
+            "Metrics, caveat count, version policy, and research-only boundary were checked.",
+            "Caveats or missing policy metadata prevent a clean pass."
+            if caveats or not metrics
+            else "Backtest context is present for research review.",
+            _refs(
+                ("metrics", "metrics"),
+                ("comparison_caveats", "comparison_caveats"),
+                ("version_pack", "threshold_policy_version"),
+                ("version_pack", "price_basis_version"),
+            ),
+            backtest_result,
+        ),
+        _check(
+            "robustness",
+            "method",
+            "pass"
+            if validation_metrics and baselines and not robust_result["blocker_caveat_count"]
+            else "warning"
+            if validation or caveats or warnings or not baselines
+            else "not_evaluated",
+            "Validation metrics, baselines, warnings, and blocker caveats were checked.",
+            "Validation metrics, baselines, or caveats limit robustness confidence.",
+            _refs(
+                ("validation", "validation"),
+                ("baselines", "baselines"),
+                ("warnings", "warnings"),
+                ("comparison_caveats", "comparison_caveats"),
+            ),
+            robust_result,
+        ),
+        _check(
+            "parameter_sensitivity",
+            "method",
+            sensitivity["status"],
+            sensitivity["reason"],
+            "Sensitivity output is provisional and local.",
+            _refs(("signals", "signals"), ("request_payload", "strategy")),
+            sensitivity["result"],
+        ),
+        _check(
+            "evidence_traceability",
+            "self_review",
+            "pass"
+            if (rows and traceable_row_count == len(rows)) or state != "viable"
+            else "fail",
+            "Viable rows were checked for row-specific latest signal references.",
+            "Rows without row-specific signal references block viability.",
+            _refs(("signals", "signals"), ("artifact_completeness", "artifact_completeness")),
+            {
+                "row_count": len(rows),
+                "row_specific_signal_reference_count": sum(
+                    _row_signal_reference_count(row) for row in rows
+                ),
+                "untraceable_row_count": len(rows) - traceable_row_count,
+            },
+        ),
+        _check(
+            "risk_present",
+            "self_review",
+            "pass"
+            if (rows and concrete_risk_row_count == len(rows)) or limitations
+            else "fail",
+            "Rows were checked for concrete warning, caveat, artifact-risk, or no-warning evidence.",
+            _risk_context(payload)[0],
+            _risk_context(payload)[1],
+            {
+                "row_count": len(rows),
+                "concrete_risk_row_count": concrete_risk_row_count,
+                "missing_risk_row_count": len(rows) - concrete_risk_row_count,
+                "limitation_count": len(limitations),
+            },
+        ),
+        _check(
+            "invalidation_present",
+            "self_review",
+            "pass"
+            if (rows and concrete_invalidation_row_count == len(rows)) or limitations
+            else "fail",
+            "Rows were checked for concrete invalidation families and supporting references.",
+            _invalidation_context(payload)[0],
+            _invalidation_context(payload)[1],
+            {
+                "row_count": len(rows),
+                "concrete_invalidation_row_count": concrete_invalidation_row_count,
+                "missing_invalidation_row_count": len(rows)
+                - concrete_invalidation_row_count,
+                "limitation_count": len(limitations),
+            },
+        ),
+        _check(
+            "manual_adoption_boundary",
+            "self_review",
+            "pass" if boundary_present else "fail",
+            "Opinion-facing text was scanned for forbidden execution or advice language.",
+            "Forbidden execution or advice wording blocks manual-adoption boundary."
+            if not boundary_present
+            else "Manual adoption boundary is preserved.",
+            _refs(("version_pack", "manual_adoption_only")),
+            {"manual_adoption_only": True, "forbidden_language_found": not boundary_present},
+        ),
+        _check(
+            "insufficient_evidence_gate",
+            "self_review",
+            "pass" if not limitations or state in {"no-opinion", "do-not-adopt"} else "fail",
+            "Downgrade matrix was applied to current artifact limitations.",
+            "Unavailable evidence must not emit viable action rows.",
+            _refs(("artifact_completeness", "artifact_completeness")),
+            {"state": state, "limitation_count": len(limitations)},
+        ),
+        _check(
+            "source_artifact_audit",
+            "source_provider_audit",
+            "warning" if source_audit_result["config_fallback_metadata_present"] else "not_evaluated",
+            "Config/fallback metadata is separate from unavailable raw provider/parser audit metadata."
+            if source_audit_result["config_fallback_metadata_present"]
+            else "No config, fallback, raw provider, or parser audit metadata is available.",
+            "Raw provider/parser audit coverage is unavailable in current persisted run artifacts.",
+            _refs(("config_sources", "config_sources"), ("fallback_audit", "fallback_audit")),
+            source_audit_result,
+        ),
+        _check(
+            "text_evidence_summary",
+            "evidence_summary",
+            "warning" if text_sources else "not_evaluated",
+            "Persisted warning or caveat text was summarized from the same response surface."
+            if text_sources
+            else "No persisted warning, caveat, or source text exists on this response surface.",
+            "No generated advice text is used.",
+            text_result["source_artifact_references"] or _refs(("warnings", "warnings")),
+            text_result,
+        ),
+    ]
+    boundary_present = _manual_boundary_present(*_opinion_texts(payload, rows, checks))
+    for item in checks:
+        if item["check"] == "manual_adoption_boundary":
+            item["status"] = "pass" if boundary_present else "fail"
+            item["risk_or_warning"] = (
+                "Forbidden execution or advice wording blocks manual-adoption boundary."
+                if not boundary_present
+                else "Manual adoption boundary is preserved."
+            )
+            item["result"] = {
+                "manual_adoption_only": True,
+                "forbidden_language_found": not boundary_present,
+                "scanned_review_check_copy": True,
+            }
+        elif item["check"] == "backtest_report_discipline":
+            item["result"]["research_only_boundary_present"] = boundary_present
+            if not boundary_present:
+                item["risk_or_warning"] = (
+                    "Caveats, missing policy metadata, or boundary wording prevent a clean pass."
+                )
+            if (
+                item["result"]["metric_keys"]
+                and item["result"]["threshold_policy_version_present"]
+                and item["result"]["price_basis_version_present"]
+                and boundary_present
+                and item["result"]["caveat_count"] == 0
+            ):
+                item["status"] = "pass"
+            elif item["result"]["metric_keys"]:
+                item["status"] = "warning"
+            else:
+                item["status"] = "fail"
+    return checks
+
+
+def _empty_artifact(
+    state: str,
+    reason: str,
+    limitations: list[str],
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {
+        "artifact_version": OPINION_ARTIFACT_VERSION,
+        "state": state,
+        "state_reason": reason,
+        "manual_adoption_only": True,
+        "evidence_limitations": limitations,
+        "buy_candidates": [],
+        "sell_or_avoid": [],
+        "watch": [],
+        "review_checks": _review_checks(payload, [], state, limitations),
+    }
+
+
+def build_opinion_artifact(payload: Mapping[str, Any]) -> dict[str, Any]:
+    if payload.get("summary_only"):
+        return {
+            "artifact_version": OPINION_ARTIFACT_VERSION,
+            "state": "no-opinion",
+            "state_reason": OMITTED_DETAIL_LIMITATION,
+            "manual_adoption_only": True,
+            "evidence_limitations": [OMITTED_DETAIL_LIMITATION],
+            "buy_candidates": [],
+            "sell_or_avoid": [],
+            "watch": [],
+            "review_checks": _summary_checks(),
+        }
+
+    limitations: list[str] = []
+    status = payload.get("status")
+    completeness = payload.get("artifact_completeness")
+    if status is not None and status != "succeeded":
+        limitations.append(f"Run status is {status}; artifacts are not adoptable.")
+    if completeness != "complete":
+        missing = [str(item) for item in _as_list(payload.get("missing_artifacts"))]
+        detail = f" Missing artifacts: {', '.join(missing)}." if missing else ""
+        limitations.append(f"Artifact completeness is {completeness}.{detail}")
+    if not _as_mapping(payload.get("metrics")):
+        limitations.append("Strategy metrics artifact is unavailable.")
+    if not _as_mapping(payload.get("model_diagnostics")):
+        limitations.append("Model diagnostics artifact is unavailable.")
+    if not _as_list(payload.get("signals")):
+        limitations.append("Signal artifact is unavailable.")
+    if payload.get("stale_mark_days_with_open_positions") or payload.get("stale_risk_share"):
+        limitations.append("Stale mark risk is present in persisted artifacts.")
+
+    if status is not None and status != "succeeded":
+        return _empty_artifact(
+            "do-not-adopt",
+            "Research run did not complete successfully.",
+            limitations,
+            payload,
+        )
+    if limitations:
+        return _empty_artifact(
+            "no-opinion",
+            "Persisted artifacts are insufficient for a traceable opinion.",
+            limitations,
+            payload,
+        )
+
+    rows = _action_rows(payload)
+    if not rows:
+        limitations = ["Signal rows lacked symbol, score, or position fields."]
+        return _empty_artifact(
+            "no-opinion",
+            "No valid symbol-level signal rows were available.",
+            limitations,
+            payload,
+        )
+
+    buy_candidates = [row for row in rows if row["position_signal"] > 0]
+    sell_or_avoid = [row for row in rows if row["position_signal"] < 0]
+    watch = [row for row in rows if row["position_signal"] == 0]
+    artifact = {
+        "artifact_version": OPINION_ARTIFACT_VERSION,
+        "state": "viable",
+        "state_reason": "Complete persisted research artifacts support traceable opinion rows.",
+        "manual_adoption_only": True,
+        "evidence_limitations": [],
+        "buy_candidates": buy_candidates,
+        "sell_or_avoid": sell_or_avoid,
+        "watch": watch,
+    }
+    artifact["review_checks"] = _review_checks(
+        {**payload, "state_reason": artifact["state_reason"]},
+        rows,
+        "viable",
+        [],
+    )
+    if any(item["status"] == "fail" for item in artifact["review_checks"]):
+        artifact["state"] = "no-opinion"
+        artifact["state_reason"] = "Self-review gates blocked a viable opinion."
+        artifact["evidence_limitations"] = [
+            "One or more self-review gates failed; reload details before adopting."
+        ]
+        artifact["buy_candidates"] = []
+        artifact["sell_or_avoid"] = []
+        artifact["watch"] = []
+    return artifact

--- a/backend/research/domain/opinion.py
+++ b/backend/research/domain/opinion.py
@@ -342,6 +342,11 @@ def _opinion_texts(
     checks: list[dict[str, Any]] | None = None,
 ) -> list[str]:
     texts = [str(payload.get("state_reason", ""))]
+    for field, value in payload.items():
+        if field in {"execution_route", "tradability_state"} or field.startswith(
+            "live_control_"
+        ):
+            texts.extend(_string_values(value))
     for row in rows:
         texts.extend(
             str(row.get(field, ""))

--- a/backend/research/repositories/runs.py
+++ b/backend/research/repositories/runs.py
@@ -12,16 +12,17 @@ from backend.database import (
     ResearchRunLiquidityCoverage,
     SessionLocal,
 )
-from backend.research.domain.artifact_summary import build_review_artifact_summary
-from backend.research.domain.version_pack import build_version_pack_payload
-from backend.platform.errors import DataAccessError, DataNotFoundError
-from backend.platform.time import utc_now
 from backend.platform.db.repository_helpers import (
     clone_payload,
     json_dumps,
     json_loads,
     normalize_created_at,
 )
+from backend.platform.errors import DataAccessError, DataNotFoundError
+from backend.platform.time import utc_now
+from backend.research.domain.artifact_summary import build_review_artifact_summary
+from backend.research.domain.opinion import build_opinion_artifact
+from backend.research.domain.version_pack import build_version_pack_payload
 
 logger = logging.getLogger(__name__)
 
@@ -127,7 +128,9 @@ def _review_artifact_summary_from_row(
     )
 
 
-def _run_row_to_dict(row: ResearchRun, *, include_artifacts: bool = True) -> dict[str, Any]:
+def _run_row_to_dict(
+    row: ResearchRun, *, include_artifacts: bool = True
+) -> dict[str, Any]:
     effective_strategy = None
     if row.effective_threshold is not None and row.effective_top_n is not None:
         effective_strategy = {
@@ -138,6 +141,10 @@ def _run_row_to_dict(row: ResearchRun, *, include_artifacts: bool = True) -> dic
     validation_outcome = json_loads(row.validation_outcome_json, None)
     model_diagnostics = json_loads(row.model_diagnostics_json, None)
     request_payload = json_loads(row.request_payload_json, None)
+    metrics = json_loads(row.metrics_json, None)
+    signals = json_loads(row.signals_json, [])
+    baselines = json_loads(row.baselines_json, {})
+    warnings = json_loads(row.warnings_json, [])
     payload = {
         "run_id": row.run_id,
         "request_id": row.request_id,
@@ -154,17 +161,17 @@ def _run_row_to_dict(row: ResearchRun, *, include_artifacts: bool = True) -> dic
         "validation_outcome": validation_outcome,
         "rejection_reason": row.rejection_reason,
         "request_payload": request_payload,
-        "metrics": json_loads(row.metrics_json, None),
+        "metrics": metrics,
         "equity_curve": json_loads(row.equity_curve_json, [])
         if include_artifacts
         else [],
-        "signals": json_loads(row.signals_json, []) if include_artifacts else [],
+        "signals": signals if include_artifacts else [],
         "validation": _validation_summary_from_payload(validation_outcome),
         "model_diagnostics": _model_diagnostics_from_payload(model_diagnostics)
         if include_artifacts
         else _summarize_model_diagnostics(model_diagnostics),
-        "baselines": json_loads(row.baselines_json, {}),
-        "warnings": json_loads(row.warnings_json, []),
+        "baselines": baselines,
+        "warnings": warnings,
         "factor_catalog_version": row.factor_catalog_version,
         "scoring_factor_ids": json_loads(row.scoring_factor_ids_json, []),
         "external_signal_policy_version": row.external_signal_policy_version,
@@ -253,6 +260,20 @@ def _run_row_to_dict(row: ResearchRun, *, include_artifacts: bool = True) -> dic
             }
         )
     )
+    payload["opinion_artifact"] = build_opinion_artifact(
+        {
+            **payload,
+            "summary_only": not include_artifacts,
+            "signals": signals if include_artifacts else [],
+            "warnings": warnings if include_artifacts else [],
+            "comparison_caveats": payload["comparison_caveats"]
+            if include_artifacts
+            else [],
+            "model_diagnostics": _model_diagnostics_from_payload(model_diagnostics)
+            if include_artifacts
+            else None,
+        }
+    )
     return payload
 
 
@@ -309,9 +330,7 @@ def persist_research_run_record(payload: dict[str, Any]) -> dict[str, Any]:
             row.metrics_json = json_dumps(record.get("metrics"))
             row.equity_curve_json = json_dumps(record.get("equity_curve", []))
             row.signals_json = json_dumps(record.get("signals", []))
-            row.model_diagnostics_json = json_dumps(
-                record.get("model_diagnostics")
-            )
+            row.model_diagnostics_json = json_dumps(record.get("model_diagnostics"))
             row.baselines_json = json_dumps(record.get("baselines", {}))
             row.warnings_json = json_dumps(record.get("warnings", []))
             row.factor_catalog_version = record.get("factor_catalog_version")

--- a/backend/research/repositories/runs.py
+++ b/backend/research/repositories/runs.py
@@ -142,7 +142,7 @@ def _run_row_to_dict(
     model_diagnostics = json_loads(row.model_diagnostics_json, None)
     request_payload = json_loads(row.request_payload_json, None)
     metrics = json_loads(row.metrics_json, None)
-    signals = json_loads(row.signals_json, [])
+    signals = json_loads(row.signals_json, []) if include_artifacts else []
     baselines = json_loads(row.baselines_json, {})
     warnings = json_loads(row.warnings_json, [])
     payload = {
@@ -261,18 +261,7 @@ def _run_row_to_dict(
         )
     )
     payload["opinion_artifact"] = build_opinion_artifact(
-        {
-            **payload,
-            "summary_only": not include_artifacts,
-            "signals": signals if include_artifacts else [],
-            "warnings": warnings if include_artifacts else [],
-            "comparison_caveats": payload["comparison_caveats"]
-            if include_artifacts
-            else [],
-            "model_diagnostics": _model_diagnostics_from_payload(model_diagnostics)
-            if include_artifacts
-            else None,
-        }
+        {**payload, "summary_only": not include_artifacts}
     )
     return payload
 

--- a/backend/research/services/runs.py
+++ b/backend/research/services/runs.py
@@ -47,31 +47,9 @@ def _response_with_artifact_summary(
         },
     )
     opinion_payload = {
+        **response.model_dump(mode="json", exclude={"opinion_artifact"}),
         "status": "succeeded",
         "request_payload": request.model_dump(mode="json"),
-        "effective_strategy": response.effective_strategy.model_dump(mode="json"),
-        "metrics": response.metrics.model_dump(mode="json"),
-        "model_diagnostics": response.model_diagnostics.model_dump(mode="json")
-        if response.model_diagnostics
-        else None,
-        "signals": [item.model_dump(mode="json") for item in response.signals],
-        "validation": response.validation.model_dump(mode="json")
-        if response.validation
-        else None,
-        "baselines": response.baselines,
-        "warnings": response.warnings,
-        "config_sources": response.config_sources.model_dump(mode="json"),
-        "fallback_audit": response.fallback_audit.model_dump(mode="json"),
-        "execution_route": response.execution_route,
-        "tradability_state": response.tradability_state,
-        "live_control_profile_id": response.live_control_profile_id,
-        "live_control_version": response.live_control_version,
-        "stale_mark_days_with_open_positions": (
-            response.stale_mark_days_with_open_positions
-        ),
-        "stale_risk_share": response.stale_risk_share,
-        "threshold_policy_version": response.threshold_policy_version,
-        "price_basis_version": response.price_basis_version,
         **summary,
     }
     return response.model_copy(

--- a/backend/research/services/runs.py
+++ b/backend/research/services/runs.py
@@ -62,6 +62,10 @@ def _response_with_artifact_summary(
         "warnings": response.warnings,
         "config_sources": response.config_sources.model_dump(mode="json"),
         "fallback_audit": response.fallback_audit.model_dump(mode="json"),
+        "execution_route": response.execution_route,
+        "tradability_state": response.tradability_state,
+        "live_control_profile_id": response.live_control_profile_id,
+        "live_control_version": response.live_control_version,
         "stale_mark_days_with_open_positions": (
             response.stale_mark_days_with_open_positions
         ),

--- a/backend/research/services/runs.py
+++ b/backend/research/services/runs.py
@@ -5,15 +5,17 @@ from typing import Any, Callable
 from uuid import uuid4
 
 from backend.platform.errors import BacktestError, DataAccessError
-from backend.research.domain.artifact_summary import build_review_artifact_summary
-from backend.research.repositories.runs import (
-    get_research_run_record,
-    list_research_run_records,
-)
 from backend.research.contracts.runs import (
+    OpinionArtifact,
     ResearchRunCreateRequest,
     ResearchRunRecordResponse,
     ResearchRunResponse,
+)
+from backend.research.domain.artifact_summary import build_review_artifact_summary
+from backend.research.domain.opinion import build_opinion_artifact
+from backend.research.repositories.runs import (
+    get_research_run_record,
+    list_research_run_records,
 )
 from backend.research.services.execution import execute_research_run
 from backend.research.services.registry import (
@@ -44,7 +46,34 @@ def _response_with_artifact_summary(
             "baselines": isinstance(response.baselines, dict),
         },
     )
-    return response.model_copy(update=summary)
+    opinion_payload = {
+        "status": "succeeded",
+        "request_payload": request.model_dump(mode="json"),
+        "effective_strategy": response.effective_strategy.model_dump(mode="json"),
+        "metrics": response.metrics.model_dump(mode="json"),
+        "model_diagnostics": response.model_diagnostics.model_dump(mode="json")
+        if response.model_diagnostics
+        else None,
+        "signals": [item.model_dump(mode="json") for item in response.signals],
+        "validation": response.validation.model_dump(mode="json")
+        if response.validation
+        else None,
+        "baselines": response.baselines,
+        "warnings": response.warnings,
+        "config_sources": response.config_sources.model_dump(mode="json"),
+        "fallback_audit": response.fallback_audit.model_dump(mode="json"),
+        "threshold_policy_version": response.threshold_policy_version,
+        "price_basis_version": response.price_basis_version,
+        **summary,
+    }
+    return response.model_copy(
+        update={
+            **summary,
+            "opinion_artifact": OpinionArtifact.model_validate(
+                build_opinion_artifact(opinion_payload)
+            ),
+        }
+    )
 
 
 def _record_registry_event(

--- a/backend/research/services/runs.py
+++ b/backend/research/services/runs.py
@@ -62,6 +62,10 @@ def _response_with_artifact_summary(
         "warnings": response.warnings,
         "config_sources": response.config_sources.model_dump(mode="json"),
         "fallback_audit": response.fallback_audit.model_dump(mode="json"),
+        "stale_mark_days_with_open_positions": (
+            response.stale_mark_days_with_open_positions
+        ),
+        "stale_risk_share": response.stale_risk_share,
         "threshold_policy_version": response.threshold_policy_version,
         "price_basis_version": response.price_basis_version,
         **summary,

--- a/backend/shared/analytics/backtest.py
+++ b/backend/shared/analytics/backtest.py
@@ -54,10 +54,12 @@ def match_price(
 def build_signals(scores: pd.DataFrame, weights: pd.DataFrame) -> List[dict]:
     signals: List[dict] = []
     for dt, row in weights.iterrows():
-        active = row[row > 0]
-        if active.empty:
+        positions = row[row > 0]
+        if dt == weights.index[-1]:
+            positions = row.reindex(scores.loc[dt].dropna().index).fillna(0.0)
+        if positions.empty:
             continue
-        for symbol, position in active.items():
+        for symbol, position in positions.items():
             score = scores.at[dt, symbol]
             signals.append(
                 {

--- a/backend/shared/analytics/backtest.py
+++ b/backend/shared/analytics/backtest.py
@@ -56,7 +56,9 @@ def build_signals(scores: pd.DataFrame, weights: pd.DataFrame) -> List[dict]:
     for dt, row in weights.iterrows():
         positions = row[row > 0]
         if dt == weights.index[-1]:
-            positions = row.reindex(scores.loc[dt].dropna().index).fillna(0.0)
+            positions = row.reindex(
+                positions.index.union(scores.loc[dt].dropna().index)
+            ).fillna(0.0)
         if positions.empty:
             continue
         for symbol, position in positions.items():

--- a/docs/decision-register.md
+++ b/docs/decision-register.md
@@ -35,12 +35,32 @@ stable across multiple implementation tasks.
 | `DEC-V1-011` | retained platform-era code is internal foundation inventory | accepted | code, metadata fields, and docs may mention execution, adaptive, peer, factor, external-signal, or tick foundations only as compatibility or future-promoted surfaces, not as v1 product commitments |
 | `DEC-V1-012` | artifact completeness is derived, not migrated | accepted | run review and compare use `artifact_completeness`, artifact lists, and backend caveats derived from existing row JSON fields |
 
+## Accepted Phase Direction Decisions
+
+| ID | Decision | Status | Impact |
+| --- | --- | --- | --- |
+| `DEC-PHASE-001` | External trading and research tools are reference material, not default dependencies | accepted | Jesse, UZI-Skill, a-stock-data, OpenBB, FinGPT, FinRL, and similar projects may inform local contracts and methods, but their runtimes should not be integrated by default |
+| `DEC-PHASE-002` | Jesse-style methods are valid research-method inputs | accepted | Strategy lifecycle, signal-to-position translation, robustness checks, parameter sensitivity, and backtest-report discipline may inform a future research method library without adopting Jesse's live trading runtime |
+| `DEC-PHASE-003` | Phase 2 prioritizes backend opinion artifacts before frontend expansion | accepted | Next product work should synthesize diagnostics, signals, backtests, baselines, and warnings into decision-useful opinion artifacts before adding large UI surfaces |
+| `DEC-PHASE-004` | Live trading concepts are deferred but retained for later guarded execution planning | accepted | Broker execution, live orders, paper/live separation, order lifecycle, reconciliation, audit logs, kill switches, and manual confirmations stay out of the current phase but remain reference material for future guarded execution work |
+| `DEC-PHASE-005` | Portfolio automation is deferred behind manual adoption tracking | accepted | Nearer-term portfolio work should record manual adoption, forward outcomes, and portfolio impact before any automatic rebalancing or account-control behavior |
+
 ## Open V1 Decisions
 
 | ID | Topic | Owner area | Blocks | Next action |
 | --- | --- | --- | --- | --- |
 | `TBD-V1-002` | persisted artifact retention and size bounds | research persistence | long-running experiment history, not the current usable loop | define whether diagnostic samples, signals, and equity curves are stored fully or bounded per run |
 | `TBD-V1-003` | comparison reason hardening | experiments UX | richer pairwise explanations, not basic compare usability | extend backend caveats beyond artifact completeness and keep UI-derived assumption mismatch labels aligned |
+
+## Open Phase Direction Decisions
+
+| ID | Topic | Owner area | Blocks | Acceptance trigger |
+| --- | --- | --- | --- | --- |
+| `TBD-PHASE-001` | research method library first slice | research services | Phase 2 method sequencing, not current v1 usability | accepted when the first method slice names its input artifacts, output artifact, validation check, persistence behavior, and comparison caveats |
+| `TBD-PHASE-002` | opinion artifact implementation schema and persistence path | research contracts | Phase 2 opinion artifact implementation | accepted when the `SPEC-OPINION-*` contract is mapped to exact serialized fields, persistence location, reload behavior, and API response shape |
+| `TBD-PHASE-003` | portfolio ledger and manual adoption model | portfolio research | Phase 3 feedback loop | accepted when manual adoption record fields, holdings context, forward outcome comparison, and portfolio-impact reporting are specified without automatic trading |
+| `TBD-PHASE-004` | guarded broker and live-order promotion criteria | execution planning | future guarded execution only | accepted when safety, audit, reconciliation, idempotency, manual-confirmation, and kill-switch gates are documented before broker integration can enter active planning |
+| `TBD-PHASE-005` | US daily data-source strategy | market expansion | US daily future lane | accepted when source contracts, raw-payload audit rules, market-calendar policy, and TW/US comparison semantics are documented |
 
 ## Deferred Platform Decisions
 
@@ -54,6 +74,8 @@ them into the main workflow.
 | `TBD-002` | tick archive storage details | open | data platform | needed before durable tick archive operational qualification |
 | `TBD-003` | simulation platform choice | open | execution integration | needed before simulation readback or execution platform qualification |
 | `TBD-004` | cross-model missing-feature default policy | open | model governance | needed before broad cross-family model governance |
+| `TBD-005` | guarded broker execution safety model | open | execution integration | needed before live-order routing, broker reconciliation, manual confirmation, or kill-switch behavior |
+| `TBD-006` | portfolio auto-control boundary | open | portfolio research | needed before any automatic rebalancing, position sizing against real holdings, or account-control behavior |
 
 ## Deferred Decision Details
 
@@ -98,3 +120,26 @@ them into the main workflow.
 - Next action:
   define the shared default behavior or explicitly decide no shared default
   will exist.
+
+### TBD-005
+
+- Topic: guarded broker execution safety model
+- Status: open
+- Deferred scope:
+  broker connectivity, live orders, order lifecycle reconciliation,
+  idempotent order submission, audit logs, kill switches, and required manual
+  confirmations.
+- Next action:
+  define a guarded execution safety model before any broker or live-order
+  integration moves into active planning.
+
+### TBD-006
+
+- Topic: portfolio auto-control boundary
+- Status: open
+- Deferred scope:
+  automatic rebalancing, account-level position sizing, holdings-aware order
+  generation, and portfolio control loops.
+- Next action:
+  define manual adoption tracking and portfolio-impact measurement before
+  considering automatic portfolio controls.

--- a/docs/decision-register.md
+++ b/docs/decision-register.md
@@ -40,11 +40,12 @@ stable across multiple implementation tasks.
 | ID | Decision | Status | Impact |
 | --- | --- | --- | --- |
 | `DEC-PHASE-001` | External trading and research tools are reference material, not default dependencies | accepted | Jesse, UZI-Skill, a-stock-data, OpenBB, FinGPT, FinRL, and similar projects may inform local contracts and methods, but their runtimes should not be integrated by default |
-| `DEC-PHASE-002` | Jesse-style methods are valid research-method inputs | accepted | Strategy lifecycle, signal-to-position translation, robustness checks, parameter sensitivity, and backtest-report discipline may inform a future research method library without adopting Jesse's live trading runtime |
+| `DEC-PHASE-002` | Jesse-style methods are valid research-method inputs | accepted | Strategy lifecycle, signal-to-position translation, robustness checks, parameter sensitivity, and backtest-report discipline are implemented locally without adopting Jesse's live trading runtime |
 | `DEC-PHASE-003` | Phase 2 prioritizes backend opinion artifacts before frontend expansion | accepted | Next product work should synthesize diagnostics, signals, backtests, baselines, and warnings into decision-useful opinion artifacts before adding large UI surfaces |
 | `DEC-PHASE-004` | Live trading concepts are deferred but retained for later guarded execution planning | accepted | Broker execution, live orders, paper/live separation, order lifecycle, reconciliation, audit logs, kill switches, and manual confirmations stay out of the current phase but remain reference material for future guarded execution work |
 | `DEC-PHASE-005` | Portfolio automation is deferred behind manual adoption tracking | accepted | Nearer-term portfolio work should record manual adoption, forward outcomes, and portfolio impact before any automatic rebalancing or account-control behavior |
 | `DEC-PHASE-006` | Phase 2 opinion artifact contract and reconstruction path are fixed | accepted | `opinion_artifact` serializes state, action rows, source references, and review checks in research responses; POST builds from current response artifacts, detail reload reconstructs from persisted run artifacts, and list responses remain summary-only |
+| `DEC-PHASE-007` | The first local research-method slice is accepted | accepted | Persisted request, strategy, diagnostic, signal, metric, validation, baseline, warning, and comparison-caveat artifacts feed `opinion_artifact.review_checks`; focused contract, domain, and API validation covers the slice, detail reload reconstructs it deterministically, and comparison caveats remain explicit |
 
 ## Open V1 Decisions
 
@@ -57,7 +58,6 @@ stable across multiple implementation tasks.
 
 | ID | Topic | Owner area | Blocks | Acceptance trigger |
 | --- | --- | --- | --- | --- |
-| `TBD-PHASE-001` | research method library first slice | research services | Phase 2 method sequencing, not current v1 usability | accepted when the first method slice names its input artifacts, output artifact, validation check, persistence behavior, and comparison caveats |
 | `TBD-PHASE-003` | portfolio ledger and manual adoption model | portfolio research | Phase 3 feedback loop | accepted when manual adoption record fields, holdings context, forward outcome comparison, and portfolio-impact reporting are specified without automatic trading |
 | `TBD-PHASE-004` | guarded broker and live-order promotion criteria | execution planning | future guarded execution only | accepted when safety, audit, reconciliation, idempotency, manual-confirmation, and kill-switch gates are documented before broker integration can enter active planning |
 | `TBD-PHASE-005` | US daily data-source strategy | market expansion | US daily future lane | accepted when source contracts, raw-payload audit rules, market-calendar policy, and TW/US comparison semantics are documented |

--- a/docs/decision-register.md
+++ b/docs/decision-register.md
@@ -44,6 +44,7 @@ stable across multiple implementation tasks.
 | `DEC-PHASE-003` | Phase 2 prioritizes backend opinion artifacts before frontend expansion | accepted | Next product work should synthesize diagnostics, signals, backtests, baselines, and warnings into decision-useful opinion artifacts before adding large UI surfaces |
 | `DEC-PHASE-004` | Live trading concepts are deferred but retained for later guarded execution planning | accepted | Broker execution, live orders, paper/live separation, order lifecycle, reconciliation, audit logs, kill switches, and manual confirmations stay out of the current phase but remain reference material for future guarded execution work |
 | `DEC-PHASE-005` | Portfolio automation is deferred behind manual adoption tracking | accepted | Nearer-term portfolio work should record manual adoption, forward outcomes, and portfolio impact before any automatic rebalancing or account-control behavior |
+| `DEC-PHASE-006` | Phase 2 opinion artifact contract and reconstruction path are fixed | accepted | `opinion_artifact` serializes state, action rows, source references, and review checks in research responses; POST builds from current response artifacts, detail reload reconstructs from persisted run artifacts, and list responses remain summary-only |
 
 ## Open V1 Decisions
 
@@ -57,7 +58,6 @@ stable across multiple implementation tasks.
 | ID | Topic | Owner area | Blocks | Acceptance trigger |
 | --- | --- | --- | --- | --- |
 | `TBD-PHASE-001` | research method library first slice | research services | Phase 2 method sequencing, not current v1 usability | accepted when the first method slice names its input artifacts, output artifact, validation check, persistence behavior, and comparison caveats |
-| `TBD-PHASE-002` | opinion artifact implementation schema and persistence path | research contracts | Phase 2 opinion artifact implementation | accepted when the `SPEC-OPINION-*` contract is mapped to exact serialized fields, persistence location, reload behavior, and API response shape |
 | `TBD-PHASE-003` | portfolio ledger and manual adoption model | portfolio research | Phase 3 feedback loop | accepted when manual adoption record fields, holdings context, forward outcome comparison, and portfolio-impact reporting are specified without automatic trading |
 | `TBD-PHASE-004` | guarded broker and live-order promotion criteria | execution planning | future guarded execution only | accepted when safety, audit, reconciliation, idempotency, manual-confirmation, and kill-switch gates are documented before broker integration can enter active planning |
 | `TBD-PHASE-005` | US daily data-source strategy | market expansion | US daily future lane | accepted when source contracts, raw-payload audit rules, market-calendar policy, and TW/US comparison semantics are documented |

--- a/docs/deferred-feature-plan.md
+++ b/docs/deferred-feature-plan.md
@@ -49,7 +49,7 @@ or Experiments workflow.
 
 | Candidate | Current decision | Re-entry question |
 | --- | --- | --- |
-| Broker or live-order execution | deferred | Does this help research analysis, or is it a separate trading product? |
+| Broker or live-order execution | deferred | What guarded execution safety model, reconciliation, audit, kill-switch, and manual-confirmation rules are required before this becomes active? |
 | Simulation-platform integration | deferred | Which simulator is the baseline, and what comparison artifact does it produce? |
 | Adaptive or RL workflow | deferred | What researcher decision does adaptation explain better than static experiments? |
 | Peer inference and clustering | deferred | Which v1 analysis question needs peer context, and how is leakage avoided? |
@@ -57,6 +57,51 @@ or Experiments workflow.
 | External-signal breadth | deferred | Which signal timing and audit rules make it research-safe? |
 | Tick archive and intraday strategy UX | deferred | Is intraday analysis part of a future product, or only a data-foundation tool? |
 | Data-control completeness | deferred | Which controls are needed for the workbench user, not platform admins? |
+| Portfolio auto-control | deferred | What manual adoption and portfolio-impact evidence must exist before automatic controls are considered? |
+| US daily parity | deferred | Which market-calendar, raw-source audit, and provider-contract rules are required before US daily becomes active scope? |
+
+## External Reference Inventory
+
+External projects can inform local method design, data contracts, and future
+phase planning. They are not default dependencies, runtime platforms, or proof
+that a deferred capability belongs in the current workflow.
+
+| Reference | Keep for later | Do not import now |
+| --- | --- | --- |
+| `Jesse` | strategy lifecycle, signal-to-position translation, robustness checks, parameter sensitivity, backtest-report discipline, paper/live separation, order lifecycle concepts | trading framework runtime, exchange adapters, live trading loop, crypto assumptions |
+| `UZI-Skill` | multi-angle report structure, self-review gates, evidence/risk/invalidation sections, compact stock-analysis brief patterns | skill runtime, report generator dependency, personalized advice claims |
+| `a-stock-data` | data-source catalog, raw-payload traceability, parser versions, source fallback patterns, zero-key source caveats | A-share-specific endpoint layer, unofficial scraping assumptions, broad data platform scope |
+| `OpenBB` | provider abstraction, source-agnostic data access, future US daily source planning | full SDK or terminal integration before source contracts are chosen |
+| `FinGPT` | text evidence extraction, research-report summarization, risk/warning/invalidation support | LLM-generated trade decisions or unverified investment advice |
+| `FinRL` | train/test/trade separation, environment separation, benchmark and policy evaluation concepts | RL/adaptive control workflow before static research opinions are useful |
+| `Hummingbot` and `Freqtrade` | far-future execution safety references only if guarded execution becomes active | crypto trading bot behavior, market-making runtime, live execution as a product shortcut |
+
+## Promotion Criteria
+
+These criteria define when a reference or deferred capability can move from
+planning inventory into active implementation. Meeting these criteria does not
+automatically promote the feature; it makes the feature eligible for an update
+to `docs/plan.md` and `docs/validation-gates.md`.
+
+| Candidate | Can enter active planning when | Must stay deferred when |
+| --- | --- | --- |
+| Research method library | the first method uses existing persisted research artifacts, defines its output artifact, includes a validation check, and preserves comparison caveats | the method requires a new external runtime, new data platform, or live execution loop |
+| Jesse-style methods | the idea is implemented locally as strategy lifecycle, signal-to-position translation, robustness check, parameter sensitivity, or report discipline | the proposal imports Jesse runtime, exchange adapters, crypto assumptions, or live trading behavior |
+| UZI-Skill-style reporting | the report pattern maps to opinion rows with evidence, risk, invalidation, and self-review checks | the proposal depends on the skill runtime, generated advice copy, or untraceable report conclusions |
+| a-stock-data-style intake | the source can be represented through raw payload preservation, parser version, fetch status, and source fallback metadata | the source relies on unreviewed scraping, market-specific shortcuts, or broad data-control UX |
+| OpenBB-style provider abstraction | the provider contract is market-aware, source-audited, and useful for TW daily or a documented US daily expansion | the proposal adds a full terminal or SDK integration before source contracts are chosen |
+| FinGPT-style evidence extraction | text evidence is traceable to source material and supports evidence reason, risk, warning, or invalidation fields | LLM output produces unverified trade decisions or personalized advice |
+| FinRL or adaptive methods | a static opinion baseline exists and the policy-evaluation artifact, benchmark, and rollback criteria are specified | adaptive behavior would alter live decisions, strategy controls, or portfolio actions without a research-only evaluation contract |
+| Broker or live-order execution | safety model, idempotency, reconciliation, audit logs, manual confirmation, and kill switch gates are documented and accepted | the feature is proposed as a shortcut from opinion output to orders |
+| Portfolio auto-control | manual adoption tracking and portfolio-impact measurement already exist and define the evidence needed for automatic controls | the feature would rebalance, size positions, or control accounts before manual-adoption evidence exists |
+| US daily parity | market calendar, provider contract, raw-source audit, and TW/US comparison semantics are documented | the work is only a provider swap without data-readiness and comparability rules |
+
+## Near-Term Interpretation
+
+The next backend-oriented product slice should treat external references as
+method inputs for a local research method library and opinion artifact contract.
+It should not add new external runtimes, frontend surfaces, broker connectors,
+or account-control behavior.
 
 ## Current Todo
 

--- a/docs/research-spec.md
+++ b/docs/research-spec.md
@@ -39,6 +39,9 @@ The v1 spec has six layers:
 5. Offline backtest contract
 6. Persisted experiment and comparison contract
 
+Phase 2 adds an opinion layer on top of the persisted research artifacts. The
+opinion layer is not a broker, live-order, or portfolio-control contract.
+
 ## Dataset Contract
 
 ### SPEC-DATA-001: TW daily default
@@ -301,6 +304,80 @@ hide model diagnostics or persisted artifacts.
 Artifact completeness caveats are blocking comparison context. A run that is
 `partial` or `metadata_only`, or a run that did not finish successfully, must
 not be treated as a complete comparable result.
+
+## Phase 2 Opinion Contract
+
+### SPEC-OPINION-001: Opinion artifact shape
+
+A Phase 2 opinion artifact must be derived from an existing persisted research
+run. It must include:
+
+- strategy-level opinion state: `viable`, `no-opinion`, or `do-not-adopt`
+- buy-candidate list
+- sell-or-avoid list
+- watch list
+- evidence and risk context for each populated list item
+- invalidation notes explaining when the opinion should not be adopted
+
+Each populated symbol row must include:
+
+- symbol
+- model score
+- strategy-derived weight or position signal
+- evidence reason
+- risk or warning
+- invalidation note
+- source artifact references
+
+Candidate lists may be empty. If the evidence is insufficient, the artifact
+must return `no-opinion` or `do-not-adopt` instead of forcing a buy, sell, or
+watch result.
+
+### SPEC-OPINION-002: Evidence traceability
+
+Each populated opinion row must point back to at least one persisted research
+artifact that explains the row. Valid source artifact families include:
+
+- model diagnostics
+- score, prediction, signal, or position output
+- strategy metrics
+- baseline deltas
+- validation summary
+- warnings
+- artifact completeness or comparison caveats
+
+When a required artifact is missing, partial, metadata-only, or not evaluated,
+the opinion artifact must make that limitation visible through the evidence
+reason, risk or warning, invalidation note, or strategy-level state.
+
+### SPEC-OPINION-003: Research-method references
+
+External tools may inform local research methods, but they must not become
+implicit runtime dependencies. Jesse-style strategy lifecycle, signal-to-position
+translation, robustness checks, parameter sensitivity, and report discipline may
+be implemented locally when they improve opinion quality.
+
+Research methods added from external references must preserve:
+
+- persisted request and result artifacts
+- model-first diagnostics before strategy claims
+- offline backtest posture
+- explicit source, version, or policy metadata
+- comparison caveats when assumptions differ
+
+### SPEC-OPINION-004: Opinion boundary
+
+An opinion artifact is a model-backed research opinion for manual adoption. It
+must not imply:
+
+- personalized investment advice
+- broker routing
+- live-order readiness
+- automatic rebalancing
+- account-level portfolio control
+
+Direct action-language labels are allowed only when the artifact preserves the
+manual-adoption boundary and can also output `no-opinion` or `do-not-adopt`.
 
 ## Hidden Advanced Modules
 

--- a/docs/validation-gates.md
+++ b/docs/validation-gates.md
@@ -30,7 +30,9 @@ researcher to create, inspect, reload, and compare TW daily ML experiments.
 - `KPI-RESEARCH-*`: persisted experiment completeness
 - `KPI-COMP-*`: experiment comparison clarity
 - `KPI-COST-*`: offline backtest cost and price-assumption completeness
+- `KPI-OPINION-*`: Phase 2 opinion artifact usefulness and safety
 - `GATE-V1-*`: v1 acceptance gates
+- `GATE-P2-*`: Phase 2 opinion-layer acceptance gates
 
 The following families are not v1 pass/fail gates:
 
@@ -60,6 +62,9 @@ drive the default workbench workflow.
 - Old-run fallback rule: older records without artifacts pass only when the API
   marks them `metadata_only` or `partial` and the UI clearly labels missing
   artifacts as unavailable on the record.
+- Opinion artifact rule: a Phase 2 opinion artifact passes only when it is
+  traceable to persisted research artifacts and can produce `no-opinion` or
+  `do-not-adopt` when evidence is insufficient.
 
 ## KPI Dictionary
 
@@ -101,6 +106,16 @@ drive the default workbench workflow.
 | --- | --- | --- | --- |
 | `KPI-COST-001` | cost-model completeness | fees, slippage, and cost-model version are present or explicitly unavailable | required |
 | `KPI-COST-002` | price-basis clarity | label, entry, exit, and benchmark price-basis fields are present or explicitly unavailable | required |
+
+### Opinion Layer
+
+| ID | Metric | Definition | Gate |
+| --- | --- | --- | --- |
+| `KPI-OPINION-001` | opinion artifact shape | opinion output includes strategy-level state plus buy-candidate, sell-or-avoid, and watch lists | required for Phase 2 |
+| `KPI-OPINION-002` | row evidence completeness | each populated opinion row includes symbol, model score, strategy-derived position signal, evidence reason, risk or warning, invalidation note, and source artifact references | required for Phase 2 |
+| `KPI-OPINION-003` | evidence traceability | each populated row points to persisted diagnostics, signal, metric, baseline, validation, warning, completeness, or caveat artifacts | required for Phase 2 |
+| `KPI-OPINION-004` | insufficient-evidence handling | incomplete, missing, stale, partial, or metadata-only evidence can produce `no-opinion` or `do-not-adopt` instead of forced candidates | required for Phase 2 |
+| `KPI-OPINION-005` | manual-adoption boundary | opinion output does not imply broker routing, live-order readiness, automatic portfolio control, or personalized advice | required for Phase 2 |
 
 ## V1 Acceptance Gates
 
@@ -147,6 +162,61 @@ Passes when:
 - two or more runs can be compared
 - comparison shows model diagnostics, strategy metrics, baseline delta, and
   comparability caveats
+
+## Phase 2 Acceptance Gates
+
+Phase 2 gates do not block v1. They become pass/fail gates only when the
+opinion layer is promoted into active implementation.
+
+### GATE-P2-001: Opinion Artifact
+
+Passes when:
+
+- a complete successful research run can produce an opinion artifact
+- the artifact includes the `KPI-OPINION-001` shape
+- the artifact can represent empty buy, sell-or-avoid, or watch lists without
+  treating them as failures
+- the artifact can be reloaded or reconstructed from persisted research
+  artifacts without relying on the latest in-session response only
+
+### GATE-P2-002: Evidence Traceability
+
+Passes when:
+
+- each populated opinion row satisfies `KPI-OPINION-002`
+- each populated opinion row satisfies `KPI-OPINION-003`
+- unavailable artifacts are surfaced as evidence limitations, warnings,
+  invalidation notes, `no-opinion`, or `do-not-adopt`
+
+### GATE-P2-003: Invalidation Safety
+
+Passes when:
+
+- every actionable-looking row includes an invalidation note
+- insufficient evidence produces `no-opinion` or `do-not-adopt`
+- thresholds, confidence, or investability labels are provisional unless a
+  later versioned policy explicitly promotes them
+
+### GATE-P2-004: No Execution Creep
+
+Passes when:
+
+- opinion artifacts preserve the manual-adoption boundary
+- no Phase 2 API, contract, or UI copy implies broker routing, live orders,
+  automatic rebalancing, account control, or personalized investment advice
+- live trading and guarded execution concepts remain deferred references until
+  their own promotion criteria are met
+
+### GATE-P2-005: Backend-First Slice
+
+Passes when:
+
+- the first Phase 2 implementation defines backend opinion artifacts before
+  introducing a larger frontend workflow
+- the opinion layer uses existing persisted research-run artifacts before
+  adding external runtimes or data platforms
+- external references are implemented as local method or evidence concepts, not
+  as default runtime dependencies
 
 ## Deferred Gates
 

--- a/tests/research/test_research_api.py
+++ b/tests/research/test_research_api.py
@@ -41,6 +41,82 @@ def make_payload() -> dict:
     }
 
 
+def make_opinion_artifact() -> dict:
+    review_checks = [
+        {
+            "check": "strategy_lifecycle",
+            "category": "method",
+            "status": "pass",
+            "evidence_reason": "Persisted artifacts support the lifecycle check.",
+            "risk_or_warning": "Research-only opinion.",
+            "source_artifact_references": [
+                {"artifact": "request_payload", "field": "request_payload"}
+            ],
+            "result": {
+                "request_present": True,
+                "effective_strategy_present": True,
+                "diagnostics_present": True,
+                "signals_present": True,
+                "metrics_present": True,
+                "opinion_rows_emitted_or_limited": True,
+            },
+        },
+        {
+            "check": "source_artifact_audit",
+            "category": "source_provider_audit",
+            "status": "warning",
+            "evidence_reason": "Config source audit is persisted.",
+            "risk_or_warning": "Provider expansion is not inferred.",
+            "source_artifact_references": [
+                {"artifact": "config_sources", "field": "config_sources"}
+            ],
+            "result": {
+                "config_fallback_metadata_present": True,
+                "config_sources_present": True,
+                "fallback_audit_present": True,
+                "raw_provider_parser_audit_available": False,
+                "missing_raw_provider_parser_fields": [
+                    "provider_source_name",
+                    "parser_version",
+                    "fetch_status",
+                    "fetch_timestamp",
+                    "raw_ingest_audit_ref",
+                ],
+                "missing_config_fallback_inputs": [],
+            },
+        },
+    ]
+    return {
+        "state": "viable",
+        "state_reason": "Complete persisted research artifacts support traceable opinion rows.",
+        "manual_adoption_only": True,
+        "evidence_limitations": [],
+        "buy_candidates": [
+            {
+                "symbol": "2330",
+                "model_score": 0.01,
+                "position_signal": 1.0,
+                "evidence_reason": "Latest persisted signal links model score to strategy position for this symbol.",
+                "risk_or_warning": "Research-only opinion for manual adoption review; not an execution or personalized-advice signal.",
+                "invalidation_note": "Do not adopt if newer data invalidates this persisted run.",
+                "source_artifact_references": [
+                    {"artifact": "signals", "field": "score"},
+                    {"artifact": "signals", "field": "position"},
+                    {"artifact": "model_diagnostics", "field": "model_diagnostics"},
+                    {"artifact": "metrics", "field": "metrics"},
+                    {
+                        "artifact": "artifact_completeness",
+                        "field": "artifact_completeness",
+                    },
+                ],
+            }
+        ],
+        "sell_or_avoid": [],
+        "watch": [],
+        "review_checks": review_checks,
+    }
+
+
 def make_response(run_id: str = "run_123") -> ResearchRunResponse:
     return ResearchRunResponse(
         run_id=run_id,
@@ -52,8 +128,20 @@ def make_response(run_id: str = "run_123") -> ResearchRunResponse:
             {"date": date(2024, 1, 2), "symbol": "2330", "score": 0.01, "position": 1.0}
         ],
         validation=None,
+        model_diagnostics={
+            "task": "regression",
+            "sample_count": 2,
+            "rmse": 0.1,
+            "mae": 0.08,
+            "rank_ic": 0.2,
+            "linear_ic": 0.1,
+            "actual_vs_predicted": [],
+            "residuals": [],
+            "feature_importance": [],
+        },
         baselines={},
         warnings=[],
+        opinion_artifact=make_opinion_artifact(),
         runtime_mode="runtime_compatibility_mode",
         default_bundle_version=None,
         effective_strategy=EffectiveStrategyConfig(threshold=0.003, top_n=3),
@@ -108,7 +196,22 @@ def make_record(run_id: str = "run_123") -> ResearchRunRecordResponse:
         metrics=Metrics(
             total_return=0.12, sharpe=1.1, max_drawdown=-0.08, turnover=0.3
         ),
+        signals=[
+            {"date": date(2024, 1, 2), "symbol": "2330", "score": 0.01, "position": 1.0}
+        ],
+        model_diagnostics={
+            "task": "regression",
+            "sample_count": 2,
+            "rmse": 0.1,
+            "mae": 0.08,
+            "rank_ic": 0.2,
+            "linear_ic": 0.1,
+            "actual_vs_predicted": [],
+            "residuals": [],
+            "feature_importance": [],
+        },
         warnings=[],
+        opinion_artifact=make_opinion_artifact(),
         created_at=datetime.now(timezone.utc),
         **build_version_pack_payload(
             {
@@ -132,6 +235,20 @@ def test_create_research_run_success(monkeypatch):
     assert response.headers["X-Request-Id"]
     assert response.json()["run_id"] == "run_123"
     assert response.json()["metrics"]["total_return"] == 0.12
+    opinion = response.json()["opinion_artifact"]
+    assert opinion["state"] == "viable"
+    assert opinion["manual_adoption_only"] is True
+    assert opinion["buy_candidates"][0]["symbol"] == "2330"
+    assert opinion["sell_or_avoid"] == []
+    assert opinion["watch"] == []
+    checks = {item["check"]: item for item in opinion["review_checks"]}
+    assert checks["strategy_lifecycle"]["status"] == "pass"
+    assert checks["strategy_lifecycle"]["result"]["metrics_present"] is True
+    assert checks["source_artifact_audit"]["status"] == "warning"
+    assert (
+        checks["source_artifact_audit"]["result"]["raw_provider_parser_audit_available"]
+        is False
+    )
 
 
 def test_legacy_backtest_route_is_not_public():
@@ -283,6 +400,8 @@ def test_get_research_run(monkeypatch):
     assert response.status_code == 200
     assert response.json()["run_id"] == "run_abc"
     assert response.json()["status"] == "succeeded"
+    assert response.json()["opinion_artifact"]["buy_candidates"][0]["symbol"] == "2330"
+    assert response.json()["opinion_artifact"]["review_checks"][0]["check"]
 
 
 def test_list_research_runs(monkeypatch):

--- a/tests/research/test_research_api.py
+++ b/tests/research/test_research_api.py
@@ -97,11 +97,21 @@ def make_opinion_artifact() -> dict:
                 "model_score": 0.01,
                 "position_signal": 1.0,
                 "evidence_reason": "Latest persisted signal links model score to strategy position for this symbol.",
-                "risk_or_warning": "Research-only opinion for manual adoption review; not an execution or personalized-advice signal.",
+                "risk_or_warning": "Research-only opinion for manual adoption review.",
                 "invalidation_note": "Do not adopt if newer data invalidates this persisted run.",
                 "source_artifact_references": [
-                    {"artifact": "signals", "field": "score"},
-                    {"artifact": "signals", "field": "position"},
+                    {
+                        "artifact": "signals",
+                        "field": "score",
+                        "symbol": "2330",
+                        "date": "2024-01-02",
+                    },
+                    {
+                        "artifact": "signals",
+                        "field": "position",
+                        "symbol": "2330",
+                        "date": "2024-01-02",
+                    },
                     {"artifact": "model_diagnostics", "field": "model_diagnostics"},
                     {"artifact": "metrics", "field": "metrics"},
                     {
@@ -239,6 +249,15 @@ def test_create_research_run_success(monkeypatch):
     assert opinion["state"] == "viable"
     assert opinion["manual_adoption_only"] is True
     assert opinion["buy_candidates"][0]["symbol"] == "2330"
+    signal_refs = {
+        (ref["field"], ref["symbol"], ref["date"])
+        for ref in opinion["buy_candidates"][0]["source_artifact_references"]
+        if ref["artifact"] == "signals"
+    }
+    assert signal_refs == {
+        ("score", "2330", "2024-01-02"),
+        ("position", "2330", "2024-01-02"),
+    }
     assert opinion["sell_or_avoid"] == []
     assert opinion["watch"] == []
     checks = {item["check"]: item for item in opinion["review_checks"]}
@@ -401,6 +420,17 @@ def test_get_research_run(monkeypatch):
     assert response.json()["run_id"] == "run_abc"
     assert response.json()["status"] == "succeeded"
     assert response.json()["opinion_artifact"]["buy_candidates"][0]["symbol"] == "2330"
+    signal_refs = {
+        (ref["field"], ref["symbol"], ref["date"])
+        for ref in response.json()["opinion_artifact"]["buy_candidates"][0][
+            "source_artifact_references"
+        ]
+        if ref["artifact"] == "signals"
+    }
+    assert signal_refs == {
+        ("score", "2330", "2024-01-02"),
+        ("position", "2330", "2024-01-02"),
+    }
     checks = {
         item["check"]: item
         for item in response.json()["opinion_artifact"]["review_checks"]

--- a/tests/research/test_research_api.py
+++ b/tests/research/test_research_api.py
@@ -401,7 +401,11 @@ def test_get_research_run(monkeypatch):
     assert response.json()["run_id"] == "run_abc"
     assert response.json()["status"] == "succeeded"
     assert response.json()["opinion_artifact"]["buy_candidates"][0]["symbol"] == "2330"
-    assert response.json()["opinion_artifact"]["review_checks"][0]["check"]
+    checks = {
+        item["check"]: item
+        for item in response.json()["opinion_artifact"]["review_checks"]
+    }
+    assert checks["strategy_lifecycle"]["result"]["metrics_present"] is True
 
 
 def test_list_research_runs(monkeypatch):

--- a/tests/research/test_run_repository.py
+++ b/tests/research/test_run_repository.py
@@ -492,6 +492,54 @@ def test_list_research_run_records_keeps_summary_without_heavy_artifacts(monkeyp
     }
 
 
+def test_list_research_run_records_preserves_non_success_opinion_states(monkeypatch):
+    engine = create_engine("sqlite:///:memory:")
+    testing_session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(
+        bind=engine,
+        tables=[
+            ResearchRun.__table__,
+            ResearchRunLiquidityCoverage.__table__,
+            MicrostructureObservation.__table__,
+        ],
+    )
+    monkeypatch.setattr(research_run_repository, "SessionLocal", testing_session_local)
+    statuses = ("running", "rejected", "validation_failed", "failed")
+
+    with testing_session_local() as session:
+        for status in statuses:
+            row = ResearchRun(run_id=f"run_{status}")
+            row.request_id = f"req_{status}"
+            row.status = status
+            row.market = "TW"
+            row.symbols_json = '["2330"]'
+            row.strategy_type = "research_v1"
+            row.request_payload_json = research_run_repository.json_dumps(
+                {"symbols": ["2330"], "baselines": []}
+            )
+            row.comparison_eligibility = "comparison_metadata_only"
+            row.warnings_json = "[]"
+            session.add(row)
+        session.commit()
+
+    listed_by_status = {
+        item["status"]: item
+        for item in research_run_repository.list_research_run_records()
+    }
+
+    assert set(listed_by_status) == set(statuses)
+    for status in statuses:
+        opinion = listed_by_status[status]["opinion_artifact"]
+        assert opinion["state"] == "do-not-adopt"
+        assert opinion["buy_candidates"] == []
+        assert opinion["sell_or_avoid"] == []
+        assert opinion["watch"] == []
+        assert opinion["evidence_limitations"] == [
+            f"Run status is {status}; artifacts are not adoptable.",
+            "Detail artifacts are omitted; reload the run detail for row-level opinion review.",
+        ]
+
+
 def test_research_run_repository_reassigns_existing_observation_run_id(monkeypatch):
     engine = create_engine("sqlite:///:memory:")
     testing_session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/tests/research/test_run_repository.py
+++ b/tests/research/test_run_repository.py
@@ -57,7 +57,10 @@ def test_research_run_repository_roundtrip(monkeypatch):
         },
         "equity_curve": [{"date": "2024-01-02", "equity": 1.0}],
         "signals": [
-            {"date": "2024-01-02", "symbol": "2330", "score": 0.01, "position": 1.0}
+            {"date": "2024-01-02", "symbol": "2330", "score": 0.01, "position": 1.0},
+            {"date": "2024-01-02", "symbol": "2317", "score": -0.02, "position": -1.0},
+            {"date": "2024-01-02", "symbol": "2454", "score": 0.0, "position": 0.0},
+            {"date": "2024-01-02", "symbol": "9999", "score": None, "position": 1.0},
         ],
         "model_diagnostics": {
             "task": "regression",
@@ -144,6 +147,102 @@ def test_research_run_repository_roundtrip(monkeypatch):
     assert loaded["artifact_completeness"] == "complete"
     assert loaded["missing_artifacts"] == []
     assert loaded["not_required_artifacts"] == ["validation", "baselines"]
+    assert loaded["opinion_artifact"]["state"] == "viable"
+    assert [row["symbol"] for row in loaded["opinion_artifact"]["sell_or_avoid"]] == [
+        "2317"
+    ]
+    assert [row["symbol"] for row in loaded["opinion_artifact"]["watch"]] == [
+        "2454"
+    ]
+    opinion_row = loaded["opinion_artifact"]["buy_candidates"][0]
+    assert opinion_row["symbol"] == "2330"
+    assert opinion_row["model_score"] == 0.01
+    assert opinion_row["position_signal"] == 1.0
+    assert opinion_row["evidence_reason"]
+    assert opinion_row["risk_or_warning"]
+    assert opinion_row["invalidation_note"]
+    assert {item["artifact"] for item in opinion_row["source_artifact_references"]} >= {
+        "signals",
+        "model_diagnostics",
+        "metrics",
+        "artifact_completeness",
+        "comparison_caveats",
+    }
+    checks = {
+        item["check"]: item for item in loaded["opinion_artifact"]["review_checks"]
+    }
+    assert checks["strategy_lifecycle"]["status"] == "pass"
+    assert checks["strategy_lifecycle"]["result"] == {
+        "request_present": True,
+        "effective_strategy_present": True,
+        "diagnostics_present": True,
+        "signals_present": True,
+        "metrics_present": True,
+        "opinion_rows_emitted_or_limited": True,
+    }
+    assert checks["signal_to_position"]["status"] == "warning"
+    assert checks["signal_to_position"]["result"] == {
+        "checked_symbol_count": 4,
+        "positive_count": 1,
+        "negative_count": 1,
+        "flat_count": 1,
+        "invalid_row_count": 1,
+    }
+    assert checks["backtest_report_discipline"]["status"] == "warning"
+    assert checks["backtest_report_discipline"]["result"]["metric_keys"] == [
+        "max_drawdown",
+        "sharpe",
+        "total_return",
+        "turnover",
+    ]
+    assert checks["backtest_report_discipline"]["result"][
+        "threshold_policy_version_present"
+    ]
+    assert checks["backtest_report_discipline"]["result"][
+        "price_basis_version_present"
+    ]
+    assert checks["backtest_report_discipline"]["result"][
+        "research_only_boundary_present"
+    ]
+    assert checks["robustness"]["status"] == "warning"
+    assert checks["robustness"]["result"]["baseline_keys"] == []
+    assert checks["parameter_sensitivity"]["status"] == "warning"
+    assert checks["parameter_sensitivity"]["result"]["base_candidate_symbols"] == [
+        "2330"
+    ]
+    assert checks["parameter_sensitivity"]["result"]["scenario_candidate_counts"] == {
+        "strict_threshold": 1,
+        "loose_threshold": 1,
+        "top_n_minus_1": 2,
+        "top_n_plus_1": 3,
+    }
+    assert checks["parameter_sensitivity"]["result"]["stable_symbols"] == ["2330"]
+    assert checks["parameter_sensitivity"]["result"]["provisional_policy"]
+    assert checks["source_artifact_audit"]["status"] == "warning"
+    assert checks["source_artifact_audit"]["result"] == {
+        "config_fallback_metadata_present": True,
+        "config_sources_present": True,
+        "fallback_audit_present": True,
+        "raw_provider_parser_audit_available": False,
+        "missing_raw_provider_parser_fields": [
+            "provider_source_name",
+            "parser_version",
+            "fetch_status",
+            "fetch_timestamp",
+            "raw_ingest_audit_ref",
+        ],
+        "missing_config_fallback_inputs": [],
+    }
+    assert checks["text_evidence_summary"]["status"] == "warning"
+    assert checks["text_evidence_summary"]["result"]["caveat_count"] == 1
+    assert checks["text_evidence_summary"]["result"]["source_text_count"] == 1
+    assert checks["text_evidence_summary"]["result"]["summary_text"]
+    assert all(item["source_artifact_references"] for item in checks.values())
+    assert all(
+        reference.get("symbol") == opinion_row["symbol"]
+        for reference in opinion_row["source_artifact_references"]
+        if reference["artifact"] == "signals"
+    )
 
 
 def test_research_run_repository_classifies_metadata_only_old_row(monkeypatch):
@@ -189,6 +288,19 @@ def test_research_run_repository_classifies_metadata_only_old_row(monkeypatch):
         "METADATA_ONLY_RECORD",
         "COMPARISON_METADATA_ONLY",
     }
+    assert loaded["opinion_artifact"]["state"] == "no-opinion"
+    assert loaded["opinion_artifact"]["buy_candidates"] == []
+    assert loaded["opinion_artifact"]["sell_or_avoid"] == []
+    assert loaded["opinion_artifact"]["watch"] == []
+    assert loaded["opinion_artifact"]["evidence_limitations"]
+    checks = {
+        item["check"]: item for item in loaded["opinion_artifact"]["review_checks"]
+    }
+    assert checks["insufficient_evidence_gate"]["status"] == "pass"
+    assert checks["robustness"]["status"] == "warning"
+    assert checks["parameter_sensitivity"]["status"] == "not_evaluated"
+    assert checks["source_artifact_audit"]["status"] == "not_evaluated"
+    assert checks["text_evidence_summary"]["status"] == "warning"
 
 
 def test_research_run_repository_classifies_partial_artifacts(monkeypatch):
@@ -239,6 +351,14 @@ def test_research_run_repository_classifies_partial_artifacts(monkeypatch):
     assert {item["code"] for item in loaded["comparison_caveats"]} == {
         "REVIEW_ARTIFACTS_MISSING"
     }
+    assert loaded["opinion_artifact"]["state"] == "no-opinion"
+    assert loaded["opinion_artifact"]["evidence_limitations"]
+    checks = {
+        item["check"]: item for item in loaded["opinion_artifact"]["review_checks"]
+    }
+    assert checks["robustness"]["status"] == "warning"
+    assert checks["parameter_sensitivity"]["status"] == "not_evaluated"
+    assert checks["source_artifact_audit"]["status"] == "not_evaluated"
 
 
 def test_research_run_repository_marks_running_artifacts_not_evaluated(monkeypatch):
@@ -276,6 +396,8 @@ def test_research_run_repository_marks_running_artifacts_not_evaluated(monkeypat
         "ARTIFACTS_NOT_EVALUATED",
         "METADATA_ONLY_RECORD",
     }
+    assert loaded["opinion_artifact"]["state"] == "do-not-adopt"
+    assert loaded["opinion_artifact"]["evidence_limitations"]
 
 
 def test_list_research_run_records_keeps_summary_without_heavy_artifacts(monkeypatch):
@@ -333,6 +455,20 @@ def test_list_research_run_records_keeps_summary_without_heavy_artifacts(monkeyp
     assert listed[0]["equity_curve"] == []
     assert listed[0]["signals"] == []
     assert listed[0]["model_diagnostics"]["actual_vs_predicted"] == []
+    assert listed[0]["opinion_artifact"]["state"] == "no-opinion"
+    assert listed[0]["opinion_artifact"]["buy_candidates"] == []
+    assert listed[0]["opinion_artifact"]["sell_or_avoid"] == []
+    assert listed[0]["opinion_artifact"]["watch"] == []
+    assert listed[0]["opinion_artifact"]["evidence_limitations"] == [
+        "Detail artifacts are omitted; reload the run detail for row-level opinion review."
+    ]
+    listed_checks = {
+        item["check"]: item for item in listed[0]["opinion_artifact"]["review_checks"]
+    }
+    assert listed_checks["signal_to_position"]["status"] == "not_evaluated"
+    assert listed_checks["signal_to_position"]["result"] == {
+        "omitted_for_summary": True
+    }
 
 
 def test_research_run_repository_reassigns_existing_observation_run_id(monkeypatch):

--- a/tests/research/test_run_repository.py
+++ b/tests/research/test_run_repository.py
@@ -31,7 +31,7 @@ def test_research_run_repository_roundtrip(monkeypatch):
         "request_id": "req_123",
         "status": "succeeded",
         "market": "TW",
-        "symbols": ["2330"],
+        "symbols": ["2330", "2317", "2454", "9999"],
         "strategy_type": "research_v1",
         "runtime_mode": "runtime_compatibility_mode",
         "default_bundle_version": None,
@@ -48,7 +48,7 @@ def test_research_run_repository_roundtrip(monkeypatch):
         },
         "validation_outcome": {"ok": True},
         "rejection_reason": None,
-        "request_payload": {"symbols": ["2330"]},
+        "request_payload": {"symbols": ["2330", "2317", "2454", "9999"]},
         "metrics": {
             "total_return": 0.12,
             "sharpe": 1.1,
@@ -174,6 +174,16 @@ def test_research_run_repository_roundtrip(monkeypatch):
         "artifact_completeness",
         "comparison_caveats",
     }
+    for reference in opinion_row["source_artifact_references"]:
+        if reference["artifact"] == "signals":
+            assert any(
+                str(signal["symbol"]) == reference["symbol"]
+                and str(signal["date"])[:10] == reference["date"]
+                and reference["field"] in signal
+                for signal in loaded["signals"]
+            )
+        else:
+            assert reference["field"] in loaded
     checks = {
         item["check"]: item for item in loaded["opinion_artifact"]["review_checks"]
     }

--- a/tests/research/test_run_repository.py
+++ b/tests/research/test_run_repository.py
@@ -79,7 +79,7 @@ def test_research_run_repository_roundtrip(monkeypatch):
             "feature_importance": [],
         },
         "warnings": [],
-        "tradability_state": "execution_ready",
+        "tradability_state": "research_only",
         "tradability_contract_version": "p3_tradability_monitoring_v1",
         "capacity_screening_active": False,
         "missing_feature_policy_state": "native_missing_supported",
@@ -146,6 +146,7 @@ def test_research_run_repository_roundtrip(monkeypatch):
     assert loaded["effective_strategy"] == {"threshold": 0.003, "top_n": 3}
     assert loaded["comparison_eligibility"] == "research_only_comparable"
     assert loaded["version_pack_status"]["adv_basis_version"] == "implemented"
+    assert loaded["tradability_state"] == "research_only"
     assert loaded["tradability_contract_version"] == "p3_tradability_monitoring_v1"
     assert loaded["liquidity_bucket_coverages"][0]["bucket_key"] == "50m_to_200m"
     assert loaded["monitor_observation_status"] == "persisted"

--- a/tests/research/test_run_repository.py
+++ b/tests/research/test_run_repository.py
@@ -57,7 +57,12 @@ def test_research_run_repository_roundtrip(monkeypatch):
         },
         "equity_curve": [{"date": "2024-01-02", "equity": 1.0}],
         "signals": [
-            {"date": "2024-01-02", "symbol": "2330", "score": 0.01, "position": 1.0},
+            {
+                "date": datetime(2024, 1, 2, 12, 30, tzinfo=timezone.utc),
+                "symbol": "2330",
+                "score": 0.01,
+                "position": 1.0,
+            },
             {"date": "2024-01-02", "symbol": "2317", "score": -0.02, "position": -1.0},
             {"date": "2024-01-02", "symbol": "2454", "score": 0.0, "position": 0.0},
             {"date": "2024-01-02", "symbol": "9999", "score": None, "position": 1.0},
@@ -243,6 +248,11 @@ def test_research_run_repository_roundtrip(monkeypatch):
         for reference in opinion_row["source_artifact_references"]
         if reference["artifact"] == "signals" and "symbol" in reference
     )
+    assert {
+        reference["date"]
+        for reference in opinion_row["source_artifact_references"]
+        if reference["artifact"] == "signals" and "date" in reference
+    } == {"2024-01-02"}
 
 
 def test_research_run_repository_classifies_metadata_only_old_row(monkeypatch):

--- a/tests/research/test_run_repository.py
+++ b/tests/research/test_run_repository.py
@@ -124,7 +124,7 @@ def test_research_run_repository_roundtrip(monkeypatch):
                 "threshold_policy_version": "static_absolute_gross_label_v1",
                 "price_basis_version": "label_open_to_open__entry_ohlc_default__exit_ohlc_default__benchmark_unset_v1",
                 "benchmark_comparability_gate": False,
-                "comparison_eligibility": "comparison_metadata_only",
+                "comparison_eligibility": "research_only_comparable",
                 "investability_screening_active": False,
                 "capacity_screening_version": "adv_ex_ante_buy_notional_0p5pct_v1",
                 "adv_basis_version": "raw_close_x_volume_active_session_v1",
@@ -139,7 +139,7 @@ def test_research_run_repository_roundtrip(monkeypatch):
 
     assert loaded["run_id"] == "run_123"
     assert loaded["effective_strategy"] == {"threshold": 0.003, "top_n": 3}
-    assert loaded["comparison_eligibility"] == "comparison_metadata_only"
+    assert loaded["comparison_eligibility"] == "research_only_comparable"
     assert loaded["version_pack_status"]["adv_basis_version"] == "implemented"
     assert loaded["tradability_contract_version"] == "p3_tradability_monitoring_v1"
     assert loaded["liquidity_bucket_coverages"][0]["bucket_key"] == "50m_to_200m"
@@ -188,7 +188,7 @@ def test_research_run_repository_roundtrip(monkeypatch):
         "flat_count": 1,
         "invalid_row_count": 1,
     }
-    assert checks["backtest_report_discipline"]["status"] == "warning"
+    assert checks["backtest_report_discipline"]["status"] == "pass"
     assert checks["backtest_report_discipline"]["result"]["metric_keys"] == [
         "max_drawdown",
         "sharpe",
@@ -233,15 +233,15 @@ def test_research_run_repository_roundtrip(monkeypatch):
         ],
         "missing_config_fallback_inputs": [],
     }
-    assert checks["text_evidence_summary"]["status"] == "warning"
-    assert checks["text_evidence_summary"]["result"]["caveat_count"] == 1
-    assert checks["text_evidence_summary"]["result"]["source_text_count"] == 1
-    assert checks["text_evidence_summary"]["result"]["summary_text"]
+    assert checks["text_evidence_summary"]["status"] == "not_evaluated"
+    assert checks["text_evidence_summary"]["result"]["caveat_count"] == 0
+    assert checks["text_evidence_summary"]["result"]["source_text_count"] == 0
+    assert checks["text_evidence_summary"]["result"]["summary_text"] == ""
     assert all(item["source_artifact_references"] for item in checks.values())
     assert all(
         reference.get("symbol") == opinion_row["symbol"]
         for reference in opinion_row["source_artifact_references"]
-        if reference["artifact"] == "signals"
+        if reference["artifact"] == "signals" and "symbol" in reference
     )
 
 

--- a/tests/research/test_runs.py
+++ b/tests/research/test_runs.py
@@ -167,6 +167,44 @@ def test_opinion_contract_rejects_unknown_check_and_category():
         OpinionReviewCheck.model_validate({**payload, "category": "unknown"})
 
 
+@pytest.mark.parametrize("status", ["pass", "warning", "fail"])
+def test_opinion_contract_requires_result_for_evaluated_checks(status):
+    payload = {
+        "check": "risk_present",
+        "category": "self_review",
+        "status": status,
+        "evidence_reason": "Risk context was checked.",
+        "risk_or_warning": "Persisted warning was checked.",
+        "source_artifact_references": [
+            {"artifact": "warnings", "field": "warnings"}
+        ],
+        "result": {},
+    }
+
+    with pytest.raises(
+        ValidationError,
+        match="evaluated review checks require a non-empty result",
+    ):
+        OpinionReviewCheck.model_validate(payload)
+
+
+def test_opinion_contract_allows_default_result_for_not_evaluated_check():
+    check = OpinionReviewCheck.model_validate(
+        {
+            "check": "risk_present",
+            "category": "self_review",
+            "status": "not_evaluated",
+            "evidence_reason": "Persisted warnings are unavailable.",
+            "risk_or_warning": "Risk could not be evaluated.",
+            "source_artifact_references": [
+                {"artifact": "warnings", "field": "warnings"}
+            ],
+        }
+    )
+
+    assert check.result == {}
+
+
 def test_opinion_builder_uses_latest_dated_signal_rows_for_actions_and_checks():
     payload = make_opinion_payload()
     payload["symbols"] = ["2330", "2317", "2454", "9999", "8888"]

--- a/tests/research/test_runs.py
+++ b/tests/research/test_runs.py
@@ -135,6 +135,7 @@ def test_opinion_contract_requires_source_artifact_references():
         "status": "pass",
         "evidence_reason": "Risk context was checked.",
         "risk_or_warning": "Persisted warning was checked.",
+        "result": {"risk_checked": True},
     }
 
     with pytest.raises(ValidationError):
@@ -159,6 +160,7 @@ def test_opinion_contract_rejects_unknown_check_and_category():
         "source_artifact_references": [
             {"artifact": "warnings", "field": "warnings"}
         ],
+        "result": {"risk_checked": True},
     }
 
     with pytest.raises(ValidationError):
@@ -221,6 +223,7 @@ def test_opinion_builder_uses_latest_dated_signal_rows_for_actions_and_checks():
         {"date": "2024-01-04", "symbol": "2454", "score": 0.0, "position": 0.0},
         {"date": "2024-01-04", "symbol": "9999", "score": None, "position": 1.0},
         {"date": "not-a-date", "symbol": "8888", "score": 0.5, "position": 1.0},
+        {"date": "2024-01-04", "score": 0.5, "position": 1.0},
     ]
 
     artifact = build_opinion_artifact(payload)
@@ -250,7 +253,7 @@ def test_opinion_builder_uses_latest_dated_signal_rows_for_actions_and_checks():
         "positive_count": 1,
         "negative_count": 1,
         "flat_count": 1,
-        "invalid_row_count": 1,
+        "invalid_row_count": 3,
     }
     assert checks["parameter_sensitivity"]["result"]["base_candidate_symbols"] == [
         "2330"

--- a/tests/research/test_runs.py
+++ b/tests/research/test_runs.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 from copy import deepcopy
 
 import pytest
+from pydantic import ValidationError
 
 import backend.research.domain.opinion as opinion_domain
 import backend.research.services.runs as research_run_service
@@ -11,6 +12,8 @@ from backend.research.contracts.runs import (
     EffectiveStrategyConfig,
     FallbackAudit,
     Metrics,
+    OpinionReviewCheck,
+    OpinionRow,
     ResearchRunCreateRequest,
     ResearchRunResponse,
 )
@@ -116,6 +119,35 @@ def make_opinion_payload() -> dict:
     }
 
 
+def test_opinion_contract_requires_source_artifact_references():
+    row_payload = {
+        "symbol": "2330",
+        "model_score": 0.01,
+        "position_signal": 1.0,
+        "evidence_reason": "Latest persisted signal was checked.",
+        "risk_or_warning": "Persisted warning was checked.",
+        "invalidation_note": "Newer persisted data may supersede this signal.",
+    }
+    check_payload = {
+        "check": "risk_present",
+        "category": "self_review",
+        "status": "pass",
+        "evidence_reason": "Risk context was checked.",
+        "risk_or_warning": "Persisted warning was checked.",
+    }
+
+    with pytest.raises(ValidationError):
+        OpinionRow.model_validate(row_payload)
+    with pytest.raises(ValidationError):
+        OpinionRow.model_validate({**row_payload, "source_artifact_references": []})
+    with pytest.raises(ValidationError):
+        OpinionReviewCheck.model_validate(check_payload)
+    with pytest.raises(ValidationError):
+        OpinionReviewCheck.model_validate(
+            {**check_payload, "source_artifact_references": []}
+        )
+
+
 def test_opinion_builder_uses_latest_dated_signal_rows_for_actions_and_checks():
     payload = make_opinion_payload()
     payload["signals"] = [
@@ -191,6 +223,11 @@ def _assert_self_review_blocks_viability(artifact: dict, check_name: str) -> Non
     assert artifact["sell_or_avoid"] == []
     assert artifact["watch"] == []
     assert artifact["evidence_limitations"]
+    assert checks["insufficient_evidence_gate"]["status"] == "pass"
+    assert checks["insufficient_evidence_gate"]["result"] == {
+        "state": "no-opinion",
+        "limitation_count": len(artifact["evidence_limitations"]),
+    }
 
 
 def test_opinion_builder_missing_row_specific_signal_ref_blocks_viability(

--- a/tests/research/test_runs.py
+++ b/tests/research/test_runs.py
@@ -373,6 +373,27 @@ def test_opinion_builder_manual_boundary_variants_downgrade_viability(
     assert artifact["evidence_limitations"]
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("execution_route", "broker-routing-v1"),
+        ("tradability_state", "execution_ready"),
+        ("live_control_profile_id", "broker-routing-profile"),
+        ("live_control_version", "live_order_controls_v1"),
+    ],
+)
+def test_opinion_builder_manual_boundary_scans_execution_metadata(field, value):
+    payload = make_opinion_payload()
+    payload[field] = value
+
+    artifact = build_opinion_artifact(payload)
+    checks = {item["check"]: item for item in artifact["review_checks"]}
+
+    assert checks["manual_adoption_boundary"]["status"] == "fail"
+    assert artifact["state"] == "no-opinion"
+    assert artifact["buy_candidates"] == []
+
+
 def test_opinion_builder_manual_boundary_allows_broker_metadata_description():
     payload = make_opinion_payload()
     payload["warnings"] = ["Broker comparison metadata is unavailable."]
@@ -571,6 +592,22 @@ def test_create_response_stale_evidence_blocks_opinion_rows():
         make_request(),
     )
 
+    assert result.opinion_artifact.state == "no-opinion"
+    assert result.opinion_artifact.buy_candidates == []
+
+
+def test_create_response_execution_metadata_blocks_opinion_rows():
+    response = make_response().model_copy(
+        update={"tradability_state": "execution_ready"}
+    )
+
+    result = research_run_service._response_with_artifact_summary(
+        response,
+        make_request(),
+    )
+    checks = {item.check: item for item in result.opinion_artifact.review_checks}
+
+    assert checks["manual_adoption_boundary"].status == "fail"
     assert result.opinion_artifact.state == "no-opinion"
     assert result.opinion_artifact.buy_candidates == []
 

--- a/tests/research/test_runs.py
+++ b/tests/research/test_runs.py
@@ -1,7 +1,9 @@
 from types import SimpleNamespace
+from copy import deepcopy
 
 import pytest
 
+import backend.research.domain.opinion as opinion_domain
 import backend.research.services.runs as research_run_service
 from backend.platform.errors import DataAccessError
 from backend.research.contracts.runs import (
@@ -12,6 +14,7 @@ from backend.research.contracts.runs import (
     ResearchRunCreateRequest,
     ResearchRunResponse,
 )
+from backend.research.domain.opinion import build_opinion_artifact
 from backend.research.domain.version_pack import build_version_pack_payload
 
 
@@ -84,6 +87,243 @@ def make_response(run_id: str = "run_123") -> ResearchRunResponse:
             }
         ),
     )
+
+
+def make_opinion_payload() -> dict:
+    return {
+        "status": "succeeded",
+        "request_payload": {
+            "symbols": ["2330"],
+            "strategy": {"threshold": 0.003, "top_n": 2},
+        },
+        "effective_strategy": {"threshold": 0.003, "top_n": 2},
+        "metrics": {"total_return": 0.12, "sharpe": 1.1},
+        "model_diagnostics": {"task": "regression", "sample_count": 2},
+        "signals": [
+            {"date": "2024-01-02", "symbol": "2330", "score": 0.01, "position": 1.0},
+            {"date": "2024-01-02", "symbol": "2317", "score": -0.02, "position": -1.0},
+        ],
+        "validation": {"method": "walk_forward", "metrics": {"rmse": 0.1}},
+        "baselines": {"buy_hold": {"total_return": 0.05}},
+        "warnings": [],
+        "config_sources": {"strategy": {"threshold": "request_override"}},
+        "fallback_audit": {"strategy": {"threshold": {"attempted": False}}},
+        "artifact_completeness": "complete",
+        "missing_artifacts": [],
+        "comparison_caveats": [],
+        "threshold_policy_version": "static_absolute_gross_label_v1",
+        "price_basis_version": "label_open_to_open__entry_ohlc_default__exit_ohlc_default__benchmark_unset_v1",
+    }
+
+
+def test_opinion_builder_uses_latest_dated_signal_rows_for_actions_and_checks():
+    payload = make_opinion_payload()
+    payload["signals"] = [
+        {"date": "2024-01-03", "symbol": "2330", "score": 0.02, "position": 1.0},
+        {"date": "2024-01-01", "symbol": "2330", "score": -0.04, "position": -1.0},
+        {"date": "2024-01-01", "symbol": "2317", "score": 0.04, "position": 1.0},
+        {"date": "2024-01-04", "symbol": "2317", "score": -0.03, "position": -1.0},
+        {"date": "2024-01-04", "symbol": "2454", "score": 0.0, "position": 0.0},
+        {"date": "2024-01-04", "symbol": "9999", "score": None, "position": 1.0},
+        {"date": "not-a-date", "symbol": "8888", "score": 0.5, "position": 1.0},
+    ]
+
+    artifact = build_opinion_artifact(payload)
+    checks = {item["check"]: item for item in artifact["review_checks"]}
+
+    assert [row["symbol"] for row in artifact["buy_candidates"]] == ["2330"]
+    assert [row["symbol"] for row in artifact["sell_or_avoid"]] == ["2317"]
+    assert [row["symbol"] for row in artifact["watch"]] == ["2454"]
+    assert all(row["symbol"] != "8888" for row in artifact["buy_candidates"])
+    assert {
+        ref["date"]
+        for ref in artifact["buy_candidates"][0]["source_artifact_references"]
+        if ref["artifact"] == "signals" and "date" in ref
+    } == {"2024-01-03"}
+    assert checks["signal_to_position"]["result"] == {
+        "checked_symbol_count": 5,
+        "positive_count": 1,
+        "negative_count": 1,
+        "flat_count": 1,
+        "invalid_row_count": 2,
+    }
+    assert checks["parameter_sensitivity"]["result"]["base_candidate_symbols"] == [
+        "2330"
+    ]
+    assert checks["parameter_sensitivity"]["result"]["scenario_candidate_counts"][
+        "top_n_minus_1"
+    ] == 1
+
+
+def test_opinion_builder_robustness_does_not_pass_empty_validation_metrics():
+    payload = make_opinion_payload()
+    payload["validation"] = {"method": "walk_forward", "metrics": {}}
+    payload["baselines"] = {}
+    payload["comparison_caveats"] = [
+        {"code": "REVIEW_ARTIFACTS_MISSING", "label": "missing", "severity": "blocker"}
+    ]
+
+    checks = {
+        item["check"]: item for item in build_opinion_artifact(payload)["review_checks"]
+    }
+
+    assert checks["robustness"]["status"] == "warning"
+    assert checks["robustness"]["result"] == {
+        "validation_metric_keys": [],
+        "baseline_keys": [],
+        "warning_count": 0,
+        "blocker_caveat_count": 1,
+    }
+
+
+def _valid_opinion_row() -> dict:
+    return deepcopy(
+        build_opinion_artifact(make_opinion_payload())["buy_candidates"][0]
+    )
+
+
+def _assert_self_review_blocks_viability(artifact: dict, check_name: str) -> None:
+    checks = {item["check"]: item for item in artifact["review_checks"]}
+
+    assert checks[check_name]["status"] == "fail"
+    assert artifact["state"] == "no-opinion"
+    assert artifact["buy_candidates"] == []
+    assert artifact["sell_or_avoid"] == []
+    assert artifact["watch"] == []
+    assert artifact["evidence_limitations"]
+
+
+def test_opinion_builder_missing_row_specific_signal_ref_blocks_viability(
+    monkeypatch,
+):
+    row = _valid_opinion_row()
+    for reference in row["source_artifact_references"]:
+        if reference["artifact"] == "signals":
+            reference.pop("symbol", None)
+            reference.pop("date", None)
+    monkeypatch.setattr(opinion_domain, "_action_rows", lambda payload: [row])
+
+    artifact = build_opinion_artifact(make_opinion_payload())
+
+    _assert_self_review_blocks_viability(artifact, "evidence_traceability")
+
+
+def test_opinion_builder_generic_risk_disclaimer_blocks_viability(monkeypatch):
+    row = _valid_opinion_row()
+    row["risk_or_warning"] = "Research-only opinion for manual review."
+    monkeypatch.setattr(opinion_domain, "_action_rows", lambda payload: [row])
+
+    artifact = build_opinion_artifact(make_opinion_payload())
+
+    _assert_self_review_blocks_viability(artifact, "risk_present")
+
+
+def test_opinion_builder_static_invalidation_template_blocks_viability(monkeypatch):
+    row = _valid_opinion_row()
+    row["invalidation_note"] = "Do not adopt this signal."
+    monkeypatch.setattr(opinion_domain, "_action_rows", lambda payload: [row])
+
+    artifact = build_opinion_artifact(make_opinion_payload())
+
+    _assert_self_review_blocks_viability(artifact, "invalidation_present")
+
+
+@pytest.mark.parametrize(
+    "forbidden_text",
+    [
+        "execution-ready signal",
+        "send through order routing",
+        "automatic rebalance from this opinion",
+        "automatic rebalancing from this opinion",
+        "broker action from this signal",
+        "account control instruction",
+        "personalized investment advice",
+    ],
+)
+def test_opinion_builder_manual_boundary_variants_downgrade_viability(
+    forbidden_text,
+):
+    payload = make_opinion_payload()
+    payload["warnings"] = [forbidden_text]
+
+    artifact = build_opinion_artifact(payload)
+    checks = {item["check"]: item for item in artifact["review_checks"]}
+
+    assert checks["manual_adoption_boundary"]["status"] == "fail"
+    assert artifact["state"] == "no-opinion"
+    assert artifact["buy_candidates"] == []
+    assert artifact["evidence_limitations"]
+
+
+def test_opinion_builder_manual_boundary_scans_review_check_copy(monkeypatch):
+    def fake_parameter_sensitivity(payload):
+        return {
+            "status": "warning",
+            "reason": "Local provisional sensitivity scenarios were computed.",
+            "result": {
+                "base_candidate_symbols": ["2330"],
+                "scenario_candidate_counts": {},
+                "stable_symbols": [],
+                "changed_symbols": [],
+                "provisional_policy": "execution-ready review output",
+                "skipped_scenarios": [],
+            },
+        }
+
+    monkeypatch.setattr(
+        opinion_domain,
+        "_parameter_sensitivity",
+        fake_parameter_sensitivity,
+    )
+
+    artifact = build_opinion_artifact(make_opinion_payload())
+    checks = {item["check"]: item for item in artifact["review_checks"]}
+
+    assert checks["manual_adoption_boundary"]["status"] == "fail"
+    assert checks["manual_adoption_boundary"]["result"]["scanned_review_check_copy"]
+    assert artifact["state"] == "no-opinion"
+    assert artifact["buy_candidates"] == []
+    assert artifact["evidence_limitations"]
+
+
+def test_opinion_builder_source_audit_names_missing_config_inputs():
+    payload = make_opinion_payload()
+    payload["config_sources"] = None
+    payload["fallback_audit"] = None
+
+    checks = {
+        item["check"]: item for item in build_opinion_artifact(payload)["review_checks"]
+    }
+
+    assert checks["source_artifact_audit"]["status"] == "not_evaluated"
+    assert checks["source_artifact_audit"]["result"]["config_sources_present"] is False
+    assert checks["source_artifact_audit"]["result"]["fallback_audit_present"] is False
+    assert checks["source_artifact_audit"]["result"][
+        "missing_config_fallback_inputs"
+    ] == ["config_sources", "fallback_audit"]
+
+
+def test_opinion_builder_stale_evidence_blocks_forced_rows():
+    payload = make_opinion_payload()
+    payload["stale_risk_share"] = 0.25
+
+    artifact = build_opinion_artifact(payload)
+
+    assert artifact["state"] == "no-opinion"
+    assert artifact["buy_candidates"] == []
+    assert "Stale mark risk" in " ".join(artifact["evidence_limitations"])
+
+
+def test_opinion_builder_text_evidence_summary_does_not_invent_prose():
+    payload = make_opinion_payload()
+
+    checks = {
+        item["check"]: item for item in build_opinion_artifact(deepcopy(payload))["review_checks"]
+    }
+
+    assert checks["text_evidence_summary"]["status"] == "not_evaluated"
+    assert checks["text_evidence_summary"]["result"]["source_text_count"] == 0
+    assert checks["text_evidence_summary"]["result"]["summary_text"] == ""
 
 
 def test_create_research_run_fails_when_success_registry_write_fails(monkeypatch):
@@ -170,4 +410,48 @@ def test_create_research_run_records_started_before_execute(monkeypatch):
     assert response.run_id == "run_started"
     assert response.artifact_completeness == "complete"
     assert response.not_required_artifacts == ["validation", "baselines"]
+    assert response.opinion_artifact.state == "viable"
+    assert response.opinion_artifact.sell_or_avoid == []
+    assert response.opinion_artifact.watch == []
+    opinion_row = response.opinion_artifact.buy_candidates[0]
+    assert opinion_row.symbol == "2330"
+    assert opinion_row.model_score == pytest.approx(0.01)
+    assert opinion_row.position_signal == pytest.approx(1.0)
+    assert opinion_row.evidence_reason
+    assert opinion_row.risk_or_warning
+    assert opinion_row.invalidation_note
+    assert {item.artifact for item in opinion_row.source_artifact_references} >= {
+        "signals",
+        "model_diagnostics",
+        "metrics",
+        "artifact_completeness",
+    }
+    checks = {item.check: item for item in response.opinion_artifact.review_checks}
+    assert {
+        "strategy_lifecycle",
+        "signal_to_position",
+        "backtest_report_discipline",
+        "robustness",
+        "parameter_sensitivity",
+        "evidence_traceability",
+        "risk_present",
+        "invalidation_present",
+        "manual_adoption_boundary",
+        "insufficient_evidence_gate",
+        "source_artifact_audit",
+        "text_evidence_summary",
+    } <= set(checks)
+    assert checks["strategy_lifecycle"].status == "pass"
+    assert checks["signal_to_position"].status == "pass"
+    assert checks["backtest_report_discipline"].status == "pass"
+    assert checks["manual_adoption_boundary"].status == "pass"
+    assert checks["strategy_lifecycle"].result["metrics_present"]
+    assert checks["signal_to_position"].result["checked_symbol_count"] == 1
+    assert checks["robustness"].status == "warning"
+    assert checks["parameter_sensitivity"].status == "pass"
+    assert checks["parameter_sensitivity"].result["base_candidate_symbols"] == [
+        "2330"
+    ]
+    assert checks["source_artifact_audit"].status == "warning"
+    assert checks["text_evidence_summary"].status == "not_evaluated"
     assert call_order == ["started", "executed", "success"]

--- a/tests/research/test_runs.py
+++ b/tests/research/test_runs.py
@@ -347,10 +347,12 @@ def test_opinion_builder_static_invalidation_template_blocks_viability(monkeypat
     "forbidden_text",
     [
         "execution-ready signal",
+        "live_order readiness",
         "send through order routing",
         "automatic rebalance from this opinion",
         "automatic rebalancing from this opinion",
-        "broker action from this signal",
+        "broker-routing action from this signal",
+        "portfolio-control instruction",
         "account control instruction",
         "personalized investment advice",
         "Execution route research_only produced 1 order record(s).",
@@ -369,6 +371,16 @@ def test_opinion_builder_manual_boundary_variants_downgrade_viability(
     assert artifact["state"] == "no-opinion"
     assert artifact["buy_candidates"] == []
     assert artifact["evidence_limitations"]
+
+
+def test_opinion_builder_manual_boundary_allows_broker_metadata_description():
+    payload = make_opinion_payload()
+    payload["warnings"] = ["Broker comparison metadata is unavailable."]
+
+    artifact = build_opinion_artifact(payload)
+    checks = {item["check"]: item for item in artifact["review_checks"]}
+
+    assert checks["manual_adoption_boundary"]["status"] == "pass"
 
 
 def test_opinion_builder_manual_boundary_scans_review_check_copy(monkeypatch):
@@ -538,6 +550,17 @@ def test_opinion_builder_stale_evidence_blocks_forced_rows():
     assert artifact["state"] == "no-opinion"
     assert artifact["buy_candidates"] == []
     assert "Stale mark risk" in " ".join(artifact["evidence_limitations"])
+
+
+def test_opinion_builder_missing_status_is_do_not_adopt():
+    payload = make_opinion_payload()
+    payload.pop("status")
+
+    artifact = build_opinion_artifact(payload)
+
+    assert artifact["state"] == "do-not-adopt"
+    assert artifact["buy_candidates"] == []
+    assert "Run status is unavailable" in " ".join(artifact["evidence_limitations"])
 
 
 def test_create_response_stale_evidence_blocks_opinion_rows():

--- a/tests/research/test_runs.py
+++ b/tests/research/test_runs.py
@@ -1,5 +1,6 @@
-from types import SimpleNamespace
 from copy import deepcopy
+from datetime import datetime
+from types import SimpleNamespace
 
 import pytest
 from pydantic import ValidationError
@@ -101,7 +102,7 @@ def make_opinion_payload() -> dict:
         },
         "effective_strategy": {"threshold": 0.003, "top_n": 2},
         "metrics": {"total_return": 0.12, "sharpe": 1.1},
-        "model_diagnostics": {"task": "regression", "sample_count": 2},
+        "model_diagnostics": {"task": "regression", "sample_count": 2, "rmse": 0.1},
         "signals": [
             {"date": "2024-01-02", "symbol": "2330", "score": 0.01, "position": 1.0},
             {"date": "2024-01-02", "symbol": "2317", "score": -0.02, "position": -1.0},
@@ -148,10 +149,33 @@ def test_opinion_contract_requires_source_artifact_references():
         )
 
 
+def test_opinion_contract_rejects_unknown_check_and_category():
+    payload = {
+        "check": "risk_present",
+        "category": "self_review",
+        "status": "pass",
+        "evidence_reason": "Risk context was checked.",
+        "risk_or_warning": "Persisted warning was checked.",
+        "source_artifact_references": [
+            {"artifact": "warnings", "field": "warnings"}
+        ],
+    }
+
+    with pytest.raises(ValidationError):
+        OpinionReviewCheck.model_validate({**payload, "check": "unknown"})
+    with pytest.raises(ValidationError):
+        OpinionReviewCheck.model_validate({**payload, "category": "unknown"})
+
+
 def test_opinion_builder_uses_latest_dated_signal_rows_for_actions_and_checks():
     payload = make_opinion_payload()
     payload["signals"] = [
-        {"date": "2024-01-03", "symbol": "2330", "score": 0.02, "position": 1.0},
+        {
+            "date": datetime(2024, 1, 4, 12, 30),
+            "symbol": "2330",
+            "score": 0.02,
+            "position": 1.0,
+        },
         {"date": "2024-01-01", "symbol": "2330", "score": -0.04, "position": -1.0},
         {"date": "2024-01-01", "symbol": "2317", "score": 0.04, "position": 1.0},
         {"date": "2024-01-04", "symbol": "2317", "score": -0.03, "position": -1.0},
@@ -167,17 +191,24 @@ def test_opinion_builder_uses_latest_dated_signal_rows_for_actions_and_checks():
     assert [row["symbol"] for row in artifact["sell_or_avoid"]] == ["2317"]
     assert [row["symbol"] for row in artifact["watch"]] == ["2454"]
     assert all(row["symbol"] != "8888" for row in artifact["buy_candidates"])
+    assert "warning_count=0 and caveat_count=0" in artifact["buy_candidates"][0][
+        "risk_or_warning"
+    ]
+    assert "on 2024-01-04 links" in artifact["buy_candidates"][0]["evidence_reason"]
+    assert "Row signal date: 2024-01-04 for 2330" in artifact["buy_candidates"][0][
+        "invalidation_note"
+    ]
     assert {
         ref["date"]
         for ref in artifact["buy_candidates"][0]["source_artifact_references"]
         if ref["artifact"] == "signals" and "date" in ref
-    } == {"2024-01-03"}
+    } == {"2024-01-04"}
     assert checks["signal_to_position"]["result"] == {
-        "checked_symbol_count": 5,
+        "checked_symbol_count": 4,
         "positive_count": 1,
         "negative_count": 1,
         "flat_count": 1,
-        "invalid_row_count": 2,
+        "invalid_row_count": 1,
     }
     assert checks["parameter_sensitivity"]["result"]["base_candidate_symbols"] == [
         "2330"
@@ -185,6 +216,38 @@ def test_opinion_builder_uses_latest_dated_signal_rows_for_actions_and_checks():
     assert checks["parameter_sensitivity"]["result"]["scenario_candidate_counts"][
         "top_n_minus_1"
     ] == 1
+
+
+def test_opinion_builder_parameter_sensitivity_reports_partial_scenario_change():
+    payload = make_opinion_payload()
+    payload["signals"] = [
+        {"date": "2024-01-02", "symbol": "2330", "score": 0.004, "position": 1.0},
+        {"date": "2024-01-02", "symbol": "2317", "score": 0.003, "position": 1.0},
+    ]
+
+    checks = {
+        item["check"]: item for item in build_opinion_artifact(payload)["review_checks"]
+    }
+
+    assert checks["parameter_sensitivity"]["result"]["changed_symbols"] == ["2317"]
+
+
+def test_opinion_builder_keeps_each_symbol_latest_parseable_signal():
+    payload = make_opinion_payload()
+    payload["signals"] = [
+        {"date": "2024-01-01", "symbol": "2330", "score": 0.01, "position": 1.0},
+        {"date": "2024-01-02", "symbol": "2317", "score": 0.02, "position": 1.0},
+    ]
+
+    artifact = build_opinion_artifact(payload)
+    checks = {item["check"]: item for item in artifact["review_checks"]}
+
+    assert [row["symbol"] for row in artifact["buy_candidates"]] == ["2317", "2330"]
+    assert checks["signal_to_position"]["result"]["checked_symbol_count"] == 2
+    assert checks["parameter_sensitivity"]["result"]["base_candidate_symbols"] == [
+        "2317",
+        "2330",
+    ]
 
 
 def test_opinion_builder_robustness_does_not_pass_empty_validation_metrics():
@@ -245,6 +308,18 @@ def test_opinion_builder_missing_row_specific_signal_ref_blocks_viability(
     _assert_self_review_blocks_viability(artifact, "evidence_traceability")
 
 
+def test_opinion_builder_wrong_signal_ref_date_blocks_viability(monkeypatch):
+    row = _valid_opinion_row()
+    for reference in row["source_artifact_references"]:
+        if reference["artifact"] == "signals":
+            reference["date"] = "2024-01-01"
+    monkeypatch.setattr(opinion_domain, "_action_rows", lambda payload: [row])
+
+    artifact = build_opinion_artifact(make_opinion_payload())
+
+    _assert_self_review_blocks_viability(artifact, "evidence_traceability")
+
+
 def test_opinion_builder_generic_risk_disclaimer_blocks_viability(monkeypatch):
     row = _valid_opinion_row()
     row["risk_or_warning"] = "Research-only opinion for manual review."
@@ -275,6 +350,7 @@ def test_opinion_builder_static_invalidation_template_blocks_viability(monkeypat
         "broker action from this signal",
         "account control instruction",
         "personalized investment advice",
+        "Execution route research_only produced 1 order record(s).",
     ],
 )
 def test_opinion_builder_manual_boundary_variants_downgrade_viability(
@@ -340,6 +416,92 @@ def test_opinion_builder_source_audit_names_missing_config_inputs():
     ] == ["config_sources", "fallback_audit"]
 
 
+@pytest.mark.parametrize(
+    ("metrics", "diagnostics"),
+    [
+        (
+            {
+                "total_return": None,
+                "sharpe": None,
+                "max_drawdown": None,
+                "turnover": None,
+                "max_position_weight": None,
+            },
+            {"task": "regression", "sample_count": 2, "rmse": 0.1},
+        ),
+        (
+            {"total_return": 0.0},
+            {
+                "task": "regression",
+                "sample_count": 0,
+                "rmse": 0.1,
+                "mae": None,
+                "rank_ic": None,
+                "linear_ic": None,
+            },
+        ),
+    ],
+)
+def test_opinion_builder_requires_numeric_metrics_and_diagnostics(
+    metrics,
+    diagnostics,
+):
+    payload = make_opinion_payload()
+    payload["metrics"] = metrics
+    payload["model_diagnostics"] = diagnostics
+
+    artifact = build_opinion_artifact(payload)
+
+    assert artifact["state"] == "no-opinion"
+    assert artifact["buy_candidates"] == []
+
+
+def test_opinion_builder_unscoped_warning_blocks_all_rows():
+    payload = make_opinion_payload()
+    payload["signals"] = [payload["signals"][0]]
+    payload["warnings"] = ["Data source degraded."]
+
+    artifact = build_opinion_artifact(payload)
+    check = next(
+        item for item in artifact["review_checks"] if item["check"] == "risk_present"
+    )
+
+    assert artifact["state"] == "no-opinion"
+    assert check["result"]["concrete_risk_row_count"] == 0
+    assert "run-level/unscoped" in check["risk_or_warning"]
+
+
+def test_opinion_builder_symbol_scoped_warning_does_not_cover_other_rows():
+    payload = make_opinion_payload()
+    payload["warnings"] = ["Data source degraded for 2330."]
+
+    artifact = build_opinion_artifact(payload)
+    check = next(
+        item for item in artifact["review_checks"] if item["check"] == "risk_present"
+    )
+
+    assert artifact["state"] == "no-opinion"
+    assert check["result"]["concrete_risk_row_count"] == 1
+    assert check["result"]["missing_risk_row_count"] == 1
+
+
+def test_opinion_builder_matches_each_row_against_all_symbol_warnings():
+    payload = make_opinion_payload()
+    payload["warnings"] = [
+        "Data source degraded for 2317.",
+        "Data source degraded for 2330.",
+    ]
+
+    artifact = build_opinion_artifact(payload)
+    check = next(
+        item for item in artifact["review_checks"] if item["check"] == "risk_present"
+    )
+
+    assert artifact["state"] == "viable"
+    assert check["result"]["concrete_risk_row_count"] == 2
+    assert check["result"]["missing_risk_row_count"] == 0
+
+
 def test_opinion_builder_stale_evidence_blocks_forced_rows():
     payload = make_opinion_payload()
     payload["stale_risk_share"] = 0.25
@@ -349,6 +511,18 @@ def test_opinion_builder_stale_evidence_blocks_forced_rows():
     assert artifact["state"] == "no-opinion"
     assert artifact["buy_candidates"] == []
     assert "Stale mark risk" in " ".join(artifact["evidence_limitations"])
+
+
+def test_create_response_stale_evidence_blocks_opinion_rows():
+    response = make_response().model_copy(update={"stale_risk_share": 0.25})
+
+    result = research_run_service._response_with_artifact_summary(
+        response,
+        make_request(),
+    )
+
+    assert result.opinion_artifact.state == "no-opinion"
+    assert result.opinion_artifact.buy_candidates == []
 
 
 def test_opinion_builder_text_evidence_summary_does_not_invent_prose():

--- a/tests/research/test_runs.py
+++ b/tests/research/test_runs.py
@@ -199,10 +199,13 @@ def test_opinion_builder_uses_latest_dated_signal_rows_for_actions_and_checks():
         "invalidation_note"
     ]
     assert {
-        ref["date"]
+        (ref["field"], ref.get("symbol"), ref.get("date"))
         for ref in artifact["buy_candidates"][0]["source_artifact_references"]
-        if ref["artifact"] == "signals" and "date" in ref
-    } == {"2024-01-04"}
+        if ref["artifact"] == "signals" and ref["field"] in {"score", "position"}
+    } == {
+        ("score", "2330", "2024-01-04"),
+        ("position", "2330", "2024-01-04"),
+    }
     assert checks["signal_to_position"]["result"] == {
         "checked_symbol_count": 4,
         "positive_count": 1,
@@ -439,6 +442,30 @@ def test_opinion_builder_source_audit_names_missing_config_inputs():
                 "rank_ic": None,
                 "linear_ic": None,
             },
+        ),
+        (
+            {"total_return": float("nan")},
+            {"task": "regression", "sample_count": 2, "rmse": 0.1},
+        ),
+        (
+            {"total_return": float("inf")},
+            {"task": "regression", "sample_count": 2, "rmse": 0.1},
+        ),
+        (
+            {"total_return": float("-inf")},
+            {"task": "regression", "sample_count": 2, "rmse": 0.1},
+        ),
+        (
+            {"total_return": 0.0},
+            {"task": "regression", "sample_count": 2, "rmse": float("nan")},
+        ),
+        (
+            {"total_return": 0.0},
+            {"task": "regression", "sample_count": 2, "rmse": float("inf")},
+        ),
+        (
+            {"total_return": 0.0},
+            {"task": "regression", "sample_count": 2, "rmse": float("-inf")},
         ),
     ],
 )

--- a/tests/research/test_runs.py
+++ b/tests/research/test_runs.py
@@ -97,7 +97,7 @@ def make_opinion_payload() -> dict:
     return {
         "status": "succeeded",
         "request_payload": {
-            "symbols": ["2330"],
+            "symbols": ["2330", "2317"],
             "strategy": {"threshold": 0.003, "top_n": 2},
         },
         "effective_strategy": {"threshold": 0.003, "top_n": 2},
@@ -169,6 +169,7 @@ def test_opinion_contract_rejects_unknown_check_and_category():
 
 def test_opinion_builder_uses_latest_dated_signal_rows_for_actions_and_checks():
     payload = make_opinion_payload()
+    payload["symbols"] = ["2330", "2317", "2454", "9999", "8888"]
     payload["signals"] = [
         {
             "date": datetime(2024, 1, 4, 12, 30),
@@ -219,6 +220,26 @@ def test_opinion_builder_uses_latest_dated_signal_rows_for_actions_and_checks():
     assert checks["parameter_sensitivity"]["result"]["scenario_candidate_counts"][
         "top_n_minus_1"
     ] == 1
+
+
+def test_opinion_builder_undeclared_signal_symbol_blocks_viability():
+    payload = make_opinion_payload()
+    payload["signals"].append(
+        {
+            "date": "2024-01-02",
+            "symbol": "2454",
+            "score": 0.03,
+            "position": 1.0,
+        }
+    )
+
+    artifact = build_opinion_artifact(payload)
+
+    assert artifact["state"] == "no-opinion"
+    assert artifact["buy_candidates"] == []
+    assert "outside the declared run universe: 2454" in " ".join(
+        artifact["evidence_limitations"]
+    )
 
 
 def test_opinion_builder_parameter_sensitivity_reports_partial_scenario_change():
@@ -321,6 +342,20 @@ def test_opinion_builder_wrong_signal_ref_date_blocks_viability(monkeypatch):
     artifact = build_opinion_artifact(make_opinion_payload())
 
     _assert_self_review_blocks_viability(artifact, "evidence_traceability")
+
+
+def test_opinion_builder_nonexistent_invalidation_signal_field_blocks_viability(
+    monkeypatch,
+):
+    row = _valid_opinion_row()
+    for reference in row["source_artifact_references"]:
+        if reference["artifact"] == "signals":
+            reference["field"] = "missing"
+    monkeypatch.setattr(opinion_domain, "_action_rows", lambda payload: [row])
+
+    artifact = build_opinion_artifact(make_opinion_payload())
+
+    _assert_self_review_blocks_viability(artifact, "invalidation_present")
 
 
 def test_opinion_builder_generic_risk_disclaimer_blocks_viability(monkeypatch):

--- a/tests/shared/test_backtest.py
+++ b/tests/shared/test_backtest.py
@@ -3,11 +3,28 @@ import pytest
 
 from backend.shared.analytics.backtest import (
     _build_execution_price,
+    build_signals,
     compute_max_position_weight,
     compute_metrics,
     compute_turnover,
 )
 from backend.shared.analytics.strategy import build_weights_from_scores
+
+
+def test_build_signals_preserves_latest_flat_decision_surface():
+    idx = pd.to_datetime(["2024-01-02", "2024-01-03"])
+    scores = pd.DataFrame(
+        {"A": [0.8, 0.2], "B": [float("nan"), 0.1]}, index=idx
+    )
+    weights = pd.DataFrame({"A": [1.0, 0.0], "B": [0.0, 0.0]}, index=idx)
+
+    signals = build_signals(scores, weights)
+
+    assert [(item["date"], item["symbol"], item["position"]) for item in signals] == [
+        (idx[0].date(), "A", 1.0),
+        (idx[1].date(), "A", 0.0),
+        (idx[1].date(), "B", 0.0),
+    ]
 
 
 def test_build_weights_from_scores_proactive():

--- a/tests/shared/test_backtest.py
+++ b/tests/shared/test_backtest.py
@@ -14,16 +14,27 @@ from backend.shared.analytics.strategy import build_weights_from_scores
 def test_build_signals_preserves_latest_flat_decision_surface():
     idx = pd.to_datetime(["2024-01-02", "2024-01-03"])
     scores = pd.DataFrame(
-        {"A": [0.8, 0.2], "B": [float("nan"), 0.1]}, index=idx
+        {
+            "A": [0.8, 0.2],
+            "B": [float("nan"), 0.1],
+            "C": [0.5, float("nan")],
+        },
+        index=idx,
     )
-    weights = pd.DataFrame({"A": [1.0, 0.0], "B": [0.0, 0.0]}, index=idx)
+    weights = pd.DataFrame(
+        {"A": [1.0, 0.0], "B": [0.0, 0.0], "C": [0.0, 0.4]}, index=idx
+    )
 
     signals = build_signals(scores, weights)
 
-    assert [(item["date"], item["symbol"], item["position"]) for item in signals] == [
-        (idx[0].date(), "A", 1.0),
-        (idx[1].date(), "A", 0.0),
-        (idx[1].date(), "B", 0.0),
+    assert [
+        (item["date"], item["symbol"], item["score"], item["position"])
+        for item in signals
+    ] == [
+        (idx[0].date(), "A", 0.8, 1.0),
+        (idx[1].date(), "A", 0.2, 0.0),
+        (idx[1].date(), "B", 0.1, 0.0),
+        (idx[1].date(), "C", 0.0, 0.4),
     ]
 
 


### PR DESCRIPTION
## Summary
- Add research opinion review domain, contract/service/repository changes for opinion workflow.
- Add/extend research specs, validation gates, decision records, and deferred-feature planning docs.
- Add tests covering research API, run repository, and run services for opinion-related behavior.
- Add .coderabbit.yaml review configuration and GOAL.md.

## Validation
- Existing focused test command previously executed by implementation agent: `pytest tests/research/test_runs.py tests/research/test_run_repository.py tests/research/test_research_api.py` (58 passed)
- New/changed files were committed only; no additional verification run in this execution.

## Risks
- Changes are scoped to research opinion flow and tests; verify end-to-end behavior if downstream callers rely on opinion payload shapes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Phase 2 “opinion artifact” layer to research run responses, including structured buy/sell/watch candidates, evidence/risk/invalidation context, and outcome-driven review checks that downgrade outputs when evidence is insufficient.
* **Bug Fixes**
  * Improved backtest signal generation on the final weight date to preserve the latest decision surface, including newly appearing symbols.
  * Refined artifact inclusion/exclusion behavior for research-run payloads and listings.
* **Documentation**
  * Expanded Phase 2 backend specs, validation gates, and deferred/decision planning guidance.
* **Tests**
  * Strengthened deterministic opinion-artifact construction, API/repository behavior, and review-check semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->