### PR TITLE
feat: add calibrated direction confirmation

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -80,11 +80,13 @@ Accepted Scope:
   research-run artifacts
 - add focused backend tests that would fail against the current shallow
   implementation
-- keep the work backend-first and research-only
+- keep the remaining work backend-first and research-only while retaining the
+  existing hybrid review integration
 
 Non-Claims:
 
-- no frontend workflow
+- no further frontend workflow expansion beyond the retained Opinion,
+  direction-diagnostic, workflow-payload, and type integration
 - no broker routing or live orders
 - no personalized investment advice
 - no automatic rebalancing or account-level portfolio control
@@ -157,7 +159,8 @@ Rejected Evidence:
 ### Constraints
 
 - Repository artifacts stay in English.
-- Keep edits minimal and backend-scoped.
+- Keep remaining implementation edits minimal and backend-scoped; retain the
+  existing hybrid review integration without expanding it.
 - Prefer extending existing `opinion_artifact` over adding new top-level API
   fields.
 - Prefer deterministic reconstruction from persisted run artifacts over adding
@@ -172,7 +175,8 @@ Rejected Evidence:
 
 ### Non-Goals
 
-- Frontend UI for opinions.
+- Further frontend opinion UI expansion beyond the retained hybrid review
+  surface.
 - Broker integration or live-order execution.
 - Paper/live execution loop.
 - Portfolio auto-control or automatic rebalancing.
@@ -241,9 +245,10 @@ evidence:
 - acceptance status for every AC below
 - manual audit against `docs/research-spec.md`, `docs/validation-gates.md`,
   `docs/decision-register.md`, and `docs/deferred-feature-plan.md`
-- explicit statement that no frontend, broker/live execution, portfolio
-  auto-control, US provider implementation, provider abstraction, adaptive/RL
-  workflow, crypto trading behavior, or external runtime dependency was added
+- explicit statement that no further frontend expansion, broker/live execution,
+  portfolio auto-control, US provider implementation, provider abstraction,
+  adaptive/RL workflow, crypto trading behavior, or external runtime dependency
+  was added; the existing hybrid review integration remains retained
 
 The evaluator must not assume hidden tool output, provider memory, unsurfaced
 local state, or latest in-session response content.
@@ -701,10 +706,11 @@ Self-review failures must affect `state`, `state_reason`, or
 - [ ] AC-18: No execution or dependency creep
   Given backend opinion expansion is implemented
   When API contracts, code paths, dependencies, and touched docs are inspected
-  Then they do not add or imply frontend workflow expansion, broker routing,
-  live orders, automatic rebalancing, account control, personalized investment
-  advice, US provider implementation, provider abstraction, adaptive/RL control,
-  crypto trading behavior, or external runtime adoption
+  Then they do not add or imply frontend workflow expansion beyond the retained
+  hybrid review integration, broker routing, live orders, automatic rebalancing,
+  account control, personalized investment advice, US provider implementation,
+  provider abstraction, adaptive/RL control, crypto trading behavior, or
+  external runtime adoption
   Evidence: manual diff/dependency review against `GATE-P2-004`,
   `GATE-P2-005`, and `docs/deferred-feature-plan.md`
 
@@ -774,9 +780,9 @@ Stop and report blocked if:
   by the docs
 - focused tests cannot run after one environment/tooling retry
 - the same blocker repeats for three consecutive attempts
-- completion would require frontend, broker/live execution, portfolio control,
-  US provider work, provider abstraction, adaptive/RL control, crypto runtime
-  behavior, or an external dependency
+- completion would require further frontend expansion, broker/live execution,
+  portfolio control, US provider work, provider abstraction, adaptive/RL
+  control, crypto runtime behavior, or an external dependency
 - checked docs conflict about acceptance or scope
 
 If a method cannot be evaluated from current artifacts, do not invent data.

--- a/README.md
+++ b/README.md
@@ -17,16 +17,18 @@ The main workflow is:
 5. Strategy backtest
 6. Experiment comparison
 
-Prediction tasks include both regression and classification at the specification
-level. The first implementation pass supports regression diagnostics; the
-classification contract is documented so it can be added without changing the
-research workflow shape.
+The default prediction task combines forward-return regression with a
+provisionally calibrated direction classifier. Regression ranks predicted
+returns; classification confirms direction before the workbench emits
+prospective model output for review. Artifact completeness does not establish
+out-of-sample skill or investment viability.
 
 ## What This Repository Owns
 
 - TW daily research-run creation and persisted review
 - feature selection for model-ready daily data
 - tabular regression model diagnostics
+- calibrated direction-classification diagnostics
 - strategy backtest artifacts derived from model scores
 - experiment registry and comparison context
 - data-readiness diagnostics needed to explain research reliability
@@ -52,6 +54,7 @@ promotes them deliberately.
 | TW daily data readiness | implemented with diagnostics | ingestion, replay, lifecycle, important-event, and recovery surfaces support data trust checks |
 | Baseline experiment builder | implemented | a researcher can start from the baseline workflow without editing API payloads |
 | Regression diagnostics | implemented | successful regression runs return and reload model-quality artifacts before strategy interpretation |
+| Hybrid model opinion | implemented | regression ranking and direction confirmation produce a common-date, manual-review opinion; holdout signals remain evaluation-only |
 | Persisted artifact reload | verified | new successful runs reload request config, diagnostics, equity, signals, baselines, warnings, runtime metadata, and artifact completeness summaries |
 | Experiment comparison | usable for v1 loop | search, load, and compare work for complete research-review runs; metadata-only and partial records expose backend caveats before comparison |
 | Advanced/platform modules | hidden advanced | execution, adaptive, peer, factor, and tick archive capabilities are not v1 main-flow surfaces |

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ diagnostic surfaces unless a future roadmap promotes them.
 
 ## Still Partial Or Deferred
 
-- classification is specified but not implemented in the first code pass
+- direction classification is implemented as provisional confirmation; its
+  calibration gates and pooled diagnostics do not establish per-symbol skill
 - richer pairwise comparison explanations can still improve review workflow, but
   incomplete artifacts and backend comparison caveats now block optimistic compare
 - execution, adaptive, peer, factor, and tick archive modules are deferred from

--- a/backend/research/api.py
+++ b/backend/research/api.py
@@ -13,6 +13,7 @@ from backend.research.contracts.governance import (
 )
 from backend.research.contracts.runs import (
     DateRange,
+    DirectionModelConfig,
     ExecutionConfig,
     FeatureRegistryResponse,
     FeatureSpec,
@@ -57,6 +58,7 @@ class PublicResearchRunCreateRequest(RequestModel):
     horizon_days: conint(ge=1) = 1  # type: ignore[valid-type]
     features: list[FeatureSpec]
     model: ModelConfig = Field(default_factory=ModelConfig)
+    direction_model: DirectionModelConfig | None = None
     strategy: StrategyConfig
     execution: ExecutionConfig = Field(default_factory=ExecutionConfig)
     validation: ValidationConfig | None = None

--- a/backend/research/contracts/__init__.py
+++ b/backend/research/contracts/__init__.py
@@ -12,6 +12,8 @@ from .governance import (
 from .runs import (
     BacktestRequest,
     DateRange,
+    DirectionClassificationDiagnostics,
+    DirectionModelConfig,
     EquityPoint,
     ExecutionConfig,
     FeatureDefinition,
@@ -54,6 +56,8 @@ __all__ = [
     "ResearchPhaseGateResponse",
     "BacktestRequest",
     "DateRange",
+    "DirectionClassificationDiagnostics",
+    "DirectionModelConfig",
     "EquityPoint",
     "ExecutionConfig",
     "FeatureDefinition",

--- a/backend/research/contracts/runs.py
+++ b/backend/research/contracts/runs.py
@@ -63,7 +63,7 @@ class FeatureSpec(RequestModel):
     name: FeatureName
     window: conint(ge=1)  # type: ignore[valid-type]
     source: PriceSource = "close"
-    shift: conint(ge=0) = 1  # type: ignore[valid-type]
+    shift: conint(ge=1) = 1  # type: ignore[valid-type]
 
 
 class FeatureDefinition(BaseModel):
@@ -82,6 +82,17 @@ class FeatureRegistryResponse(BaseModel):
 class ModelConfig(RequestModel):
     type: ModelType = Field(default="xgboost", description="Model identifier.")
     params: Dict[str, object] = Field(default_factory=dict)
+
+
+class DirectionModelConfig(ModelConfig):
+    positive_return_threshold: float = 0.0
+    confirmation_probability_threshold: confloat(ge=0, le=1) = 0.5  # type: ignore[valid-type]
+    calibration_policy_version: Literal[
+        "chronological_tail_20pct_min20_class5_v1"
+    ] = "chronological_tail_20pct_min20_class5_v1"
+    confirmation_policy_version: Literal[
+        "regression_threshold_direction_probability_v1"
+    ] = "regression_threshold_direction_probability_v1"
 
 
 class StrategyConfig(RequestModel):
@@ -114,6 +125,7 @@ class ResearchRunCreateRequest(RequestModel):
     horizon_days: conint(ge=1) = 1  # type: ignore[valid-type]
     features: List[FeatureSpec]
     model: ModelConfig = Field(default_factory=ModelConfig)
+    direction_model: Optional[DirectionModelConfig] = None
     strategy: StrategyConfig
     execution: ExecutionConfig = Field(default_factory=ExecutionConfig)
     validation: Optional[ValidationConfig] = None
@@ -231,13 +243,32 @@ class EquityPoint(BaseModel):
 class SignalPoint(BaseModel):
     date: date
     symbol: str
-    score: float
+    score: Optional[float]
     position: float
+    signal_kind: Literal["holdout_evaluation", "forward_opinion"] = (
+        "holdout_evaluation"
+    )
+    up_probability: Optional[float] = None
+    predicted_direction: Optional[Literal["up", "down"]] = None
 
 
 class ValidationSummary(BaseModel):
     method: ValidationMethod
+    evaluation_status: Literal["evaluated", "not_evaluated"]
+    status_reason: Optional[str] = None
     metrics: Dict[str, float]
+
+    @model_validator(mode="after")
+    def status_matches_metrics(self) -> "ValidationSummary":
+        if self.evaluation_status == "evaluated":
+            if not self.metrics:
+                raise ValueError("evaluated validation requires non-empty metrics")
+            return self
+        if self.metrics:
+            raise ValueError("not_evaluated validation must not include metrics")
+        if not self.status_reason:
+            raise ValueError("not_evaluated validation requires status_reason")
+        return self
 
 
 class RegressionDiagnosticPoint(BaseModel):
@@ -253,6 +284,36 @@ class FeatureImportancePoint(BaseModel):
     importance: float
 
 
+class DirectionClassificationDiagnostics(BaseModel):
+    task: Literal["binary_classification"] = "binary_classification"
+    evaluation_status: Literal["evaluated", "not_evaluated"]
+    status_reason: Optional[str] = None
+    sample_count: int = Field(
+        default=0,
+        description="Holdout rows pooled across all evaluated symbols.",
+    )
+    positive_return_threshold: float = 0.0
+    confirmation_probability_threshold: float = 0.5
+    calibration_method: Literal["sigmoid"] = "sigmoid"
+    calibration_policy_version: Literal[
+        "chronological_tail_20pct_min20_class5_v1"
+    ] = "chronological_tail_20pct_min20_class5_v1"
+    confirmation_policy_version: Literal[
+        "regression_threshold_direction_probability_v1"
+    ] = "regression_threshold_direction_probability_v1"
+    calibration_sample_count: int = Field(
+        default=0,
+        description="Sum of calibration rows across all evaluated symbols.",
+    )
+    positive_prevalence: Optional[float] = None
+    confusion_matrix: List[List[int]] = Field(default_factory=list)
+    precision: Optional[float] = None
+    recall: Optional[float] = None
+    roc_auc: Optional[float] = None
+    pr_auc: Optional[float] = None
+    brier: Optional[float] = None
+
+
 class RegressionDiagnostics(BaseModel):
     task: Literal["regression"] = "regression"
     sample_count: int = 0
@@ -263,6 +324,7 @@ class RegressionDiagnostics(BaseModel):
     actual_vs_predicted: List[RegressionDiagnosticPoint] = Field(default_factory=list)
     residuals: List[RegressionDiagnosticPoint] = Field(default_factory=list)
     feature_importance: List[FeatureImportancePoint] = Field(default_factory=list)
+    direction_classification: Optional[DirectionClassificationDiagnostics] = None
 
 
 class ComparisonCaveat(BaseModel):
@@ -330,6 +392,9 @@ class OpinionRow(BaseModel):
     symbol: str
     model_score: float
     position_signal: float
+    signal_date: date
+    up_probability: float
+    confirmation_state: Literal["confirmed", "conflict"]
     evidence_reason: str
     risk_or_warning: str
     invalidation_note: str
@@ -361,6 +426,7 @@ class OpinionArtifact(BaseModel):
     state: OpinionArtifactState
     state_reason: str
     manual_adoption_only: Literal[True] = True
+    opinion_as_of: Optional[date] = None
     evidence_limitations: List[str] = Field(default_factory=list)
     buy_candidates: List[OpinionRow] = Field(default_factory=list)
     sell_or_avoid: List[OpinionRow] = Field(default_factory=list)

--- a/backend/research/contracts/runs.py
+++ b/backend/research/contracts/runs.py
@@ -433,6 +433,18 @@ class OpinionArtifact(BaseModel):
     watch: List[OpinionRow] = Field(default_factory=list)
     review_checks: List[OpinionReviewCheck] = Field(default_factory=list)
 
+    @model_validator(mode="after")
+    def opinion_rows_match_as_of(self) -> "OpinionArtifact":
+        rows = [*self.buy_candidates, *self.sell_or_avoid, *self.watch]
+        if rows and (
+            self.opinion_as_of is None
+            or any(row.signal_date != self.opinion_as_of for row in rows)
+        ):
+            raise ValueError(
+                "opinion rows must share the persisted opinion_as_of date"
+            )
+        return self
+
 
 class ReviewArtifactSummaryMixin(BaseModel):
     artifact_completeness: ArtifactCompleteness = "metadata_only"

--- a/backend/research/domain/artifact_summary.py
+++ b/backend/research/domain/artifact_summary.py
@@ -43,6 +43,19 @@ def _requests_baselines(request_payload: dict[str, Any] | None) -> bool | None:
     return isinstance(baselines, list) and len(baselines) > 0
 
 
+def has_requested_baselines(
+    request_payload: dict[str, Any] | None, baselines: Any
+) -> bool:
+    if not isinstance(baselines, dict):
+        return False
+    if request_payload is None:
+        return True
+    requested = request_payload.get("baselines")
+    if not isinstance(requested, list):
+        return True
+    return all(baseline in baselines for baseline in requested)
+
+
 def _required_artifacts(
     request_payload: dict[str, Any] | None,
 ) -> tuple[ReviewArtifactName, ...]:

--- a/backend/research/domain/opinion.py
+++ b/backend/research/domain/opinion.py
@@ -47,6 +47,10 @@ def _is_number(value: Any) -> bool:
     )
 
 
+def _is_probability(value: Any) -> bool:
+    return _is_number(value) and 0.0 <= value <= 1.0
+
+
 def _has_metrics_evidence(value: Any) -> bool:
     metrics = _as_mapping(value)
     return any(
@@ -191,13 +195,15 @@ def _latest_signals(
         _as_mapping(payload.get("request_payload")).get("symbols")
     )
     allowed_symbols = {str(symbol) for symbol in declared if symbol}
-    latest_by_symbol: dict[str, Mapping[str, Any]] = {}
-    latest_dates: dict[str, str] = {}
+    forward_by_symbol: dict[str, Mapping[str, Any]] = {}
+    forward_dates: set[str] = set()
     unexpected_symbols: set[str] = set()
     unexpected_signal_count = 0
     malformed_signal_count = 0
     for item in _as_list(payload.get("signals")):
         signal = _as_mapping(item)
+        if signal.get("signal_kind") != "forward_opinion":
+            continue
         symbol = signal.get("symbol")
         if not symbol:
             malformed_signal_count += 1
@@ -211,18 +217,23 @@ def _latest_signals(
         if signal_date is None:
             malformed_signal_count += 1
             continue
-        if (
-            symbol_key not in latest_dates
-            or signal_date >= latest_dates[symbol_key]
-        ):
-            latest_by_symbol[symbol_key] = signal
-            latest_dates[symbol_key] = signal_date
-    latest = [latest_by_symbol[symbol] for symbol in sorted(latest_by_symbol)]
+        if symbol_key in forward_by_symbol:
+            malformed_signal_count += 1
+            continue
+        forward_by_symbol[symbol_key] = signal
+        forward_dates.add(signal_date)
+    latest = [forward_by_symbol[symbol] for symbol in sorted(forward_by_symbol)]
+    if allowed_symbols and set(forward_by_symbol) != allowed_symbols:
+        malformed_signal_count += len(allowed_symbols.symmetric_difference(forward_by_symbol))
+    if len(forward_dates) > 1:
+        malformed_signal_count += len(forward_dates)
     invalid_count = sum(
         1
         for item in latest
         if not _is_number(item.get("score"))
         or not _is_number(item.get("position"))
+        or not _is_probability(item.get("up_probability"))
+        or item.get("predicted_direction") not in {"up", "down"}
     )
     return (
         latest,
@@ -239,6 +250,8 @@ def _valid_latest_signals(payload: Mapping[str, Any]) -> list[Mapping[str, Any]]
         if _signal_date_key(item) is not None
         and _is_number(item.get("score"))
         and _is_number(item.get("position"))
+        and _is_probability(item.get("up_probability"))
+        and item.get("predicted_direction") in {"up", "down"}
     ]
 
 
@@ -254,6 +267,11 @@ def _action_rows(payload: Mapping[str, Any]) -> list[dict[str, Any]]:
                 "symbol": symbol,
                 "model_score": float(signal["score"]),
                 "position_signal": float(signal["position"]),
+                "signal_date": signal_date,
+                "up_probability": float(signal["up_probability"]),
+                "confirmation_state": "confirmed"
+                if signal["predicted_direction"] == "up"
+                else "conflict",
                 "evidence_reason": (
                     f"Latest persisted signal for {symbol} on {signal_date} links "
                     "numeric score to strategy position."
@@ -263,6 +281,7 @@ def _action_rows(payload: Mapping[str, Any]) -> list[dict[str, Any]]:
                 "source_artifact_references": [
                     _signal_ref("score", signal),
                     _signal_ref("position", signal),
+                    _signal_ref("up_probability", signal),
                     *_refs(
                         ("model_diagnostics", "model_diagnostics"),
                         ("metrics", "metrics"),
@@ -303,6 +322,14 @@ def _strategy_top_n(payload: Mapping[str, Any]) -> int | None:
     )
     top_n = strategy.get("top_n")
     return int(top_n) if isinstance(top_n, int) and not isinstance(top_n, bool) else None
+
+
+def _confirmation_threshold(payload: Mapping[str, Any]) -> float | None:
+    direction = _as_mapping(
+        _as_mapping(payload.get("request_payload")).get("direction_model")
+    )
+    threshold = direction.get("confirmation_probability_threshold")
+    return float(threshold) if _is_number(threshold) else None
 
 
 def _string_values(value: Any) -> list[str]:
@@ -544,10 +571,14 @@ def _parameter_sensitivity(payload: Mapping[str, Any]) -> dict[str, Any]:
         skipped.append("threshold_missing_or_non_positive")
     else:
         scenarios["strict_threshold"] = {
-            str(item["symbol"]) for item in valid if float(item["score"]) >= threshold * 1.25
+            str(item["symbol"])
+            for item in valid
+            if float(item["score"]) >= threshold * 1.25
         }
         scenarios["loose_threshold"] = {
-            str(item["symbol"]) for item in valid if float(item["score"]) >= threshold * 0.75
+            str(item["symbol"])
+            for item in valid
+            if float(item["score"]) >= threshold * 0.75
         }
 
     ranked = sorted(valid, key=lambda item: float(item["score"]), reverse=True)
@@ -563,7 +594,8 @@ def _parameter_sensitivity(payload: Mapping[str, Any]) -> dict[str, Any]:
         else:
             skipped.append("top_n_minus_1_requires_top_n_above_one")
         scenarios["top_n_plus_1"] = {
-            str(item["symbol"]) for item in ranked[: min(top_n + 1, len(ranked))]
+            str(item["symbol"])
+            for item in ranked[: min(top_n + 1, len(ranked))]
         }
 
     if not scenarios:
@@ -948,6 +980,7 @@ def _empty_artifact(
         "state": state,
         "state_reason": reason,
         "manual_adoption_only": True,
+        "opinion_as_of": None,
         "evidence_limitations": limitations,
         "buy_candidates": [],
         "sell_or_avoid": [],
@@ -975,6 +1008,7 @@ def build_opinion_artifact(payload: Mapping[str, Any]) -> dict[str, Any]:
                 else "Research run did not complete successfully."
             ),
             "manual_adoption_only": True,
+            "opinion_as_of": None,
             "evidence_limitations": limitations,
             "buy_candidates": [],
             "sell_or_avoid": [],
@@ -997,15 +1031,37 @@ def build_opinion_artifact(payload: Mapping[str, Any]) -> dict[str, Any]:
         limitations.append("Strategy metrics artifact is unavailable.")
     if not _has_diagnostics_evidence(payload.get("model_diagnostics")):
         limitations.append("Model diagnostics artifact is unavailable.")
-    if not _as_list(payload.get("signals")):
+    signals = _as_list(payload.get("signals"))
+    if not signals:
         limitations.append("Signal artifact is unavailable.")
     else:
-        _, _, unexpected_symbols = _latest_signals(payload)
+        forward_signals, invalid_signal_count, unexpected_symbols = _latest_signals(
+            payload
+        )
+        if not forward_signals:
+            limitations.append(
+                "Prospective direction-confirmed signals are unavailable; "
+                "holdout evaluation signals are not investment opinions."
+            )
+        elif invalid_signal_count:
+            limitations.append(
+                "Prospective signals must contain exactly one valid row per declared "
+                "symbol on a common as-of date."
+            )
         if unexpected_symbols:
             limitations.append(
                 "Signal artifact contains symbols outside the declared run universe: "
                 f"{', '.join(unexpected_symbols)}."
             )
+    direction_diagnostics = _as_mapping(
+        _as_mapping(payload.get("model_diagnostics")).get(
+            "direction_classification"
+        )
+    )
+    if direction_diagnostics.get("evaluation_status") != "evaluated":
+        limitations.append(
+            "Direction classification diagnostics are unavailable or not evaluated."
+        )
     if payload.get("stale_mark_days_with_open_positions") or payload.get("stale_risk_share"):
         limitations.append("Stale mark risk is present in persisted artifacts.")
 
@@ -1019,7 +1075,7 @@ def build_opinion_artifact(payload: Mapping[str, Any]) -> dict[str, Any]:
     if limitations:
         return _empty_artifact(
             "no-opinion",
-            "Persisted artifacts are insufficient for a traceable opinion.",
+            "Persisted artifacts are insufficient for reviewable, traceable model output.",
             limitations,
             payload,
         )
@@ -1034,14 +1090,50 @@ def build_opinion_artifact(payload: Mapping[str, Any]) -> dict[str, Any]:
             payload,
         )
 
-    buy_candidates = [row for row in rows if row["position_signal"] > 0]
-    sell_or_avoid = [row for row in rows if row["position_signal"] < 0]
-    watch = [row for row in rows if row["position_signal"] == 0]
+    regression_threshold = _strategy_threshold(payload)
+    confirmation_threshold = _confirmation_threshold(payload)
+    if regression_threshold is None or confirmation_threshold is None:
+        return _empty_artifact(
+            "no-opinion",
+            "Hybrid prediction policy is unavailable.",
+            ["Regression or direction confirmation threshold is unavailable."],
+            payload,
+        )
+    buy_candidates = [
+        row
+        for row in rows
+        if row["position_signal"] > 0
+        and row["up_probability"] >= confirmation_threshold
+    ]
+    sell_or_avoid = [
+        row
+        for row in rows
+        if row["model_score"] < regression_threshold
+        and row["up_probability"] < confirmation_threshold
+    ]
+    action_symbols = {
+        row["symbol"] for row in [*buy_candidates, *sell_or_avoid]
+    }
+    watch = [row for row in rows if row["symbol"] not in action_symbols]
+    for row in buy_candidates:
+        row["confirmation_state"] = "confirmed"
+    for row in [*sell_or_avoid, *watch]:
+        row["confirmation_state"] = (
+            "confirmed"
+            if (row["model_score"] < regression_threshold)
+            == (row["up_probability"] < confirmation_threshold)
+            else "conflict"
+        )
+    opinion_as_of = rows[0]["signal_date"]
     artifact = {
         "artifact_version": OPINION_ARTIFACT_VERSION,
         "state": "viable",
-        "state_reason": "Complete persisted research artifacts support traceable opinion rows.",
+        "state_reason": (
+            "Complete persisted artifacts support reviewable, traceable model output; "
+            "they do not establish out-of-sample skill or investment viability."
+        ),
         "manual_adoption_only": True,
+        "opinion_as_of": opinion_as_of,
         "evidence_limitations": [],
         "buy_candidates": buy_candidates,
         "sell_or_avoid": sell_or_avoid,
@@ -1059,7 +1151,7 @@ def build_opinion_artifact(payload: Mapping[str, Any]) -> dict[str, Any]:
     }
     if failed_checks:
         artifact["state"] = "no-opinion"
-        artifact["state_reason"] = "Self-review gates blocked a viable opinion."
+        artifact["state_reason"] = "Self-review gates blocked reviewable model output."
         artifact["evidence_limitations"] = [
             "One or more self-review gates failed; reload details before adopting."
         ]

--- a/backend/research/repositories/runs.py
+++ b/backend/research/repositories/runs.py
@@ -20,7 +20,11 @@ from backend.platform.db.repository_helpers import (
 )
 from backend.platform.errors import DataAccessError, DataNotFoundError
 from backend.platform.time import utc_now
-from backend.research.domain.artifact_summary import build_review_artifact_summary
+from backend.research.contracts.runs import ValidationSummary
+from backend.research.domain.artifact_summary import (
+    build_review_artifact_summary,
+    has_requested_baselines,
+)
 from backend.research.domain.opinion import build_opinion_artifact
 from backend.research.domain.version_pack import build_version_pack_payload
 
@@ -44,19 +48,72 @@ def _validation_summary_from_payload(value: Any) -> dict[str, Any] | None:
         return None
     if "method" not in value or "metrics" not in value:
         return None
-    if value["method"] not in {
-        "holdout",
-        "walk_forward",
-        "rolling_window",
-        "expanding_window",
-    }:
-        return None
     if not isinstance(value["metrics"], dict):
         return None
-    for metric_value in value["metrics"].values():
-        if not isinstance(metric_value, int | float):
+    payload = dict(value)
+    if "evaluation_status" not in payload:
+        if payload["metrics"]:
+            payload["evaluation_status"] = "evaluated"
+        else:
+            payload["evaluation_status"] = "not_evaluated"
+            payload["status_reason"] = (
+                "Legacy validation record has no metrics or persisted status reason."
+            )
+    try:
+        return ValidationSummary.model_validate(payload).model_dump(mode="json")
+    except ValueError:
+        return None
+
+
+def _direction_diagnostics_from_payload(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict) or value.get("task") != "binary_classification":
+        return None
+    if value.get("evaluation_status") not in {"evaluated", "not_evaluated"}:
+        return None
+    payload = {
+        "task": "binary_classification",
+        "evaluation_status": value["evaluation_status"],
+        "status_reason": value.get("status_reason"),
+        "sample_count": value.get("sample_count", 0),
+        "positive_return_threshold": value.get("positive_return_threshold", 0.0),
+        "confirmation_probability_threshold": value.get(
+            "confirmation_probability_threshold", 0.5
+        ),
+        "calibration_method": value.get("calibration_method", "sigmoid"),
+        "calibration_policy_version": value.get(
+            "calibration_policy_version",
+            "chronological_tail_20pct_min20_class5_v1",
+        ),
+        "confirmation_policy_version": value.get(
+            "confirmation_policy_version",
+            "regression_threshold_direction_probability_v1",
+        ),
+        "calibration_sample_count": value.get("calibration_sample_count", 0),
+        "positive_prevalence": value.get("positive_prevalence"),
+        "confusion_matrix": value.get("confusion_matrix", []),
+        "precision": value.get("precision"),
+        "recall": value.get("recall"),
+        "roc_auc": value.get("roc_auc"),
+        "pr_auc": value.get("pr_auc"),
+        "brier": value.get("brier"),
+    }
+    for key in (
+        "sample_count",
+        "positive_return_threshold",
+        "confirmation_probability_threshold",
+        "calibration_sample_count",
+        "positive_prevalence",
+        "precision",
+        "recall",
+        "roc_auc",
+        "pr_auc",
+        "brier",
+    ):
+        if payload[key] is not None and not isinstance(payload[key], int | float):
             return None
-    return value
+    if not isinstance(payload["confusion_matrix"], list):
+        return None
+    return payload
 
 
 def _model_diagnostics_from_payload(value: Any) -> dict[str, Any] | None:
@@ -79,6 +136,9 @@ def _model_diagnostics_from_payload(value: Any) -> dict[str, Any] | None:
         "actual_vs_predicted": value.get("actual_vs_predicted", []),
         "residuals": value.get("residuals", []),
         "feature_importance": value.get("feature_importance", []),
+        "direction_classification": _direction_diagnostics_from_payload(
+            value.get("direction_classification")
+        ),
     }
     for key in ("rmse", "mae", "rank_ic", "linear_ic"):
         if payload[key] is not None and not isinstance(payload[key], int | float):
@@ -108,6 +168,7 @@ def _review_artifact_summary_from_row(
     validation_outcome: Any,
     model_diagnostics: Any,
 ) -> dict[str, Any]:
+    baselines = json_loads(row.baselines_json, None)
     return build_review_artifact_summary(
         status=row.status,
         request_payload=request_payload,
@@ -123,7 +184,7 @@ def _review_artifact_summary_from_row(
             "validation": _validation_summary_from_payload(validation_outcome)
             is not None,
             "baselines": row.baselines_json is not None
-            and isinstance(json_loads(row.baselines_json, None), dict),
+            and has_requested_baselines(request_payload, baselines),
         },
     )
 

--- a/backend/research/services/execution.py
+++ b/backend/research/services/execution.py
@@ -1,9 +1,18 @@
 from __future__ import annotations
 
 import logging
+import math
 from dataclasses import dataclass
 
 import pandas as pd
+from sklearn.metrics import (
+    average_precision_score,
+    brier_score_loss,
+    confusion_matrix,
+    precision_score,
+    recall_score,
+    roc_auc_score,
+)
 
 from backend.platform.errors import (
     DataNotFoundError,
@@ -11,6 +20,7 @@ from backend.platform.errors import (
     UnsupportedConfigurationError,
 )
 from backend.research.contracts.runs import (
+    DirectionClassificationDiagnostics,
     Metrics,
     RegressionDiagnostics,
     ResearchRunCreateRequest,
@@ -64,6 +74,15 @@ class ResearchRunExecutionArtifacts:
     warnings: list[str]
 
 
+def _metrics_are_finite(metrics: dict) -> bool:
+    if not metrics:
+        return False
+    try:
+        return all(math.isfinite(float(value)) for value in metrics.values())
+    except (TypeError, ValueError, OverflowError):
+        return False
+
+
 def build_feature_config(request: ResearchRunCreateRequest) -> tuple[dict, dict]:
     config: dict = {}
     shift_map: dict = {}
@@ -107,8 +126,11 @@ def apply_feature_shifts(df: pd.DataFrame, shift_map: dict, symbol: str) -> None
             raise UnsupportedConfigurationError(
                 f"[{symbol}] Expected feature column '{column}' not found after feature generation."
             )
-        if shift:
-            df[column] = df[column].shift(shift)
+        if shift < 1:
+            raise UnsupportedConfigurationError(
+                f"[{symbol}] Feature shift for '{column}' must be >= 1."
+            )
+        df[column] = df[column].shift(shift)
 
 
 def load_symbol_data(
@@ -157,8 +179,11 @@ def load_symbol_data(
         )
 
     try:
+        purge = model_service.target_lookahead(
+            request.return_target, request.horizon_days
+        )
         X_train, X_test, y_train, y_test = model_service.time_series_split(
-            X, y, test_size=test_size
+            X, y, test_size=test_size, purge=purge
         )
     except ValueError as exc:
         raise InsufficientDataError(f"[{symbol}] {exc}") from exc
@@ -172,7 +197,7 @@ def load_symbol_data(
     preds = model.predict(X_test)
     predictions = pd.Series(preds, index=X_test.index, name=symbol)
 
-    return {
+    result = {
         "symbol": symbol,
         "df_model": df_model,
         "X": X,
@@ -181,6 +206,7 @@ def load_symbol_data(
         "actuals": y_test.rename(symbol),
         "predictions": predictions,
         "feature_names": list(X_train.columns),
+        "prediction_features": df_features.reindex(columns=X.columns).dropna(),
         "feature_importance": _extract_feature_importance(model, list(X_train.columns)),
         "open": df_model.loc[X_test.index, "open"].rename(symbol),
         "high": df_model.loc[X_test.index, "high"].rename(symbol),
@@ -189,6 +215,165 @@ def load_symbol_data(
         "volume": df_model.loc[X_test.index, "volume"].rename(symbol),
         "factor_materializations": factor_materializations,
     }
+    direction_config = request.direction_model
+    if direction_config is not None:
+        direction_train = (
+            y_train > direction_config.positive_return_threshold
+        ).astype(int)
+        classifier, unavailable_reason, calibration_size = (
+            model_service.fit_calibrated_direction_classifier(
+                model_type=direction_config.type,
+                X_train=X_train,
+                y_train=direction_train,
+                model_params=direction_config.params,
+                purge=purge,
+            )
+        )
+        result.update(
+            {
+                "direction_config": direction_config,
+                "direction_unavailable_reason": unavailable_reason,
+                "direction_calibration_sample_count": calibration_size,
+            }
+        )
+        if classifier is not None:
+            positive_class_index = list(classifier.classes_).index(1)
+            result["direction_actuals"] = (
+                y_test > direction_config.positive_return_threshold
+            ).astype(int)
+            result["up_probabilities"] = pd.Series(
+                classifier.predict_proba(X_test)[:, positive_class_index],
+                index=X_test.index,
+                name=symbol,
+            )
+    return result
+
+
+def build_forward_opinion_signals(
+    symbol_data: list[dict],
+    request: ResearchRunCreateRequest,
+    strategy: ResearchStrategyConfig,
+) -> tuple[list[dict], str | None]:
+    direction_config = request.direction_model
+    if direction_config is None:
+        return [], None
+    if not symbol_data:
+        return [], "Prospective opinion unavailable: no symbol data was loaded."
+    purge = model_service.target_lookahead(
+        request.return_target, request.horizon_days
+    )
+    if purge == 0:
+        return (
+            [],
+            "Prospective opinion unavailable: the configured target has no "
+            "unlabeled forward feature row.",
+        )
+    loaded_symbols = {item.get("symbol") for item in symbol_data}
+    if loaded_symbols != set(request.symbols) or len(symbol_data) != len(
+        request.symbols
+    ):
+        return (
+            [],
+            "Prospective opinion unavailable: loaded symbols do not match the "
+            "requested universe.",
+        )
+
+    latest_dates = [item["prediction_features"].index.max() for item in symbol_data]
+    if any(pd.isna(value) for value in latest_dates) or len(set(latest_dates)) != 1:
+        return (
+            [],
+            "Prospective opinion unavailable: requested symbols do not share one "
+            "latest feature date.",
+        )
+    as_of = latest_dates[0]
+
+    scores: dict[str, float] = {}
+    probabilities: dict[str, float] = {}
+    for item in symbol_data:
+        X = item["X"]
+        y = item["y"]
+        forward_features = item["prediction_features"].loc[[as_of]]
+        regressor = model_service.fit_regressor(
+            model_type=request.model.type,
+            X_train=X,
+            y_train=y,
+            model_params=request.model.params,
+        )
+        classifier, unavailable_reason, _ = (
+            model_service.fit_calibrated_direction_classifier(
+                model_type=direction_config.type,
+                X_train=X,
+                y_train=(y > direction_config.positive_return_threshold).astype(int),
+                model_params=direction_config.params,
+                purge=purge,
+            )
+        )
+        if classifier is None:
+            return (
+                [],
+                f"[{item['symbol']}] Prospective direction calibration unavailable: "
+                f"{unavailable_reason or 'classifier was not produced.'}",
+            )
+        positive_class_index = list(classifier.classes_).index(1)
+        score = float(regressor.predict(forward_features)[0])
+        probability = float(
+            classifier.predict_proba(forward_features)[0][positive_class_index]
+        )
+        if (
+            not math.isfinite(score)
+            or not math.isfinite(probability)
+            or not 0.0 <= probability <= 1.0
+        ):
+            return (
+                [],
+                f"[{item['symbol']}] Prospective opinion unavailable: model output "
+                "was non-finite or outside the probability range.",
+            )
+        scores[item["symbol"]] = score
+        probabilities[item["symbol"]] = probability
+
+    scores_df = pd.DataFrame(scores, index=[as_of])
+    probabilities_df = pd.DataFrame(probabilities, index=[as_of])
+    weights = backtest_service.build_target_weights(
+        scores=scores_df,
+        strategy=strategy,
+        confirmation_probabilities=probabilities_df,
+        confirmation_threshold=direction_config.confirmation_probability_threshold,
+    )
+    signals = backtest_service.build_signals(
+        scores_df,
+        weights,
+        probabilities_df,
+        signal_kind="forward_opinion",
+        confirmation_threshold=direction_config.confirmation_probability_threshold,
+    )
+    return signals, None
+
+
+def build_holdout_confirmation_probabilities(
+    symbol_data: list[dict],
+    scores: pd.DataFrame,
+    request: ResearchRunCreateRequest,
+) -> tuple[pd.DataFrame | None, str | None]:
+    if request.direction_model is None:
+        return None, None
+
+    unavailable = [
+        item["symbol"]
+        for item in symbol_data
+        if item.get("up_probabilities") is None
+    ]
+    if unavailable:
+        return (
+            pd.DataFrame(float("nan"), index=scores.index, columns=scores.columns),
+            "Direction confirmation unavailable for "
+            f"{', '.join(unavailable)}; hybrid backtest positions were held at zero.",
+        )
+
+    probabilities = pd.concat(
+        [item["up_probabilities"] for item in symbol_data], axis=1
+    )
+    return probabilities.reindex(index=scores.index, columns=scores.columns), None
 
 
 def _extract_feature_importance(model: object, feature_names: list[str]) -> dict[str, float]:
@@ -211,7 +396,96 @@ def _clean_metric(value: float) -> float | None:
     return float(value) if pd.notna(value) else None
 
 
+def build_direction_classification_diagnostics(
+    symbol_data: list[dict],
+) -> DirectionClassificationDiagnostics | None:
+    configured = [item for item in symbol_data if item.get("direction_config")]
+    if not configured:
+        return None
+
+    config = configured[0]["direction_config"]
+    unavailable = [
+        f"{item['symbol']}: {item['direction_unavailable_reason']}"
+        for item in configured
+        if item.get("direction_unavailable_reason")
+    ]
+    if unavailable or len(configured) != len(symbol_data):
+        return DirectionClassificationDiagnostics(
+            evaluation_status="not_evaluated",
+            status_reason="; ".join(unavailable)
+            or "Direction model was not evaluated for the complete symbol universe.",
+            positive_return_threshold=config.positive_return_threshold,
+            confirmation_probability_threshold=(
+                config.confirmation_probability_threshold
+            ),
+            calibration_policy_version=config.calibration_policy_version,
+            confirmation_policy_version=config.confirmation_policy_version,
+        )
+
+    frames = []
+    for item in configured:
+        actuals = item.get("direction_actuals")
+        probabilities = item.get("up_probabilities")
+        if actuals is None or probabilities is None:
+            return DirectionClassificationDiagnostics(
+                evaluation_status="not_evaluated",
+                status_reason=(
+                    "Direction model outputs are incomplete for the symbol universe."
+                ),
+                positive_return_threshold=config.positive_return_threshold,
+                confirmation_probability_threshold=(
+                    config.confirmation_probability_threshold
+                ),
+                calibration_policy_version=config.calibration_policy_version,
+                confirmation_policy_version=config.confirmation_policy_version,
+            )
+        frame = pd.DataFrame(
+            {"actual": actuals, "probability": probabilities.reindex(actuals.index)}
+        ).dropna()
+        if frame.empty:
+            return DirectionClassificationDiagnostics(
+                evaluation_status="not_evaluated",
+                status_reason="Direction model produced no evaluable holdout rows.",
+                positive_return_threshold=config.positive_return_threshold,
+                confirmation_probability_threshold=(
+                    config.confirmation_probability_threshold
+                ),
+                calibration_policy_version=config.calibration_policy_version,
+                confirmation_policy_version=config.confirmation_policy_version,
+            )
+        frames.append(frame)
+
+    diagnostics_frame = pd.concat(frames)
+    actual = diagnostics_frame["actual"].astype(int)
+    probability = diagnostics_frame["probability"].astype(float)
+    predicted = (probability >= config.confirmation_probability_threshold).astype(int)
+    has_both_classes = actual.nunique() == 2
+    return DirectionClassificationDiagnostics(
+        evaluation_status="evaluated",
+        sample_count=len(diagnostics_frame),
+        positive_return_threshold=config.positive_return_threshold,
+        confirmation_probability_threshold=config.confirmation_probability_threshold,
+        calibration_policy_version=config.calibration_policy_version,
+        confirmation_policy_version=config.confirmation_policy_version,
+        calibration_sample_count=sum(
+            item["direction_calibration_sample_count"] for item in configured
+        ),
+        positive_prevalence=float(actual.mean()),
+        confusion_matrix=confusion_matrix(actual, predicted, labels=[0, 1]).tolist(),
+        precision=float(precision_score(actual, predicted, zero_division=0)),
+        recall=float(recall_score(actual, predicted, zero_division=0)),
+        roc_auc=float(roc_auc_score(actual, probability))
+        if has_both_classes
+        else None,
+        pr_auc=float(average_precision_score(actual, probability))
+        if has_both_classes
+        else None,
+        brier=float(brier_score_loss(actual, probability)),
+    )
+
+
 def build_regression_diagnostics(symbol_data: list[dict]) -> RegressionDiagnostics:
+    direction_diagnostics = build_direction_classification_diagnostics(symbol_data)
     frames: list[pd.DataFrame] = []
     feature_importance: dict[str, list[float]] = {}
 
@@ -238,7 +512,7 @@ def build_regression_diagnostics(symbol_data: list[dict]) -> RegressionDiagnosti
             feature_importance.setdefault(feature, []).append(float(importance))
 
     if not frames:
-        return RegressionDiagnostics()
+        return RegressionDiagnostics(direction_classification=direction_diagnostics)
 
     diagnostics_frame = pd.concat(frames).sort_index()
     residuals = diagnostics_frame["residual"]
@@ -288,6 +562,7 @@ def build_regression_diagnostics(symbol_data: list[dict]) -> RegressionDiagnosti
         actual_vs_predicted=diagnostic_points,
         residuals=diagnostic_points,
         feature_importance=importance_points,
+        direction_classification=direction_diagnostics,
     )
 
 
@@ -321,33 +596,83 @@ def compute_validation_summary(
     if request.validation is None:
         return None
 
-    metrics_list: list[dict] = []
+    def not_evaluated(reason: str) -> ValidationSummary:
+        return ValidationSummary(
+            method=request.validation.method,
+            evaluation_status="not_evaluated",
+            status_reason=reason,
+            metrics={},
+        )
+
+    purge = model_service.target_lookahead(
+        request.return_target, request.horizon_days
+    )
+    loaded_symbols = [data.get("symbol") for data in symbol_data]
+    if (
+        len(symbol_data) != len(request.symbols)
+        or len(loaded_symbols) != len(set(loaded_symbols))
+        or set(loaded_symbols) != set(request.symbols)
+    ):
+        return not_evaluated(
+            "Validation symbol data does not match the requested universe."
+        )
+
+    common_index = symbol_data[0]["X"].index
     for data in symbol_data:
-        symbol = data["symbol"]
-        df_model = data["df_model"]
-        X = data["X"]
-        y = data["y"]
-
-        try:
-            splits = validation_service.generate_splits(
-                length=len(X),
-                method=request.validation.method,
-                splits=request.validation.splits,
-                test_size=request.validation.test_size,
+        if data["X"].index.has_duplicates:
+            return not_evaluated(
+                f"[{data['symbol']}] Validation feature dates contain duplicates."
             )
-        except ValueError as exc:
-            raise InsufficientDataError(
-                f"[{symbol}] Validation cannot run: {exc}"
-            ) from exc
+        common_index = common_index.intersection(data["X"].index, sort=False)
+    common_index = common_index.sort_values()
+    if common_index.empty:
+        return not_evaluated(
+            "Validation symbols have no common model-ready dates."
+        )
+    try:
+        folds = validation_service.generate_splits(
+            length=len(common_index),
+            method=request.validation.method,
+            splits=request.validation.splits,
+            test_size=request.validation.test_size,
+            purge=purge,
+        )
+    except ValueError as exc:
+        return not_evaluated(
+            f"Validation cannot run on the common-date sample: {exc}"
+        )
+    if not folds:
+        return not_evaluated("Validation produced no common-date folds.")
 
-        for train_range, test_range in splits:
-            X_train = X.iloc[list(train_range)]
-            y_train = y.iloc[list(train_range)]
-            X_test = X.iloc[list(test_range)]
+    metrics_list: list[dict] = []
+    for train_range, test_range in folds:
+        train_index = common_index[list(train_range)]
+        test_index = common_index[list(test_range)]
+        fold_scores: list[pd.Series] = []
+        fold_probabilities: list[pd.Series] = []
+        fold_prices: dict[str, list[pd.Series]] = {
+            "open": [],
+            "high": [],
+            "low": [],
+            "close": [],
+        }
+        for data in symbol_data:
+            symbol = data["symbol"]
+            X = data["X"]
+            y = data["y"]
+            X_train = X.reindex(train_index)
+            y_train = y.reindex(train_index)
+            X_test = X.reindex(test_index)
 
-            if X_train.empty or X_test.empty:
-                raise InsufficientDataError(
-                    f"[{symbol}] Validation split has insufficient data."
+            if (
+                X_train.empty
+                or X_test.empty
+                or X_train.isna().any().any()
+                or X_test.isna().any().any()
+                or y_train.isna().any()
+            ):
+                return not_evaluated(
+                    f"[{symbol}] Validation split is incomplete on common dates."
                 )
 
             model = model_service.fit_regressor(
@@ -357,26 +682,108 @@ def compute_validation_summary(
                 model_params=request.model.params,
             )
             preds = model.predict(X_test)
-            scores = pd.DataFrame({symbol: preds}, index=X_test.index)
-            open_df = df_model.loc[X_test.index, "open"].to_frame(symbol)
-            high_df = df_model.loc[X_test.index, "high"].to_frame(symbol)
-            low_df = df_model.loc[X_test.index, "low"].to_frame(symbol)
-            close_df = df_model.loc[X_test.index, "close"].to_frame(symbol)
-            metrics, _, _, _ = backtest_service.run_backtest(
-                scores=scores,
-                open_df=open_df,
-                high_df=high_df,
-                low_df=low_df,
-                close_df=close_df,
-                strategy=strategy,
-                execution=request.execution,
-                market=request.market,
-                return_target=request.return_target,
+            fold_scores.append(pd.Series(preds, index=X_test.index, name=symbol))
+            if request.direction_model is not None:
+                direction_config = request.direction_model
+                classifier, unavailable_reason, _ = (
+                    model_service.fit_calibrated_direction_classifier(
+                        model_type=direction_config.type,
+                        X_train=X_train,
+                        y_train=(
+                            y_train > direction_config.positive_return_threshold
+                        ).astype(int),
+                        model_params=direction_config.params,
+                        purge=purge,
+                    )
+                )
+                if classifier is None:
+                    return not_evaluated(
+                        f"[{symbol}] Direction validation unavailable: "
+                        f"{unavailable_reason or 'classifier was not produced.'}"
+                    )
+                positive_class_index = list(classifier.classes_).index(1)
+                fold_probabilities.append(
+                    pd.Series(
+                        classifier.predict_proba(X_test)[:, positive_class_index],
+                        index=X_test.index,
+                        name=symbol,
+                    )
+                )
+            for price_name in fold_prices:
+                fold_prices[price_name].append(
+                    data["df_model"].reindex(X_test.index)[price_name].rename(symbol)
+                )
+
+        scores = pd.concat(fold_scores, axis=1)
+        price_frames = {
+            name: pd.concat(series, axis=1) for name, series in fold_prices.items()
+        }
+        if (
+            set(scores.columns) != set(request.symbols)
+            or scores.shape[1] != len(request.symbols)
+            or any(
+                set(frame.columns) != set(request.symbols)
+                or frame.shape[1] != len(request.symbols)
+                for frame in price_frames.values()
             )
-            metrics_list.append(metrics)
+        ):
+            return not_evaluated(
+                "Validation fold does not contain the complete requested universe."
+            )
+        scores = scores.reindex(index=test_index, columns=request.symbols)
+        price_frames = {
+            name: frame.reindex(index=test_index, columns=request.symbols)
+            for name, frame in price_frames.items()
+        }
+        values = [scores, *price_frames.values()]
+        if any(
+            frame.isna().any().any()
+            or not all(math.isfinite(float(value)) for value in frame.to_numpy().flat)
+            for frame in values
+        ):
+            return not_evaluated(
+                "Validation fold contains missing or non-finite model/price values."
+            )
+
+        confirmation_probabilities = None
+        if request.direction_model is not None:
+            confirmation_probabilities = pd.concat(
+                fold_probabilities, axis=1
+            ).reindex(index=test_index, columns=request.symbols)
+            if confirmation_probabilities.isna().any().any() or not all(
+                math.isfinite(float(value)) and 0.0 <= float(value) <= 1.0
+                for value in confirmation_probabilities.to_numpy().flat
+            ):
+                return not_evaluated(
+                    "Validation direction probabilities are missing, non-finite, or "
+                    "outside [0, 1]."
+                )
+
+        metrics, _, _, _ = backtest_service.run_backtest(
+            scores=scores,
+            open_df=price_frames["open"],
+            high_df=price_frames["high"],
+            low_df=price_frames["low"],
+            close_df=price_frames["close"],
+            strategy=strategy,
+            execution=request.execution,
+            market=request.market,
+            return_target=request.return_target,
+            confirmation_probabilities=confirmation_probabilities,
+            confirmation_threshold=(
+                request.direction_model.confirmation_probability_threshold
+                if request.direction_model is not None
+                else 0.5
+            ),
+        )
+        if not _metrics_are_finite(metrics):
+            return not_evaluated(
+                "Validation backtest produced empty or non-finite metrics."
+            )
+        metrics_list.append(metrics)
 
     if not metrics_list:
-        raise InsufficientDataError(
+        return not_evaluated(
             "Validation requested but no validation metrics were produced."
         )
 
@@ -386,7 +793,15 @@ def compute_validation_summary(
     }
     if "sharpe" in avg_metrics:
         avg_metrics["avg_sharpe"] = avg_metrics["sharpe"]
-    return ValidationSummary(method=request.validation.method, metrics=avg_metrics)
+    if not _metrics_are_finite(avg_metrics):
+        return not_evaluated(
+            "Validation average produced empty or non-finite metrics."
+        )
+    return ValidationSummary(
+        method=request.validation.method,
+        evaluation_status="evaluated",
+        metrics=avg_metrics,
+    )
 
 
 def execute_research_run(
@@ -418,6 +833,9 @@ def execute_research_run(
 
     scores_df = pd.concat([item["scores"] for item in symbol_data], axis=1).sort_index()
     scores_df.index = pd.to_datetime(scores_df.index)
+    confirmation_probabilities, direction_warning = (
+        build_holdout_confirmation_probabilities(symbol_data, scores_df, request)
+    )
 
     open_df = pd.concat([item["open"] for item in symbol_data], axis=1).reindex(
         scores_df.index
@@ -434,10 +852,15 @@ def execute_research_run(
     volume_df = pd.concat([item["volume"] for item in symbol_data], axis=1).reindex(
         scores_df.index
     )
-    weights = backtest_service.build_target_weights(
-        scores=scores_df,
-        strategy=resolved_strategy,
-    )
+    weight_kwargs = {"scores": scores_df, "strategy": resolved_strategy}
+    if confirmation_probabilities is not None and request.direction_model is not None:
+        weight_kwargs.update(
+            confirmation_probabilities=confirmation_probabilities,
+            confirmation_threshold=(
+                request.direction_model.confirmation_probability_threshold
+            ),
+        )
+    weights = backtest_service.build_target_weights(**weight_kwargs)
 
     metrics, equity_curve, signals, warnings = backtest_service.run_backtest(
         scores=scores_df,
@@ -449,7 +872,25 @@ def execute_research_run(
         execution=request.execution,
         market=request.market,
         return_target=request.return_target,
+        confirmation_probabilities=confirmation_probabilities,
+        confirmation_threshold=(
+            request.direction_model.confirmation_probability_threshold
+            if request.direction_model is not None
+            else 0.5
+        ),
     )
+    if not _metrics_are_finite(metrics):
+        raise InsufficientDataError(
+            "Main backtest produced empty or non-finite metrics."
+        )
+    forward_signals, forward_warning = build_forward_opinion_signals(
+        symbol_data, request, resolved_strategy
+    )
+    signals.extend(forward_signals)
+    if direction_warning is not None:
+        warnings.append(direction_warning)
+    if forward_warning is not None:
+        warnings.append(forward_warning)
     warnings = [*warnings, *foundation_warnings]
     p3_summary = build_p3_summary(
         request=request,
@@ -473,11 +914,24 @@ def execute_research_run(
                 market=request.market,
                 return_target=request.return_target,
             )
+            if not _metrics_are_finite(base_metrics):
+                warnings.append(
+                    f"Baseline '{baseline}' not evaluated: backtest produced "
+                    "empty or non-finite metrics."
+                )
+                continue
             baselines[baseline] = base_metrics
 
     validation_summary = compute_validation_summary(
         symbol_data, request, resolved_strategy
     )
+    if (
+        validation_summary is not None
+        and validation_summary.evaluation_status == "not_evaluated"
+    ):
+        warnings.append(
+            f"Validation not evaluated: {validation_summary.status_reason}"
+        )
     model_diagnostics = build_regression_diagnostics(symbol_data)
     version_pack = build_version_pack_payload(
         {

--- a/backend/research/services/runs.py
+++ b/backend/research/services/runs.py
@@ -11,7 +11,10 @@ from backend.research.contracts.runs import (
     ResearchRunRecordResponse,
     ResearchRunResponse,
 )
-from backend.research.domain.artifact_summary import build_review_artifact_summary
+from backend.research.domain.artifact_summary import (
+    build_review_artifact_summary,
+    has_requested_baselines,
+)
 from backend.research.domain.opinion import build_opinion_artifact
 from backend.research.repositories.runs import (
     get_research_run_record,
@@ -43,7 +46,9 @@ def _response_with_artifact_summary(
             "equity_curve": True,
             "signals": True,
             "validation": response.validation is not None,
-            "baselines": isinstance(response.baselines, dict),
+            "baselines": has_requested_baselines(
+                request.model_dump(mode="json"), response.baselines
+            ),
         },
     )
     opinion_payload = {

--- a/backend/research/services/tradability.py
+++ b/backend/research/services/tradability.py
@@ -626,7 +626,10 @@ def build_p3_summary(
         tradability_state = "unresolved_corporate_event"
     elif stale_mark_days_with_open_positions > 0:
         tradability_state = "stale_risk"
-    elif latest_execution_universe_count > 0:
+    elif (
+        latest_execution_universe_count > 0
+        and request.execution_route != "research_only"
+    ):
         tradability_state = "execution_ready"
     else:
         tradability_state = "research_only"

--- a/backend/shared/analytics/backtest.py
+++ b/backend/shared/analytics/backtest.py
@@ -51,7 +51,13 @@ def match_price(
     return min(open_price, high)
 
 
-def build_signals(scores: pd.DataFrame, weights: pd.DataFrame) -> List[dict]:
+def build_signals(
+    scores: pd.DataFrame,
+    weights: pd.DataFrame,
+    confirmation_probabilities: pd.DataFrame | None = None,
+    signal_kind: str = "holdout_evaluation",
+    confirmation_threshold: float = 0.5,
+) -> List[dict]:
     signals: List[dict] = []
     for dt, row in weights.iterrows():
         positions = row[row > 0]
@@ -67,8 +73,26 @@ def build_signals(scores: pd.DataFrame, weights: pd.DataFrame) -> List[dict]:
                 {
                     "date": dt.date() if hasattr(dt, "date") else dt,
                     "symbol": symbol,
-                    "score": float(score) if pd.notna(score) else 0.0,
+                    "score": float(score) if pd.notna(score) else None,
                     "position": float(position),
+                    "signal_kind": signal_kind,
+                    "up_probability": (
+                        float(confirmation_probabilities.at[dt, symbol])
+                        if confirmation_probabilities is not None
+                        and pd.notna(confirmation_probabilities.at[dt, symbol])
+                        else None
+                    ),
+                    "predicted_direction": (
+                        "up"
+                        if confirmation_probabilities is not None
+                        and pd.notna(confirmation_probabilities.at[dt, symbol])
+                        and confirmation_probabilities.at[dt, symbol]
+                        >= confirmation_threshold
+                        else "down"
+                        if confirmation_probabilities is not None
+                        and pd.notna(confirmation_probabilities.at[dt, symbol])
+                        else None
+                    ),
                 }
             )
     return signals
@@ -93,10 +117,17 @@ def compute_max_position_weight(weights: pd.DataFrame) -> float:
 def build_target_weights(
     scores: pd.DataFrame,
     strategy: StrategyConfig | ResearchStrategyConfig,
+    confirmation_probabilities: pd.DataFrame | None = None,
+    confirmation_threshold: float = 0.5,
 ) -> pd.DataFrame:
     strategy_config = resolve_strategy_config(strategy)
     runner = get_strategy_runner(strategy_config.type)
-    weights = runner.build_weights(scores=scores, strategy=strategy_config)
+    weights = runner.build_weights(
+        scores=scores,
+        strategy=strategy_config,
+        confirmation_probabilities=confirmation_probabilities,
+        confirmation_threshold=confirmation_threshold,
+    )
     return weights.reindex(scores.index).fillna(0.0).sort_index()
 
 
@@ -286,10 +317,17 @@ def run_backtest(
     execution: object,
     market: str,
     return_target: str,
+    confirmation_probabilities: pd.DataFrame | None = None,
+    confirmation_threshold: float = 0.5,
 ) -> Tuple[Dict[str, float], List[dict], List[dict], List[str]]:
     warnings: List[str] = []
     strategy_config = resolve_strategy_config(strategy)
-    weights = build_target_weights(scores=scores, strategy=strategy_config)
+    weights = build_target_weights(
+        scores=scores,
+        strategy=strategy_config,
+        confirmation_probabilities=confirmation_probabilities,
+        confirmation_threshold=confirmation_threshold,
+    )
     logger.info(
         "Running backtest strategy=%s market=%s symbols=%s periods=%s",
         strategy_config.type,
@@ -308,7 +346,12 @@ def run_backtest(
         market=market,
         return_target=return_target,
     )
-    signals = build_signals(scores, weights)
+    signals = build_signals(
+        scores,
+        weights,
+        confirmation_probabilities,
+        confirmation_threshold=confirmation_threshold,
+    )
 
     execution_price = _build_execution_price(
         weights=weights,

--- a/backend/shared/analytics/models.py
+++ b/backend/shared/analytics/models.py
@@ -9,7 +9,7 @@ from sklearn.metrics import mean_squared_error
 from backend.shared.analytics.features import add_features
 
 if TYPE_CHECKING:
-    from xgboost import XGBRegressor
+    from xgboost import XGBClassifier, XGBRegressor
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +19,11 @@ MODEL_FAMILY_BY_TYPE = {
     "extra_trees": "bagging_trees",
 }
 TRAINING_OUTPUT_CONTRACT_VERSION = "tabular_regression_scores_v1"
+DIRECTION_CALIBRATION_SUPPORT_POLICY_VERSION = (
+    "chronological_tail_20pct_min20_class5_v1"
+)
+DIRECTION_CALIBRATION_MIN_SAMPLES = 20
+DIRECTION_CALIBRATION_MIN_CLASS_SUPPORT = 5
 
 
 def _load_xgboost_regressor():
@@ -29,6 +34,16 @@ def _load_xgboost_regressor():
             "xgboost failed to import. On macOS, install OpenMP with `brew install libomp`."
         ) from exc
     return XGBRegressor
+
+
+def _load_xgboost_classifier():
+    try:
+        from xgboost import XGBClassifier
+    except Exception as exc:
+        raise RuntimeError(
+            "xgboost failed to import. On macOS, install OpenMP with `brew install libomp`."
+        ) from exc
+    return XGBClassifier
 
 
 def _load_sklearn_regressor(model_type: str):
@@ -47,19 +62,42 @@ def _load_sklearn_regressor(model_type: str):
     return regressor_cls
 
 
+def _load_sklearn_classifier(model_type: str):
+    try:
+        from sklearn.ensemble import ExtraTreesClassifier, RandomForestClassifier
+    except Exception as exc:
+        raise RuntimeError(
+            "scikit-learn failed to import. Install project dependencies before using sklearn model families."
+        ) from exc
+    classifier_cls = {
+        "random_forest": RandomForestClassifier,
+        "extra_trees": ExtraTreesClassifier,
+    }.get(model_type)
+    if classifier_cls is None:
+        raise ValueError(f"Unsupported sklearn model type: {model_type}")
+    return classifier_cls
+
+
 def compute_return_target(
     df: pd.DataFrame, return_target: str, horizon_days: int
 ) -> pd.Series:
+    lookahead = target_lookahead(return_target, horizon_days)
+
+    if return_target == "open_to_open":
+        return df["open"].shift(-lookahead) / df["open"] - 1.0
+    if return_target == "close_to_close":
+        return df["close"].shift(-lookahead) / df["close"] - 1.0
+    return df["close"].shift(-lookahead) / df["open"] - 1.0
+
+
+def target_lookahead(return_target: str, horizon_days: int) -> int:
     if horizon_days < 1:
         raise ValueError("horizon_days must be >= 1")
 
-    if return_target == "open_to_open":
-        return df["open"].shift(-horizon_days) / df["open"] - 1.0
-    if return_target == "close_to_close":
-        return df["close"].shift(-horizon_days) / df["close"] - 1.0
+    if return_target in {"open_to_open", "close_to_close"}:
+        return horizon_days
     if return_target == "open_to_close":
-        shift = -(horizon_days - 1)
-        return df["close"].shift(shift) / df["open"] - 1.0
+        return horizon_days - 1
 
     raise ValueError(f"Unsupported return_target: {return_target}")
 
@@ -107,19 +145,25 @@ def time_series_split(
     X: pd.DataFrame,
     y: pd.Series,
     test_size: float = 0.2,
+    purge: int = 0,
 ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.Series, pd.Series]:
     if not 0 < test_size < 1:
         raise ValueError("test_size must be between 0 and 1.")
 
+    if purge < 0:
+        raise ValueError("purge must be >= 0.")
+
     split_idx = int(len(X) * (1 - test_size))
-    if split_idx <= 0 or split_idx >= len(X):
+    train_end = split_idx - purge
+    if train_end <= 0 or split_idx >= len(X):
         raise ValueError(
-            f"Not enough data to create a train/test split with test_size={test_size}."
+            "Not enough data to create a train/test split with "
+            f"test_size={test_size} and purge={purge}."
         )
 
-    X_train = X.iloc[:split_idx]
+    X_train = X.iloc[:train_end]
     X_test = X.iloc[split_idx:]
-    y_train = y.iloc[:split_idx]
+    y_train = y.iloc[:train_end]
     y_test = y.iloc[split_idx:]
     logger.info("Created time-series split train=%s test=%s", len(X_train), len(X_test))
     return X_train, X_test, y_train, y_test
@@ -184,6 +228,90 @@ def fit_regressor(
             model_params=model_params,
         )
     raise ValueError(f"Unsupported model type: {model_type}")
+
+
+def build_classifier(
+    *,
+    model_type: str,
+    model_params: Dict[str, object] | None = None,
+):
+    params: Dict[str, object] = {
+        "n_estimators": 200,
+        "random_state": 42,
+        "n_jobs": -1,
+    }
+    if model_type == "xgboost":
+        params.update({"objective": "binary:logistic", "eval_metric": "logloss"})
+        classifier_cls = _load_xgboost_classifier()
+    elif model_type in {"random_forest", "extra_trees"}:
+        classifier_cls = _load_sklearn_classifier(model_type)
+    else:
+        raise ValueError(f"Unsupported model type: {model_type}")
+    if model_params:
+        params.update(model_params)
+    return classifier_cls(**params)
+
+
+def fit_calibrated_direction_classifier(
+    *,
+    model_type: str,
+    X_train: pd.DataFrame,
+    y_train: pd.Series,
+    model_params: Dict[str, object] | None = None,
+    purge: int = 0,
+) -> tuple[object | None, str | None, int]:
+    from sklearn.calibration import CalibratedClassifierCV
+
+    calibration_size = max(
+        DIRECTION_CALIBRATION_MIN_SAMPLES,
+        int(len(X_train) * 0.2),
+    )
+    calibration_start = len(X_train) - calibration_size
+    base_end = calibration_start - purge
+    if base_end < DIRECTION_CALIBRATION_MIN_SAMPLES:
+        return (
+            None,
+            "Insufficient rows for provisional chronological direction calibration "
+            f"({DIRECTION_CALIBRATION_SUPPORT_POLICY_VERSION}).",
+            0,
+        )
+
+    base_labels = y_train.iloc[:base_end]
+    calibration_labels = y_train.iloc[calibration_start:]
+    if base_labels.value_counts().reindex([0, 1], fill_value=0).min() < (
+        DIRECTION_CALIBRATION_MIN_CLASS_SUPPORT
+    ):
+        return (
+            None,
+            "Provisional direction model training window requires at least "
+            f"{DIRECTION_CALIBRATION_MIN_CLASS_SUPPORT} rows per class "
+            f"({DIRECTION_CALIBRATION_SUPPORT_POLICY_VERSION}).",
+            0,
+        )
+    if calibration_labels.value_counts().reindex([0, 1], fill_value=0).min() < (
+        DIRECTION_CALIBRATION_MIN_CLASS_SUPPORT
+    ):
+        return (
+            None,
+            "Provisional direction model calibration window requires at least "
+            f"{DIRECTION_CALIBRATION_MIN_CLASS_SUPPORT} rows per class "
+            f"({DIRECTION_CALIBRATION_SUPPORT_POLICY_VERSION}).",
+            0,
+        )
+
+    model = CalibratedClassifierCV(
+        build_classifier(model_type=model_type, model_params=model_params),
+        method="sigmoid",
+        cv=[
+            (
+                np.arange(base_end),
+                np.arange(calibration_start, len(X_train)),
+            )
+        ],
+        ensemble=True,
+    )
+    model.fit(X_train, y_train)
+    return model, None, calibration_size
 
 
 def build_model_family(model_type: str) -> str:

--- a/backend/shared/analytics/strategy.py
+++ b/backend/shared/analytics/strategy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Dict, Literal, Protocol
 
@@ -54,6 +55,8 @@ class StrategyRunner(Protocol):
         self,
         scores: pd.DataFrame,
         strategy: ResearchStrategyConfig,
+        confirmation_probabilities: pd.DataFrame | None = None,
+        confirmation_threshold: float = 0.5,
     ) -> pd.DataFrame: ...
 
 
@@ -71,13 +74,30 @@ def build_weights_from_scores(
     threshold: float,
     top_n: int,
     allow_proactive_sells: bool,
+    confirmation_probabilities: pd.DataFrame | None = None,
+    confirmation_threshold: float = 0.5,
 ) -> pd.DataFrame:
     weights = pd.DataFrame(0.0, index=scores.index, columns=scores.columns)
     current_holdings: set[str] = set()
+    aligned_probabilities = (
+        confirmation_probabilities.reindex(
+            index=scores.index, columns=scores.columns
+        )
+        if confirmation_probabilities is not None
+        else None
+    )
 
     for idx, row in scores.iterrows():
         row = row.dropna()
+        row = row[row.map(math.isfinite)]
         eligible = row[row >= threshold]
+        if aligned_probabilities is not None:
+            confirmed = aligned_probabilities.loc[idx]
+            eligible = eligible[
+                confirmed.reindex(eligible.index).between(
+                    confirmation_threshold, 1.0, inclusive="both"
+                )
+            ]
         selected = eligible.nlargest(top_n).index.tolist()
 
         if allow_proactive_sells:
@@ -102,12 +122,16 @@ class ResearchV1Runner:
         self,
         scores: pd.DataFrame,
         strategy: ResearchStrategyConfig,
+        confirmation_probabilities: pd.DataFrame | None = None,
+        confirmation_threshold: float = 0.5,
     ) -> pd.DataFrame:
         return build_weights_from_scores(
             scores=scores,
             threshold=strategy.threshold,
             top_n=strategy.top_n,
             allow_proactive_sells=strategy.allow_proactive_sells,
+            confirmation_probabilities=confirmation_probabilities,
+            confirmation_threshold=confirmation_threshold,
         )
 
 

--- a/backend/shared/analytics/validation.py
+++ b/backend/shared/analytics/validation.py
@@ -6,6 +6,7 @@ def generate_splits(
     method: str,
     splits: int,
     test_size: float,
+    purge: int = 0,
 ) -> List[Tuple[range, range]]:
     if length <= 0:
         raise ValueError("length must be positive")
@@ -13,6 +14,8 @@ def generate_splits(
         raise ValueError("test_size must be between 0 and 1")
     if splits < 1:
         raise ValueError("splits must be >= 1")
+    if purge < 0:
+        raise ValueError("purge must be >= 0")
 
     test_len = int(length * test_size)
     if test_len <= 0:
@@ -22,7 +25,9 @@ def generate_splits(
     if method == "holdout":
         if length <= test_len:
             raise ValueError("Not enough data for holdout split")
-        train_range = range(0, length - test_len)
+        train_range = range(0, length - test_len - purge)
+        if not train_range:
+            raise ValueError("Not enough training data after purge")
         test_range = range(length - test_len, length)
         return [(train_range, test_range)]
 
@@ -37,7 +42,10 @@ def generate_splits(
             train_end = train_len + i * test_len
             test_start = train_end
             test_end = test_start + test_len
-            split_ranges.append((range(0, train_end), range(test_start, test_end)))
+            train_range = range(0, train_end - purge)
+            if not train_range:
+                raise ValueError("Not enough training data after purge")
+            split_ranges.append((train_range, range(test_start, test_end)))
         return split_ranges
 
     if method == "rolling_window":
@@ -46,9 +54,10 @@ def generate_splits(
             train_end = train_start + train_len
             test_start = train_end
             test_end = test_start + test_len
-            split_ranges.append(
-                (range(train_start, train_end), range(test_start, test_end))
-            )
+            train_range = range(train_start, train_end - purge)
+            if not train_range:
+                raise ValueError("Not enough training data after purge")
+            split_ranges.append((train_range, range(test_start, test_end)))
         return split_ranges
 
     raise ValueError(f"Unknown validation method: {method}")

--- a/docs/decision-register.md
+++ b/docs/decision-register.md
@@ -46,6 +46,9 @@ stable across multiple implementation tasks.
 | `DEC-PHASE-005` | Portfolio automation is deferred behind manual adoption tracking | accepted | Nearer-term portfolio work should record manual adoption, forward outcomes, and portfolio impact before any automatic rebalancing or account-control behavior |
 | `DEC-PHASE-006` | Phase 2 opinion artifact contract and reconstruction path are fixed | accepted | `opinion_artifact` serializes state, action rows, source references, and review checks in research responses; POST builds from current response artifacts, detail reload reconstructs from persisted run artifacts, and list responses remain summary-only |
 | `DEC-PHASE-007` | The first local research-method slice is accepted | accepted | Persisted request, strategy, diagnostic, signal, metric, validation, baseline, warning, and comparison-caveat artifacts feed `opinion_artifact.review_checks`; focused contract, domain, and API validation covers the slice, detail reload reconstructs it deterministically, and comparison caveats remain explicit |
+| `DEC-PHASE-008` | Prospective opinions use regression ranking plus calibrated direction confirmation | accepted | Holdout signals remain evaluation-only; a viable opinion requires a complete common-date forward snapshot and manual adoption review |
+| `DEC-PHASE-009` | Retain the existing hybrid review UI while Phase 2 remains backend-first | accepted | The current Opinion, direction-diagnostic, workflow-payload, and frontend type integration stays in place, but no further frontend feature or browser-acceptance work is part of the active backend phase |
+| `DEC-PHASE-010` | Current direction diagnostics are pooled across symbols | accepted | Pooled holdout metrics and summed calibration samples are research-level diagnostics, not per-symbol skill claims; per-symbol diagnostics and training-cost optimization remain deferred pending evidence |
 
 ## Open V1 Decisions
 

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -15,7 +15,7 @@ in the v1 product navigation.
 
 ## Status Scope
 
-- status date: `2026-05-14`
+- status date: `2026-07-22`
 - status terms:
   - `implemented`: behavior exists and is usable in the current codebase
   - `partial`: meaningful foundation exists, but the v1 product expectation is
@@ -33,7 +33,8 @@ in the v1 product navigation.
 | Regression diagnostics contract | implemented | backend, frontend types, and review UI include `model_diagnostics`, including residual samples |
 | Persisted result artifacts | verified | new successful runs reload request config, diagnostics, equity curve, signals, baselines, metrics, warnings, runtime metadata, and artifact completeness summaries; old metadata-only records show explicit fallback copy |
 | Experiments comparison | implemented | search, sort, load, and compare work for complete research-review runs; backend caveats block metadata-only, partial, and unfinished records |
-| Classification | contract-defined | task and diagnostics are specified, but implementation is deferred |
+| Direction classification | implemented | provisionally calibrated tree classification confirms regression-ranked candidates and persists diagnostics; artifact completeness does not establish out-of-sample skill or investment viability |
+| Hybrid opinion review | implemented | the existing Opinion, direction-diagnostic, workflow-payload, and frontend type integration is retained; further frontend expansion is paused while backend contracts and evaluation mature |
 | Data readiness | implemented | start surface uses requested-symbol TW daily readiness with ready/warning/missing-stale counts |
 | Advanced/platform modules | hidden advanced | execution, adaptive, peer, factor, external-signal, and tick-archive surfaces remain code foundations, not v1 main-flow commitments |
 
@@ -45,7 +46,7 @@ in the v1 product navigation.
   - task entry for baseline study, recent experiments, and data readiness
 - `Experiment Builder`
   - baseline TW daily research workflow
-  - currently regression-first; classification remains a documented future task
+  - regression ranking with direction-classification confirmation by default
 - `Experiments`
   - persisted run lookup, result review, filtering, sorting, and comparison
 - `Data Support`
@@ -139,6 +140,10 @@ These foundations are implementation inventory, not v1 product scope.
 
 ### Frontend
 
+- the existing hybrid Opinion review, direction diagnostics, workflow payload,
+  and type integration are retained
+- no additional frontend feature development is active; frontend work is
+  limited to backend-contract compatibility, typecheck, and build verification
 - legacy or platform-era component names should be cleaned up only after the
   current workbench surfaces fully replace them
 - residual diagnostics now have a dedicated sample section in the persisted run
@@ -148,7 +153,11 @@ These foundations are implementation inventory, not v1 product scope.
 
 ### Backend
 
-- classification remains specification-only
+- prospective opinions require a complete common-date hybrid snapshot; legacy
+  and regression-only runs remain reviewable but return `no-opinion`
+- direction metrics are currently pooled across symbols, and hybrid training
+  cost grows with symbol and validation-fold counts; per-symbol diagnostics and
+  performance optimization remain evidence-driven follow-up work
 - comparison caveat labels and reason codes still need deeper hardening for
   non-comparable runs, such as sample-window, target, feature, and cost-basis
   mismatch cases

--- a/docs/research-spec.md
+++ b/docs/research-spec.md
@@ -206,7 +206,9 @@ empty list and a warning instead of inventing values.
 ### SPEC-BACKTEST-001: Backtest posture
 
 The strategy backtest is an offline research artifact. It is not broker
-execution and must not imply live-order readiness.
+execution and must not imply live-order readiness. A run using
+`execution_route="research_only"` remains `tradability_state="research_only"`;
+`execution_ready` requires an explicitly non-research execution route.
 
 ### SPEC-BACKTEST-002: Strategy defaults
 

--- a/docs/research-spec.md
+++ b/docs/research-spec.md
@@ -85,7 +85,9 @@ Every feature row must persist:
 - `shift`
 
 Feature shifts are part of the leakage-control contract and must remain visible
-in the request config.
+in the request config. New research-run requests require `shift >= 1`; persisted
+legacy request payloads with `shift=0` remain reviewable, but must be updated
+before rerun.
 
 ### SPEC-FEATURE-002: Feature lineage
 
@@ -102,8 +104,9 @@ The v1 workbench recognizes two prediction task families:
 - `regression`
 - `classification`
 
-The first implementation pass supports regression diagnostics. Classification
-is specified here so it can be added later without changing the workbench flow.
+The default workbench run uses regression as the primary ranking model and a
+binary direction classifier as a confirmation model. Regression-only requests
+remain supported, but they cannot emit a prospective hybrid opinion.
 
 ### SPEC-TASK-002: Regression target
 
@@ -122,7 +125,7 @@ remain selectable tree-regression variants.
 
 ### SPEC-TASK-003: Classification target
 
-Classification must persist, when implemented:
+Direction classification persists:
 
 - positive-class definition
 - class horizon
@@ -136,6 +139,34 @@ Classification diagnostics should include at least:
 - precision and recall
 - ROC AUC or PR AUC when sample size supports it
 - calibration summary when probabilities are shown
+
+The current chronological sigmoid calibration gate is provisional and versioned
+as `chronological_tail_20pct_min20_class5_v1`: the calibration tail uses at
+least 20 samples, and both the base-training and calibration windows require at
+least five samples from each class. These are minimum support checks, not proof
+of calibrated performance; the positive-return and confirmation thresholds
+remain separately identifiable in persisted run configuration and diagnostics.
+
+Holdout predictions are evaluation artifacts. A prospective opinion requires
+one finite regression score and calibrated up probability for every requested
+symbol on the same latest feature date; incomplete or mixed-date snapshots must
+return `no-opinion`.
+
+Direction diagnostic metrics are pooled across evaluated symbols. `sample_count`
+is the pooled holdout-row count and `calibration_sample_count` is the sum across
+symbols; neither field establishes per-symbol skill. Prospective full-data model
+fits and fold-level validation classifiers scale with the requested symbol and
+fold counts, so performance claims require separate profiling evidence.
+
+### SPEC-TASK-004: Validation outcome
+
+Cross-sectional validation must split one sorted intersection of model-ready
+symbol dates so every symbol in a fold uses the same train and test dates.
+Validation summaries expose `evaluation_status` and `status_reason`: an
+`evaluated` summary has non-empty metrics, while a `not_evaluated` summary has
+empty metrics and a concrete reason. An unavailable auxiliary validation result
+does not fail an otherwise successful research run, and its reason must also be
+persisted as a warning.
 
 ## Model Diagnostics Contract
 
@@ -332,6 +363,11 @@ Each populated symbol row must include:
 Candidate lists may be empty. If the evidence is insufficient, the artifact
 must return `no-opinion` or `do-not-adopt` instead of forcing a buy, sell, or
 watch result.
+
+Artifact completeness only means the model output is reviewable and traceable.
+It does not establish out-of-sample predictive skill or investment viability;
+the opinion builder does not invent a performance-quality threshold for either
+claim.
 
 ### SPEC-OPINION-002: Evidence traceability
 

--- a/frontend/src/lib/components/RunReviewWorkspace.svelte
+++ b/frontend/src/lib/components/RunReviewWorkspace.svelte
@@ -23,6 +23,7 @@
     import EquityChart from "./EquityChart.svelte";
     import ResearchRunDiagnostics from "./research-runs/ResearchRunDiagnostics.svelte";
     import ResearchRunMetrics from "./research-runs/ResearchRunMetrics.svelte";
+    import ResearchRunOpinion from "./research-runs/ResearchRunOpinion.svelte";
     import ResearchRunSignals from "./research-runs/ResearchRunSignals.svelte";
     import ResearchRunValidation from "./research-runs/ResearchRunValidation.svelte";
 
@@ -1089,6 +1090,10 @@
                             for this run.
                         </p>
                     </div>
+                {/if}
+
+                {#if activeRun?.opinion_artifact}
+                    <ResearchRunOpinion opinion={activeRun.opinion_artifact} />
                 {/if}
 
                 {#if activeRun?.signals?.length}

--- a/frontend/src/lib/components/research-runs/ResearchRunDiagnostics.svelte
+++ b/frontend/src/lib/components/research-runs/ResearchRunDiagnostics.svelte
@@ -17,6 +17,47 @@
             <p class="eyebrow">Model Diagnostics</p>
             <h3>Regression Quality</h3>
         </div>
+
+        {#if diagnostics.direction_classification}
+            <div>
+                <div class="surface-header">
+                    <div>
+                        <p class="eyebrow">Direction Confirmation</p>
+                        <h4>Up-probability quality</h4>
+                    </div>
+                    <strong>{diagnostics.direction_classification.evaluation_status}</strong>
+                </div>
+                {#if diagnostics.direction_classification.evaluation_status === "evaluated"}
+                    <div class="diagnostic-grid direction-grid">
+                        <div>
+                            <span>Precision</span>
+                            <strong>{formatNumber(diagnostics.direction_classification.precision)}</strong>
+                        </div>
+                        <div>
+                            <span>Recall</span>
+                            <strong>{formatNumber(diagnostics.direction_classification.recall)}</strong>
+                        </div>
+                        <div>
+                            <span>ROC AUC</span>
+                            <strong>{formatNumber(diagnostics.direction_classification.roc_auc)}</strong>
+                        </div>
+                        <div>
+                            <span>PR AUC</span>
+                            <strong>{formatNumber(diagnostics.direction_classification.pr_auc)}</strong>
+                        </div>
+                        <div>
+                            <span>Brier</span>
+                            <strong>{formatNumber(diagnostics.direction_classification.brier)}</strong>
+                        </div>
+                    </div>
+                {:else}
+                    <p class="muted">
+                        {diagnostics.direction_classification.status_reason ??
+                            "Direction confirmation could not be evaluated."}
+                    </p>
+                {/if}
+            </div>
+        {/if}
     </div>
 
     {#if diagnostics}
@@ -153,6 +194,10 @@
         display: grid;
         grid-template-columns: repeat(5, minmax(0, 1fr));
         gap: var(--space-3);
+    }
+
+    .direction-grid {
+        margin-top: var(--space-3);
     }
 
     .diagnostic-grid > div,

--- a/frontend/src/lib/components/research-runs/ResearchRunDiagnostics.svelte
+++ b/frontend/src/lib/components/research-runs/ResearchRunDiagnostics.svelte
@@ -9,6 +9,7 @@
     $: recentPredictionSamples =
         diagnostics?.actual_vs_predicted.slice(-8) ?? [];
     $: recentResidualSamples = diagnostics?.residuals.slice(-8) ?? [];
+    $: directionDiagnostics = diagnostics?.direction_classification ?? null;
 </script>
 
 <section class="surface diagnostics-surface">
@@ -18,41 +19,41 @@
             <h3>Regression Quality</h3>
         </div>
 
-        {#if diagnostics.direction_classification}
+        {#if directionDiagnostics}
             <div>
                 <div class="surface-header">
                     <div>
                         <p class="eyebrow">Direction Confirmation</p>
                         <h4>Up-probability quality</h4>
                     </div>
-                    <strong>{diagnostics.direction_classification.evaluation_status}</strong>
+                    <strong>{directionDiagnostics.evaluation_status}</strong>
                 </div>
-                {#if diagnostics.direction_classification.evaluation_status === "evaluated"}
+                {#if directionDiagnostics.evaluation_status === "evaluated"}
                     <div class="diagnostic-grid direction-grid">
                         <div>
                             <span>Precision</span>
-                            <strong>{formatNumber(diagnostics.direction_classification.precision)}</strong>
+                            <strong>{formatNumber(directionDiagnostics.precision)}</strong>
                         </div>
                         <div>
                             <span>Recall</span>
-                            <strong>{formatNumber(diagnostics.direction_classification.recall)}</strong>
+                            <strong>{formatNumber(directionDiagnostics.recall)}</strong>
                         </div>
                         <div>
                             <span>ROC AUC</span>
-                            <strong>{formatNumber(diagnostics.direction_classification.roc_auc)}</strong>
+                            <strong>{formatNumber(directionDiagnostics.roc_auc)}</strong>
                         </div>
                         <div>
                             <span>PR AUC</span>
-                            <strong>{formatNumber(diagnostics.direction_classification.pr_auc)}</strong>
+                            <strong>{formatNumber(directionDiagnostics.pr_auc)}</strong>
                         </div>
                         <div>
                             <span>Brier</span>
-                            <strong>{formatNumber(diagnostics.direction_classification.brier)}</strong>
+                            <strong>{formatNumber(directionDiagnostics.brier)}</strong>
                         </div>
                     </div>
                 {:else}
                     <p class="muted">
-                        {diagnostics.direction_classification.status_reason ??
+                        {directionDiagnostics.status_reason ??
                             "Direction confirmation could not be evaluated."}
                     </p>
                 {/if}

--- a/frontend/src/lib/components/research-runs/ResearchRunOpinion.svelte
+++ b/frontend/src/lib/components/research-runs/ResearchRunOpinion.svelte
@@ -1,0 +1,133 @@
+<script lang="ts">
+    import type { OpinionArtifact, OpinionRow } from "../../types";
+
+    export let opinion: OpinionArtifact;
+
+    const formatNumber = (value: number) => value.toFixed(4);
+    const stateLabels: Record<OpinionArtifact["state"], string> = {
+        viable: "Reviewable model output",
+        "no-opinion": "No reviewable model output",
+        "do-not-adopt": "Do not use",
+    };
+    const groups: Array<[string, keyof Pick<OpinionArtifact, "buy_candidates" | "watch" | "sell_or_avoid">]> = [
+        ["Positive model candidates", "buy_candidates"],
+        ["Watch or conflict", "watch"],
+        ["Negative model candidates", "sell_or_avoid"],
+    ];
+</script>
+
+<section class="surface opinion-surface">
+    <div class="surface-header">
+        <div>
+            <p class="eyebrow">Model Output Review</p>
+            <h3>Regression ranking with direction confirmation</h3>
+        </div>
+        <strong>{stateLabels[opinion.state]}</strong>
+    </div>
+    <p>{opinion.state_reason}</p>
+    <p class="muted">
+        As of {opinion.opinion_as_of ?? "N/A"}. Artifact completeness means the
+        output is reviewable; it does not establish out-of-sample predictive
+        skill or investment viability.
+    </p>
+
+    {#if opinion.state === "viable"}
+        <div class="opinion-groups">
+            {#each groups as [label, key]}
+                <div>
+                    <h4>{label}</h4>
+                    {#if opinion[key].length}
+                        <div class="table-wrap">
+                            <table>
+                                <thead>
+                                    <tr>
+                                        <th>Symbol</th>
+                                        <th>Predicted return</th>
+                                        <th>Up probability</th>
+                                        <th>Confirmation</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {#each opinion[key] as row (row.symbol)}
+                                        {@const opinionRow = row as OpinionRow}
+                                        <tr>
+                                            <td>{opinionRow.symbol}</td>
+                                            <td>{formatNumber(opinionRow.model_score)}</td>
+                                            <td>{formatNumber(opinionRow.up_probability)}</td>
+                                            <td>{opinionRow.confirmation_state}</td>
+                                        </tr>
+                                    {/each}
+                                </tbody>
+                            </table>
+                        </div>
+                    {:else}
+                        <p class="muted">No symbols in this group.</p>
+                    {/if}
+                </div>
+            {/each}
+        </div>
+    {:else if opinion.evidence_limitations.length}
+        <ul>
+            {#each opinion.evidence_limitations as limitation}
+                <li>{limitation}</li>
+            {/each}
+        </ul>
+    {/if}
+</section>
+
+<style lang="scss">
+    .opinion-surface,
+    .opinion-groups {
+        display: grid;
+        gap: var(--space-4);
+    }
+
+    .surface {
+        padding: 1.1rem;
+        border-radius: 22px;
+        border: 1px solid rgba(148, 163, 184, 0.12);
+        background: rgba(15, 23, 42, 0.62);
+    }
+
+    .surface-header {
+        display: flex;
+        justify-content: space-between;
+        gap: 1rem;
+        align-items: center;
+    }
+
+    .eyebrow {
+        margin: 0 0 0.3rem;
+        color: var(--muted);
+        font-size: 0.76rem;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+    }
+
+    h3,
+    h4,
+    p {
+        margin: 0;
+    }
+
+    .muted {
+        color: var(--muted);
+    }
+
+    .table-wrap {
+        overflow-x: auto;
+    }
+
+    table {
+        width: 100%;
+        border-collapse: collapse;
+    }
+
+    th,
+    td {
+        text-align: left;
+        padding: 0.7rem 0.5rem;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+        white-space: nowrap;
+    }
+</style>

--- a/frontend/src/lib/components/research-runs/ResearchRunOpinion.svelte
+++ b/frontend/src/lib/components/research-runs/ResearchRunOpinion.svelte
@@ -45,6 +45,7 @@
                                         <th>Predicted return</th>
                                         <th>Up probability</th>
                                         <th>Confirmation</th>
+                                        <th>Review context</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -55,6 +56,25 @@
                                             <td>{formatNumber(opinionRow.model_score)}</td>
                                             <td>{formatNumber(opinionRow.up_probability)}</td>
                                             <td>{opinionRow.confirmation_state}</td>
+                                            <td class="review-cell">
+                                                <details>
+                                                    <summary>Evidence &amp; risk</summary>
+                                                    <div class="review-context">
+                                                        <p><strong>Evidence:</strong> {opinionRow.evidence_reason}</p>
+                                                        <p><strong>Risk:</strong> {opinionRow.risk_or_warning}</p>
+                                                        <p><strong>Invalidation:</strong> {opinionRow.invalidation_note}</p>
+                                                        <ul>
+                                                            {#each opinionRow.source_artifact_references as reference}
+                                                                <li>
+                                                                    {reference.artifact}.{reference.field}
+                                                                    {#if reference.symbol} · {reference.symbol}{/if}
+                                                                    {#if reference.date} · {reference.date}{/if}
+                                                                </li>
+                                                            {/each}
+                                                        </ul>
+                                                    </div>
+                                                </details>
+                                            </td>
                                         </tr>
                                     {/each}
                                 </tbody>
@@ -129,5 +149,25 @@
         padding: 0.7rem 0.5rem;
         border-bottom: 1px solid rgba(148, 163, 184, 0.12);
         white-space: nowrap;
+    }
+
+    .review-cell {
+        min-width: 20rem;
+        white-space: normal;
+    }
+
+    .review-cell summary {
+        cursor: pointer;
+    }
+
+    .review-context {
+        display: grid;
+        gap: 0.5rem;
+        margin-top: 0.6rem;
+    }
+
+    .review-context p,
+    .review-context ul {
+        margin: 0;
     }
 </style>

--- a/frontend/src/lib/components/research-runs/ResearchRunSignals.svelte
+++ b/frontend/src/lib/components/research-runs/ResearchRunSignals.svelte
@@ -29,7 +29,7 @@
                         <tr>
                             <td>{signal.date}</td>
                             <td>{signal.symbol}</td>
-                            <td>{signal.score.toFixed(4)}</td>
+                            <td>{signal.score?.toFixed(4) ?? "N/A"}</td>
                             <td>{signal.position.toFixed(3)}</td>
                         </tr>
                     {/each}

--- a/frontend/src/lib/components/research-runs/ResearchRunValidation.svelte
+++ b/frontend/src/lib/components/research-runs/ResearchRunValidation.svelte
@@ -13,8 +13,11 @@
                 <p class="eyebrow">Validation</p>
                 <h3>{validation?.method ?? "Not Requested"}</h3>
             </div>
+            {#if validation}
+                <strong>{validation.evaluation_status}</strong>
+            {/if}
         </div>
-        {#if validation}
+        {#if validation?.evaluation_status === "evaluated"}
             <div class="mini-grid">
                 {#each Object.entries(validation.metrics) as [metric, value]}
                     <div>
@@ -23,6 +26,10 @@
                     </div>
                 {/each}
             </div>
+        {:else if validation}
+            <p class="muted">
+                {validation.status_reason ?? "Validation could not be evaluated."}
+            </p>
         {:else}
             <p class="muted">{emptyMessage}</p>
         {/if}

--- a/frontend/src/lib/state/researchWorkflow.ts
+++ b/frontend/src/lib/state/researchWorkflow.ts
@@ -356,6 +356,18 @@ export const buildResearchRunPayloadFromWorkflow = (
         : draft.modelFamily.variantId,
     params: {},
   },
+  direction_model: {
+    type:
+      draft.modelFamily.variantId === "lstm"
+        ? "xgboost"
+        : draft.modelFamily.variantId,
+    params: {},
+    positive_return_threshold: 0,
+    confirmation_probability_threshold: 0.5,
+    calibration_policy_version: "chronological_tail_20pct_min20_class5_v1",
+    confirmation_policy_version:
+      "regression_threshold_direction_probability_v1",
+  },
   strategy: {
     type: "research_v1",
     threshold: draft.modelFamily.threshold ?? undefined,

--- a/frontend/src/lib/types/researchRuns.ts
+++ b/frontend/src/lib/types/researchRuns.ts
@@ -112,6 +112,8 @@ export interface SignalPoint {
 
 export interface ValidationSummary {
   method: ValidationMethod;
+  evaluation_status: "evaluated" | "not_evaluated";
+  status_reason: string | null;
   metrics: Record<string, number>;
 }
 
@@ -149,6 +151,8 @@ export interface DirectionClassificationDiagnostics {
   positive_return_threshold: number;
   confirmation_probability_threshold: number;
   calibration_method: "sigmoid";
+  calibration_policy_version: "chronological_tail_20pct_min20_class5_v1";
+  confirmation_policy_version: "regression_threshold_direction_probability_v1";
   calibration_sample_count: number;
   positive_prevalence: number | null;
   confusion_matrix: number[][];
@@ -157,6 +161,25 @@ export interface DirectionClassificationDiagnostics {
   roc_auc: number | null;
   pr_auc: number | null;
   brier: number | null;
+}
+
+export interface OpinionSourceArtifactReference {
+  artifact:
+    | "request_payload"
+    | "config_sources"
+    | "fallback_audit"
+    | "version_pack"
+    | "model_diagnostics"
+    | "signals"
+    | "metrics"
+    | "baselines"
+    | "validation"
+    | "warnings"
+    | "artifact_completeness"
+    | "comparison_caveats";
+  field: string;
+  symbol: string | null;
+  date: string | null;
 }
 
 export interface OpinionRow {
@@ -169,6 +192,10 @@ export interface OpinionRow {
   evidence_reason: string;
   risk_or_warning: string;
   invalidation_note: string;
+  source_artifact_references: [
+    OpinionSourceArtifactReference,
+    ...OpinionSourceArtifactReference[],
+  ];
 }
 
 export interface OpinionArtifact {

--- a/frontend/src/lib/types/researchRuns.ts
+++ b/frontend/src/lib/types/researchRuns.ts
@@ -64,6 +64,14 @@ export interface ResearchRunCreateRequest {
     type: ModelType;
     params: Record<string, unknown>;
   };
+  direction_model?: {
+    type: ModelType;
+    params: Record<string, unknown>;
+    positive_return_threshold: number;
+    confirmation_probability_threshold: number;
+    calibration_policy_version: "chronological_tail_20pct_min20_class5_v1";
+    confirmation_policy_version: "regression_threshold_direction_probability_v1";
+  };
   strategy: {
     type: "research_v1";
     threshold?: number;
@@ -95,8 +103,11 @@ export interface EquityPoint {
 export interface SignalPoint {
   date: string;
   symbol: string;
-  score: number;
+  score: number | null;
   position: number;
+  signal_kind: "holdout_evaluation" | "forward_opinion";
+  up_probability: number | null;
+  predicted_direction: "up" | "down" | null;
 }
 
 export interface ValidationSummary {
@@ -127,6 +138,49 @@ export interface RegressionDiagnostics {
   actual_vs_predicted: RegressionDiagnosticPoint[];
   residuals: RegressionDiagnosticPoint[];
   feature_importance: FeatureImportancePoint[];
+  direction_classification: DirectionClassificationDiagnostics | null;
+}
+
+export interface DirectionClassificationDiagnostics {
+  task: "binary_classification";
+  evaluation_status: "evaluated" | "not_evaluated";
+  status_reason: string | null;
+  sample_count: number;
+  positive_return_threshold: number;
+  confirmation_probability_threshold: number;
+  calibration_method: "sigmoid";
+  calibration_sample_count: number;
+  positive_prevalence: number | null;
+  confusion_matrix: number[][];
+  precision: number | null;
+  recall: number | null;
+  roc_auc: number | null;
+  pr_auc: number | null;
+  brier: number | null;
+}
+
+export interface OpinionRow {
+  symbol: string;
+  model_score: number;
+  position_signal: number;
+  signal_date: string;
+  up_probability: number;
+  confirmation_state: "confirmed" | "conflict";
+  evidence_reason: string;
+  risk_or_warning: string;
+  invalidation_note: string;
+}
+
+export interface OpinionArtifact {
+  artifact_version: string;
+  state: "viable" | "no-opinion" | "do-not-adopt";
+  state_reason: string;
+  manual_adoption_only: true;
+  opinion_as_of: string | null;
+  evidence_limitations: string[];
+  buy_candidates: OpinionRow[];
+  sell_or_avoid: OpinionRow[];
+  watch: OpinionRow[];
 }
 
 export interface ComparisonCaveat {
@@ -157,6 +211,7 @@ export interface ResearchRunResponse
   model_diagnostics: RegressionDiagnostics | null;
   baselines: Record<string, Record<string, number>>;
   warnings: string[];
+  opinion_artifact: OpinionArtifact;
   runtime_mode: RuntimeMode;
   default_bundle_version: DefaultBundleVersion | null;
   effective_strategy: EffectiveStrategy;
@@ -192,5 +247,6 @@ export interface ResearchRunRecord
   model_diagnostics: RegressionDiagnostics | null;
   baselines: Record<string, Record<string, number>>;
   warnings: string[];
+  opinion_artifact: OpinionArtifact;
   created_at: string;
 }

--- a/tests/research/test_execution.py
+++ b/tests/research/test_execution.py
@@ -1,7 +1,14 @@
 import pandas as pd
+import pytest
+from pydantic import ValidationError
 
 import backend.research.services.execution as backtest_engine_service
-from backend.research.contracts.runs import ResearchRunCreateRequest
+from backend.platform.errors import InsufficientDataError
+from backend.research.contracts.runs import (
+    ResearchRunCreateRequest,
+    ValidationConfig,
+    ValidationSummary,
+)
 from backend.shared.analytics.strategy import ResearchStrategyConfig
 
 
@@ -13,7 +20,7 @@ def _make_request() -> ResearchRunCreateRequest:
         date_range={"start": "2024-01-01", "end": "2024-01-04"},
         return_target="open_to_open",
         horizon_days=1,
-        features=[{"name": "ma", "window": 5, "source": "close", "shift": 0}],
+        features=[{"name": "ma", "window": 5, "source": "close", "shift": 1}],
         model={"type": "random_forest", "params": {}},
         strategy={
             "type": "research_v1",
@@ -28,8 +35,46 @@ def _make_request() -> ResearchRunCreateRequest:
     )
 
 
+@pytest.mark.parametrize(
+    "metrics",
+    [{}, {"sharpe": float("nan")}, {"sharpe": float("inf")}, {"sharpe": None}],
+)
+def test_metrics_finite_check_rejects_invalid_values(metrics):
+    assert not backtest_engine_service._metrics_are_finite(metrics)
+
+
+def test_metrics_finite_check_accepts_flat_result():
+    assert backtest_engine_service._metrics_are_finite(
+        {"total_return": 0.0, "sharpe": 0.0, "max_drawdown": 0.0}
+    )
+
+
+def test_request_rejects_unshifted_daily_features():
+    payload = _make_request().model_dump()
+    payload["features"][0]["shift"] = 0
+
+    with pytest.raises(ValidationError):
+        ResearchRunCreateRequest.model_validate(payload)
+
+
+def test_direction_model_config_defaults_and_probability_bounds():
+    payload = _make_request().model_dump()
+    payload["direction_model"] = {"type": "extra_trees", "params": {}}
+
+    request = ResearchRunCreateRequest.model_validate(payload)
+
+    assert request.direction_model.positive_return_threshold == 0.0
+    assert request.direction_model.confirmation_probability_threshold == 0.5
+
+    payload["direction_model"]["confirmation_probability_threshold"] = 1.1
+    with pytest.raises(ValidationError):
+        ResearchRunCreateRequest.model_validate(payload)
+
+
 def test_load_symbol_data_includes_peer_features_in_training_frame(monkeypatch):
-    request = _make_request()
+    payload = _make_request().model_dump()
+    payload["direction_model"] = {"type": "extra_trees", "params": {}}
+    request = ResearchRunCreateRequest.model_validate(payload)
     index = pd.to_datetime(["2024-01-01", "2024-01-02", "2024-01-03", "2024-01-04"])
     raw_df = pd.DataFrame(
         {
@@ -78,7 +123,12 @@ def test_load_symbol_data_includes_peer_features_in_training_frame(monkeypatch):
     monkeypatch.setattr(
         backtest_engine_service.model_service,
         "time_series_split",
-        lambda X, y, test_size: (X.iloc[:3], X.iloc[3:], y.iloc[:3], y.iloc[3:]),
+        lambda X, y, test_size, purge: (
+            X.iloc[:3],
+            X.iloc[3:],
+            y.iloc[:3],
+            y.iloc[3:],
+        ),
     )
 
     class _Model:
@@ -91,12 +141,24 @@ def test_load_symbol_data_includes_peer_features_in_training_frame(monkeypatch):
         lambda **kwargs: _Model(),
     )
 
+    class _DirectionModel:
+        classes_ = [0, 1]
+
+        def predict_proba(self, X_test):
+            return pd.DataFrame([[0.3, 0.7] for _ in range(len(X_test))]).to_numpy()
+
+    monkeypatch.setattr(
+        backtest_engine_service.model_service,
+        "fit_calibrated_direction_classifier",
+        lambda **kwargs: (_DirectionModel(), None, 2),
+    )
+
     result = backtest_engine_service.load_symbol_data(
         "run_123",
         request,
         "2330",
         {"ma": [{"window": 5, "source": "close"}]},
-        {"MA_5": 0},
+        {"MA_5": 1},
         0.25,
         peer_feature_map={
             "2330": {
@@ -117,10 +179,75 @@ def test_load_symbol_data_includes_peer_features_in_training_frame(monkeypatch):
     assert captured["peer_symbol_count"] == [0.0, 2.0, 2.0, 1.0]
     assert captured["peer_feature_value"] == [0.0, 2.0, 2.0, 1.0]
     assert result["scores"].iloc[0] == 0.42
+    assert result["up_probabilities"].iloc[0] == 0.7
+    assert result["direction_actuals"].iloc[0] == 1
+
+
+def test_direction_diagnostics_aggregate_holdout_probabilities():
+    payload = _make_request().model_dump()
+    payload["direction_model"] = {"type": "extra_trees", "params": {}}
+    config = ResearchRunCreateRequest.model_validate(payload).direction_model
+    index = pd.to_datetime(["2024-01-03", "2024-01-04"])
+    diagnostics = backtest_engine_service.build_direction_classification_diagnostics(
+        [
+            {
+                "symbol": "2330",
+                "direction_config": config,
+                "direction_unavailable_reason": None,
+                "direction_calibration_sample_count": 4,
+                "direction_actuals": pd.Series([0, 1], index=index),
+                "up_probabilities": pd.Series([0.2, 0.8], index=index),
+            }
+        ]
+    )
+
+    assert diagnostics.evaluation_status == "evaluated"
+    assert diagnostics.calibration_policy_version == (
+        "chronological_tail_20pct_min20_class5_v1"
+    )
+    assert diagnostics.confusion_matrix == [[1, 0], [0, 1]]
+    assert diagnostics.roc_auc == 1.0
+    assert diagnostics.pr_auc == 1.0
+    assert diagnostics.brier == pytest.approx(0.04)
+
+
+def test_direction_diagnostics_fail_closed_for_partial_universe():
+    payload = _make_request().model_dump()
+    payload["direction_model"] = {"type": "extra_trees", "params": {}}
+    config = ResearchRunCreateRequest.model_validate(payload).direction_model
+
+    diagnostics = backtest_engine_service.build_direction_classification_diagnostics(
+        [
+            {
+                "symbol": "2330",
+                "direction_config": config,
+                "direction_unavailable_reason": None,
+                "direction_calibration_sample_count": 4,
+                "direction_actuals": pd.Series([0, 1]),
+                "up_probabilities": pd.Series([0.2, 0.8]),
+            },
+            {
+                "symbol": "2317",
+                "direction_config": config,
+                "direction_unavailable_reason": (
+                    "Direction model calibration window requires both classes."
+                ),
+                "direction_calibration_sample_count": 0,
+            },
+        ]
+    )
+
+    assert diagnostics.evaluation_status == "not_evaluated"
+    assert "2317" in diagnostics.status_reason
+    assert diagnostics.confusion_matrix == []
 
 
 def test_execute_research_run_accepts_foundation_version_pack_fields(monkeypatch):
     request = _make_request()
+    request.baselines = ["buy_and_hold", "naive_momentum"]
+    request.validation = ValidationConfig(
+        method="holdout", splits=1, test_size=0.25
+    )
     request.factor_catalog_version = "catalog_manual_v1"
     request.scoring_factor_ids = [
         "company_listing_age_days_v1",
@@ -240,6 +367,27 @@ def test_execute_research_run_accepts_foundation_version_pack_fields(monkeypatch
             [],
         ),
     )
+    monkeypatch.setitem(
+        backtest_engine_service.baseline_service.BASELINE_BUILDERS,
+        "buy_and_hold",
+        lambda close: pd.DataFrame(1.0, index=close.index, columns=close.columns),
+    )
+    monkeypatch.setitem(
+        backtest_engine_service.baseline_service.BASELINE_BUILDERS,
+        "naive_momentum",
+        lambda close: pd.DataFrame(0.5, index=close.index, columns=close.columns),
+    )
+
+    def _run_baseline(weights, **kwargs):
+        if weights.iloc[0, 0] == 1.0:
+            return {"sharpe": float("nan")}, []
+        return {"sharpe": 0.5}, []
+
+    monkeypatch.setattr(
+        backtest_engine_service.backtest_service,
+        "run_backtest_from_weights",
+        _run_baseline,
+    )
     monkeypatch.setattr(
         backtest_engine_service,
         "build_p3_summary",
@@ -267,7 +415,17 @@ def test_execute_research_run_accepts_foundation_version_pack_fields(monkeypatch
     monkeypatch.setattr(
         backtest_engine_service,
         "compute_validation_summary",
-        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: ValidationSummary(
+            method="holdout",
+            evaluation_status="not_evaluated",
+            status_reason="common-date sample is insufficient",
+            metrics={},
+        ),
+    )
+    monkeypatch.setattr(
+        backtest_engine_service,
+        "build_forward_opinion_signals",
+        lambda *args, **kwargs: ([], "prospective snapshot is unavailable"),
     )
     monkeypatch.setattr(
         backtest_engine_service,
@@ -302,4 +460,549 @@ def test_execute_research_run_accepts_foundation_version_pack_fields(monkeypatch
     assert artifacts.response.adaptive_mode == "shadow"
     assert artifacts.response.reward_definition_version == "reward_v1"
     assert artifacts.response.comparison_eligibility == "research_only_comparable"
+    assert artifacts.response.baselines == {"naive_momentum": {"sharpe": 0.5}}
+    assert artifacts.response.warnings == [
+        "prospective snapshot is unavailable",
+        "Baseline 'buy_and_hold' not evaluated: backtest produced empty or "
+        "non-finite metrics.",
+        "Validation not evaluated: common-date sample is insufficient",
+    ]
+    assert artifacts.warnings == artifacts.response.warnings
     assert exclusion_calls == ["run_foundation_response"]
+
+    monkeypatch.setattr(
+        backtest_engine_service.backtest_service,
+        "run_backtest",
+        lambda **kwargs: ({"sharpe": float("nan")}, [], [], []),
+    )
+    with pytest.raises(
+        InsufficientDataError,
+        match="Main backtest produced empty or non-finite metrics",
+    ):
+        backtest_engine_service.execute_research_run("run_non_finite", request)
+
+
+def test_forward_opinion_requires_same_latest_date_and_complete_universe(monkeypatch):
+    request = _make_request()
+    request.symbols = ["2330", "2317"]
+    request = ResearchRunCreateRequest.model_validate(
+        {
+            **request.model_dump(mode="json"),
+            "direction_model": {"type": "extra_trees", "params": {}},
+        }
+    )
+    index = pd.to_datetime(["2024-01-02", "2024-01-03"])
+
+    class _Regressor:
+        def predict(self, frame):
+            return [0.02]
+
+    class _Classifier:
+        classes_ = [0, 1]
+
+        def predict_proba(self, frame):
+            return [[0.2, 0.8]]
+
+    monkeypatch.setattr(
+        backtest_engine_service.model_service,
+        "fit_regressor",
+        lambda **kwargs: _Regressor(),
+    )
+    monkeypatch.setattr(
+        backtest_engine_service.model_service,
+        "fit_calibrated_direction_classifier",
+        lambda **kwargs: (_Classifier(), None, 1),
+    )
+    symbol_data = [
+        {
+            "symbol": symbol,
+            "X": pd.DataFrame({"MA_5": [1.0]}, index=index[:1]),
+            "y": pd.Series([0.01], index=index[:1]),
+            "prediction_features": pd.DataFrame(
+                {"MA_5": [1.0, 2.0]}, index=index
+            ),
+        }
+        for symbol in ("2330", "2317")
+    ]
+    strategy = ResearchStrategyConfig(
+        type="research_v1", threshold=0.003, top_n=1, allow_proactive_sells=True
+    )
+
+    signals, warning = backtest_engine_service.build_forward_opinion_signals(
+        symbol_data, request, strategy
+    )
+
+    assert warning is None
+    assert {item["symbol"] for item in signals} == {"2330", "2317"}
+    assert {item["date"] for item in signals} == {index[-1].date()}
+    assert all(item["signal_kind"] == "forward_opinion" for item in signals)
+    symbol_data[1]["prediction_features"] = symbol_data[1][
+        "prediction_features"
+    ].iloc[:-1]
+    signals, warning = backtest_engine_service.build_forward_opinion_signals(
+        symbol_data, request, strategy
+    )
+    assert signals == []
+    assert "do not share one latest feature date" in warning
+
+
+def test_forward_opinion_fails_closed_for_zero_lookahead_target():
+    payload = _make_request().model_dump(mode="json")
+    payload.update(
+        return_target="open_to_close",
+        direction_model={"type": "extra_trees", "params": {}},
+    )
+    request = ResearchRunCreateRequest.model_validate(payload)
+
+    signals, warning = backtest_engine_service.build_forward_opinion_signals(
+        [{}],
+        request,
+        ResearchStrategyConfig(
+            type="research_v1",
+            threshold=0.003,
+            top_n=1,
+            allow_proactive_sells=True,
+        ),
+    )
+    assert signals == []
+    assert "no unlabeled forward feature row" in warning
+
+
+def test_forward_opinion_reports_direction_calibration_failure(monkeypatch):
+    payload = _make_request().model_dump(mode="json")
+    payload["direction_model"] = {"type": "extra_trees", "params": {}}
+    request = ResearchRunCreateRequest.model_validate(payload)
+    index = pd.to_datetime(["2024-01-02", "2024-01-03"])
+    symbol_data = [
+        {
+            "symbol": "2330",
+            "X": pd.DataFrame({"MA_5": [1.0]}, index=index[:1]),
+            "y": pd.Series([0.01], index=index[:1]),
+            "prediction_features": pd.DataFrame(
+                {"MA_5": [1.0, 2.0]}, index=index
+            ),
+        }
+    ]
+    monkeypatch.setattr(
+        backtest_engine_service.model_service,
+        "fit_regressor",
+        lambda **kwargs: object(),
+    )
+    monkeypatch.setattr(
+        backtest_engine_service.model_service,
+        "fit_calibrated_direction_classifier",
+        lambda **kwargs: (None, "class support unavailable", 0),
+    )
+
+    signals, warning = backtest_engine_service.build_forward_opinion_signals(
+        symbol_data, request, request.strategy
+    )
+
+    assert signals == []
+    assert warning == (
+        "[2330] Prospective direction calibration unavailable: "
+        "class support unavailable"
+    )
+
+
+def test_holdout_confirmation_fails_closed_for_partial_universe():
+    payload = _make_request().model_dump(mode="json")
+    payload.update(
+        symbols=["2330", "2317"],
+        direction_model={
+            "type": "extra_trees",
+            "params": {},
+            "confirmation_probability_threshold": 0.0,
+        },
+    )
+    request = ResearchRunCreateRequest.model_validate(payload)
+    index = pd.to_datetime(["2024-01-03", "2024-01-04"])
+    scores = pd.DataFrame(
+        {"2330": [0.01, 0.02], "2317": [0.03, 0.04]}, index=index
+    )
+
+    probabilities, warning = (
+        backtest_engine_service.build_holdout_confirmation_probabilities(
+            [
+                {
+                    "symbol": "2330",
+                    "up_probabilities": pd.Series([0.8, 0.9], index=index),
+                },
+                {"symbol": "2317"},
+            ],
+            scores,
+            request,
+        )
+    )
+
+    assert probabilities.isna().all().all()
+    assert "2317" in warning
+    weights = backtest_engine_service.backtest_service.build_target_weights(
+        scores=scores,
+        strategy=request.strategy,
+        confirmation_probabilities=probabilities,
+        confirmation_threshold=0.0,
+    )
+    assert (weights == 0.0).all().all()
+
+
+def _validation_request(*, direction: bool) -> ResearchRunCreateRequest:
+    payload = _make_request().model_dump(mode="json")
+    payload["validation"] = {"method": "holdout", "splits": 1, "test_size": 0.25}
+    if direction:
+        payload["direction_model"] = {"type": "extra_trees", "params": {}}
+    return ResearchRunCreateRequest.model_validate(payload)
+
+
+def _validation_symbol_data() -> list[dict]:
+    index = pd.date_range("2024-01-01", periods=6)
+    prices = pd.DataFrame(
+        {
+            "open": [100.0] * 6,
+            "high": [101.0] * 6,
+            "low": [99.0] * 6,
+            "close": [100.5] * 6,
+        },
+        index=index,
+    )
+    return [
+        {
+            "symbol": "2330",
+            "df_model": prices,
+            "X": pd.DataFrame({"MA_5": range(6)}, index=index),
+            "y": pd.Series([-0.02, 0.01, -0.01, 0.02, 0.01, -0.01], index=index),
+        }
+    ]
+
+
+def test_validation_uses_calibrated_direction_probabilities(monkeypatch):
+    request = _validation_request(direction=True)
+    monkeypatch.setattr(
+        backtest_engine_service.validation_service,
+        "generate_splits",
+        lambda **kwargs: [(range(0, 4), range(4, 6))],
+    )
+
+    class _Regressor:
+        def predict(self, frame):
+            return [0.02] * len(frame)
+
+    class _Classifier:
+        classes_ = [0, 1]
+
+        def predict_proba(self, frame):
+            return pd.DataFrame([[0.2, 0.8]] * len(frame)).to_numpy()
+
+    monkeypatch.setattr(
+        backtest_engine_service.model_service,
+        "fit_regressor",
+        lambda **kwargs: _Regressor(),
+    )
+    monkeypatch.setattr(
+        backtest_engine_service.model_service,
+        "fit_calibrated_direction_classifier",
+        lambda **kwargs: (_Classifier(), None, 2),
+    )
+    captured = {}
+
+    def _run_backtest(**kwargs):
+        captured.update(kwargs)
+        return {"sharpe": 1.0}, [], [], []
+
+    monkeypatch.setattr(
+        backtest_engine_service.backtest_service, "run_backtest", _run_backtest
+    )
+
+    summary = backtest_engine_service.compute_validation_summary(
+        _validation_symbol_data(),
+        request,
+        request.strategy,
+    )
+
+    assert captured["confirmation_probabilities"]["2330"].tolist() == [0.8, 0.8]
+    assert summary.evaluation_status == "evaluated"
+    assert summary.status_reason is None
+    assert summary.metrics == {"sharpe": 1.0, "avg_sharpe": 1.0}
+
+
+def test_validation_fails_closed_when_direction_calibration_is_unavailable(
+    monkeypatch,
+):
+    request = _validation_request(direction=True)
+    monkeypatch.setattr(
+        backtest_engine_service.validation_service,
+        "generate_splits",
+        lambda **kwargs: [(range(0, 4), range(4, 6))],
+    )
+
+    class _Regressor:
+        def predict(self, frame):
+            return [0.02] * len(frame)
+
+    monkeypatch.setattr(
+        backtest_engine_service.model_service,
+        "fit_regressor",
+        lambda **kwargs: _Regressor(),
+    )
+    monkeypatch.setattr(
+        backtest_engine_service.model_service,
+        "fit_calibrated_direction_classifier",
+        lambda **kwargs: (None, "calibration unavailable", 0),
+    )
+    monkeypatch.setattr(
+        backtest_engine_service.backtest_service,
+        "run_backtest",
+        lambda **kwargs: pytest.fail("hybrid validation must not fall back"),
+    )
+
+    summary = backtest_engine_service.compute_validation_summary(
+        _validation_symbol_data(),
+        request,
+        request.strategy,
+    )
+
+    assert summary.evaluation_status == "not_evaluated"
+    assert summary.metrics == {}
+    assert "calibration unavailable" in summary.status_reason
+
+
+@pytest.mark.parametrize("probability", [float("nan"), float("inf"), 1.01])
+def test_validation_reports_invalid_direction_probabilities(
+    monkeypatch, probability
+):
+    request = _validation_request(direction=True)
+    monkeypatch.setattr(
+        backtest_engine_service.validation_service,
+        "generate_splits",
+        lambda **kwargs: [(range(0, 4), range(4, 6))],
+    )
+
+    class _Regressor:
+        def predict(self, frame):
+            return [0.02] * len(frame)
+
+    class _Classifier:
+        classes_ = [0, 1]
+
+        def predict_proba(self, frame):
+            return pd.DataFrame(
+                [[1.0 - probability, probability] for _ in range(len(frame))]
+            ).to_numpy()
+
+    monkeypatch.setattr(
+        backtest_engine_service.model_service,
+        "fit_regressor",
+        lambda **kwargs: _Regressor(),
+    )
+    monkeypatch.setattr(
+        backtest_engine_service.model_service,
+        "fit_calibrated_direction_classifier",
+        lambda **kwargs: (_Classifier(), None, 2),
+    )
+    monkeypatch.setattr(
+        backtest_engine_service.backtest_service,
+        "run_backtest",
+        lambda **kwargs: pytest.fail("invalid probabilities must not be backtested"),
+    )
+
+    summary = backtest_engine_service.compute_validation_summary(
+        _validation_symbol_data(), request, request.strategy
+    )
+
+    assert summary.evaluation_status == "not_evaluated"
+    assert "outside [0, 1]" in summary.status_reason
+
+
+def test_validation_keeps_regression_only_behavior(monkeypatch):
+    request = _validation_request(direction=False)
+    monkeypatch.setattr(
+        backtest_engine_service.validation_service,
+        "generate_splits",
+        lambda **kwargs: [(range(0, 4), range(4, 6))],
+    )
+
+    class _Regressor:
+        def predict(self, frame):
+            return [0.02] * len(frame)
+
+    monkeypatch.setattr(
+        backtest_engine_service.model_service,
+        "fit_regressor",
+        lambda **kwargs: _Regressor(),
+    )
+    captured = {}
+
+    def _run_backtest(**kwargs):
+        captured.update(kwargs)
+        return {"sharpe": 1.0}, [], [], []
+
+    monkeypatch.setattr(
+        backtest_engine_service.backtest_service, "run_backtest", _run_backtest
+    )
+
+    summary = backtest_engine_service.compute_validation_summary(
+        _validation_symbol_data(),
+        request,
+        request.strategy,
+    )
+
+    assert captured["confirmation_probabilities"] is None
+    assert summary.evaluation_status == "evaluated"
+    assert summary.metrics == {"sharpe": 1.0, "avg_sharpe": 1.0}
+
+    monkeypatch.setattr(
+        backtest_engine_service.backtest_service,
+        "run_backtest",
+        lambda **kwargs: ({"sharpe": float("inf")}, [], [], []),
+    )
+    summary = backtest_engine_service.compute_validation_summary(
+        _validation_symbol_data(), request, request.strategy
+    )
+    assert summary.evaluation_status == "not_evaluated"
+    assert "non-finite metrics" in summary.status_reason
+
+
+def test_validation_backtests_complete_cross_section_once_per_fold(monkeypatch):
+    payload = _validation_request(direction=False).model_dump(mode="json")
+    payload["symbols"] = ["2330", "2317"]
+    payload["strategy"]["top_n"] = 1
+    request = ResearchRunCreateRequest.model_validate(payload)
+    symbol_data = _validation_symbol_data()
+    second = {
+        **symbol_data[0],
+        "symbol": "2317",
+        "df_model": symbol_data[0]["df_model"].copy(),
+        "X": symbol_data[0]["X"].copy(),
+        "y": symbol_data[0]["y"].copy(),
+    }
+    symbol_data.append(second)
+    monkeypatch.setattr(
+        backtest_engine_service.validation_service,
+        "generate_splits",
+        lambda **kwargs: [(range(0, 4), range(4, 6))],
+    )
+
+    prediction = iter((0.01, 0.02))
+
+    class _Regressor:
+        def __init__(self, value):
+            self.value = value
+
+        def predict(self, frame):
+            return [self.value] * len(frame)
+
+    monkeypatch.setattr(
+        backtest_engine_service.model_service,
+        "fit_regressor",
+        lambda **kwargs: _Regressor(next(prediction)),
+    )
+    calls = []
+
+    def _run_backtest(**kwargs):
+        calls.append(kwargs)
+        weights = backtest_engine_service.backtest_service.build_target_weights(
+            scores=kwargs["scores"], strategy=kwargs["strategy"]
+        )
+        assert (weights.gt(0).sum(axis=1) == 1).all()
+        return {"sharpe": 1.5}, [], [], []
+
+    monkeypatch.setattr(
+        backtest_engine_service.backtest_service, "run_backtest", _run_backtest
+    )
+
+    summary = backtest_engine_service.compute_validation_summary(
+        symbol_data, request, request.strategy
+    )
+
+    assert len(calls) == 1
+    assert list(calls[0]["scores"].columns) == ["2330", "2317"]
+    assert summary.evaluation_status == "evaluated"
+    assert summary.metrics == {"sharpe": 1.5, "avg_sharpe": 1.5}
+
+
+def test_validation_uses_common_dates_for_misaligned_symbol_calendars(monkeypatch):
+    payload = _validation_request(direction=False).model_dump(mode="json")
+    payload["symbols"] = ["2330", "2317"]
+    request = ResearchRunCreateRequest.model_validate(payload)
+    first = _validation_symbol_data()[0]
+    second = {
+        **first,
+        "symbol": "2317",
+        "df_model": first["df_model"].drop(index=first["X"].index[1]),
+        "X": first["X"].drop(index=first["X"].index[1]),
+        "y": first["y"].drop(index=first["X"].index[1]),
+    }
+    monkeypatch.setattr(
+        backtest_engine_service.validation_service,
+        "generate_splits",
+        lambda **kwargs: [(range(0, 3), range(3, 5))],
+    )
+
+    class _Regressor:
+        def predict(self, frame):
+            return [0.02] * len(frame)
+
+    monkeypatch.setattr(
+        backtest_engine_service.model_service,
+        "fit_regressor",
+        lambda **kwargs: _Regressor(),
+    )
+    calls = []
+
+    def _run_backtest(**kwargs):
+        calls.append(kwargs)
+        return {"sharpe": 1.0}, [], [], []
+
+    monkeypatch.setattr(
+        backtest_engine_service.backtest_service, "run_backtest", _run_backtest
+    )
+
+    summary = backtest_engine_service.compute_validation_summary(
+        [first, second], request, request.strategy
+    )
+
+    expected_dates = first["X"].index.drop(first["X"].index[1])[-2:]
+    assert summary.evaluation_status == "evaluated"
+    assert calls[0]["scores"].index.equals(expected_dates)
+    assert all(
+        frame.index.equals(expected_dates)
+        for frame in calls[0].values()
+        if isinstance(frame, pd.DataFrame)
+    )
+
+
+def test_validation_reports_no_common_dates_without_raising():
+    payload = _validation_request(direction=False).model_dump(mode="json")
+    payload["symbols"] = ["2330", "2317"]
+    request = ResearchRunCreateRequest.model_validate(payload)
+    first = _validation_symbol_data()[0]
+    second_index = pd.date_range("2025-01-01", periods=6)
+    second = {
+        **first,
+        "symbol": "2317",
+        "df_model": first["df_model"].set_axis(second_index),
+        "X": first["X"].set_axis(second_index),
+        "y": first["y"].set_axis(second_index),
+    }
+
+    summary = backtest_engine_service.compute_validation_summary(
+        [first, second], request, request.strategy
+    )
+
+    assert summary.evaluation_status == "not_evaluated"
+    assert summary.metrics == {}
+    assert "no common model-ready dates" in summary.status_reason
+
+
+def test_validation_reports_partial_requested_universe_without_raising():
+    payload = _validation_request(direction=False).model_dump(mode="json")
+    payload["symbols"] = ["2330", "2317"]
+    request = ResearchRunCreateRequest.model_validate(payload)
+
+    summary = backtest_engine_service.compute_validation_summary(
+        _validation_symbol_data(), request, request.strategy
+    )
+
+    assert summary.evaluation_status == "not_evaluated"
+    assert summary.metrics == {}
+    assert "does not match the requested universe" in summary.status_reason

--- a/tests/research/test_research_api.py
+++ b/tests/research/test_research_api.py
@@ -2,6 +2,7 @@ from datetime import date, datetime, timezone
 
 import pytest
 from fastapi.testclient import TestClient
+from pydantic import ValidationError
 
 import backend.app as backend_app
 import backend.research.api as research_runs_api
@@ -39,6 +40,31 @@ def make_payload() -> dict:
         "execution": {"slippage": 0.001, "fees": 0.002},
         "baselines": [],
     }
+
+
+def test_public_request_accepts_direction_model_defaults():
+    payload = make_payload()
+    payload["direction_model"] = {"type": "extra_trees", "params": {}}
+
+    request = research_runs_api.PublicResearchRunCreateRequest.model_validate(payload)
+
+    assert request.direction_model.positive_return_threshold == 0.0
+    assert request.direction_model.confirmation_probability_threshold == 0.5
+    assert request.direction_model.calibration_policy_version == (
+        "chronological_tail_20pct_min20_class5_v1"
+    )
+
+
+def test_public_request_rejects_unknown_direction_calibration_policy():
+    payload = make_payload()
+    payload["direction_model"] = {
+        "type": "extra_trees",
+        "params": {},
+        "calibration_policy_version": "future_policy",
+    }
+
+    with pytest.raises(ValidationError):
+        research_runs_api.PublicResearchRunCreateRequest.model_validate(payload)
 
 
 def make_opinion_artifact() -> dict:
@@ -90,12 +116,16 @@ def make_opinion_artifact() -> dict:
         "state": "viable",
         "state_reason": "Complete persisted research artifacts support traceable opinion rows.",
         "manual_adoption_only": True,
+        "opinion_as_of": "2024-01-02",
         "evidence_limitations": [],
         "buy_candidates": [
             {
                 "symbol": "2330",
                 "model_score": 0.01,
                 "position_signal": 1.0,
+                "signal_date": "2024-01-02",
+                "up_probability": 0.8,
+                "confirmation_state": "confirmed",
                 "evidence_reason": "Latest persisted signal links model score to strategy position for this symbol.",
                 "risk_or_warning": "Research-only opinion for manual adoption review.",
                 "invalidation_note": "Do not adopt if newer data invalidates this persisted run.",

--- a/tests/research/test_run_repository.py
+++ b/tests/research/test_run_repository.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from types import SimpleNamespace
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -11,6 +12,112 @@ from backend.database import (
     ResearchRunLiquidityCoverage,
 )
 from backend.research.domain.version_pack import build_version_pack_payload
+
+
+def test_validation_parser_upgrades_legacy_empty_metrics_with_reason():
+    payload = research_run_repository._validation_summary_from_payload(
+        {"method": "walk_forward", "metrics": {}}
+    )
+
+    assert payload == {
+        "method": "walk_forward",
+        "evaluation_status": "not_evaluated",
+        "status_reason": (
+            "Legacy validation record has no metrics or persisted status reason."
+        ),
+        "metrics": {},
+    }
+
+
+def test_legacy_validation_remains_present_in_artifact_summary():
+    row = SimpleNamespace(
+        status="succeeded",
+        comparison_eligibility="research_only_comparable",
+        metrics_json="{}",
+        equity_curve_json="[]",
+        signals_json="[]",
+        baselines_json=None,
+    )
+
+    summary = research_run_repository._review_artifact_summary_from_row(
+        row,
+        request_payload={
+            "validation": {
+                "method": "walk_forward",
+                "splits": 3,
+                "test_size": 0.2,
+            },
+            "baselines": [],
+        },
+        validation_outcome={"method": "walk_forward", "metrics": {}},
+        model_diagnostics={"task": "regression", "sample_count": 0},
+    )
+
+    assert summary["artifact_completeness"] == "complete"
+    assert "validation" in summary["present_artifacts"]
+    assert "validation" not in summary["missing_artifacts"]
+
+
+def test_requested_missing_baseline_remains_partial_after_reload():
+    row = SimpleNamespace(
+        status="succeeded",
+        comparison_eligibility="research_only_comparable",
+        metrics_json="{}",
+        equity_curve_json="[]",
+        signals_json="[]",
+        baselines_json='{"buy_and_hold": {"sharpe": 0.5}}',
+    )
+
+    summary = research_run_repository._review_artifact_summary_from_row(
+        row,
+        request_payload={
+            "validation": None,
+            "baselines": ["buy_and_hold", "naive_momentum"],
+        },
+        validation_outcome=None,
+        model_diagnostics={"task": "regression", "sample_count": 0},
+    )
+
+    assert summary["artifact_completeness"] == "partial"
+    assert "baselines" in summary["missing_artifacts"]
+    assert "baselines" not in summary["present_artifacts"]
+
+
+def test_model_diagnostics_parser_preserves_direction_diagnostics():
+    payload = research_run_repository._model_diagnostics_from_payload(
+        {
+            "task": "regression",
+            "sample_count": 2,
+            "direction_classification": {
+                "task": "binary_classification",
+                "evaluation_status": "evaluated",
+                "sample_count": 2,
+                "positive_return_threshold": 0.0,
+                "confirmation_probability_threshold": 0.5,
+                "calibration_method": "sigmoid",
+                "confirmation_policy_version": (
+                    "regression_threshold_direction_probability_v1"
+                ),
+                "calibration_sample_count": 4,
+                "positive_prevalence": 0.5,
+                "confusion_matrix": [[1, 0], [0, 1]],
+                "precision": 1.0,
+                "recall": 1.0,
+                "roc_auc": 1.0,
+                "pr_auc": 1.0,
+                "brier": 0.04,
+            },
+        }
+    )
+
+    assert payload["direction_classification"]["evaluation_status"] == "evaluated"
+    assert payload["direction_classification"]["calibration_policy_version"] == (
+        "chronological_tail_20pct_min20_class5_v1"
+    )
+    assert payload["direction_classification"]["confusion_matrix"] == [
+        [1, 0],
+        [0, 1],
+    ]
 
 
 def test_research_run_repository_roundtrip(monkeypatch):
@@ -48,7 +155,13 @@ def test_research_run_repository_roundtrip(monkeypatch):
         },
         "validation_outcome": {"ok": True},
         "rejection_reason": None,
-        "request_payload": {"symbols": ["2330", "2317", "2454", "9999"]},
+        "request_payload": {
+            "symbols": ["2330", "2317", "2454", "9999"],
+            "direction_model": {"confirmation_probability_threshold": 0.5},
+            "features": [
+                {"name": "ma", "window": 5, "source": "close", "shift": 0}
+            ],
+        },
         "metrics": {
             "total_return": 0.12,
             "sharpe": 1.1,
@@ -62,10 +175,25 @@ def test_research_run_repository_roundtrip(monkeypatch):
                 "symbol": "2330",
                 "score": 0.01,
                 "position": 1.0,
+                "signal_kind": "forward_opinion",
+                "up_probability": 0.8,
+                "predicted_direction": "up",
             },
-            {"date": "2024-01-02", "symbol": "2317", "score": -0.02, "position": -1.0},
-            {"date": "2024-01-02", "symbol": "2454", "score": 0.0, "position": 0.0},
-            {"date": "2024-01-02", "symbol": "9999", "score": None, "position": 1.0},
+            {
+                "date": "2024-01-02", "symbol": "2317", "score": -0.02,
+                "position": 0.0, "signal_kind": "forward_opinion",
+                "up_probability": 0.2, "predicted_direction": "down",
+            },
+            {
+                "date": "2024-01-02", "symbol": "2454", "score": 0.0,
+                "position": 0.0, "signal_kind": "forward_opinion",
+                "up_probability": 0.7, "predicted_direction": "up",
+            },
+            {
+                "date": "2024-01-02", "symbol": "9999", "score": 0.02,
+                "position": 0.0, "signal_kind": "forward_opinion",
+                "up_probability": 0.8, "predicted_direction": "up",
+            },
         ],
         "model_diagnostics": {
             "task": "regression",
@@ -77,6 +205,11 @@ def test_research_run_repository_roundtrip(monkeypatch):
             "actual_vs_predicted": [],
             "residuals": [],
             "feature_importance": [],
+            "direction_classification": {
+                "task": "binary_classification",
+                "evaluation_status": "evaluated",
+                "sample_count": 4,
+            },
         },
         "warnings": [],
         "tradability_state": "research_only",
@@ -143,6 +276,7 @@ def test_research_run_repository_roundtrip(monkeypatch):
     loaded = research_run_repository.get_research_run_record("run_123")
 
     assert loaded["run_id"] == "run_123"
+    assert loaded["request_payload"]["features"][0]["shift"] == 0
     assert loaded["effective_strategy"] == {"threshold": 0.003, "top_n": 3}
     assert loaded["comparison_eligibility"] == "research_only_comparable"
     assert loaded["version_pack_status"]["adv_basis_version"] == "implemented"
@@ -158,7 +292,8 @@ def test_research_run_repository_roundtrip(monkeypatch):
         "2317"
     ]
     assert [row["symbol"] for row in loaded["opinion_artifact"]["watch"]] == [
-        "2454"
+        "2454",
+        "9999",
     ]
     opinion_row = loaded["opinion_artifact"]["buy_candidates"][0]
     assert opinion_row["symbol"] == "2330"
@@ -196,13 +331,13 @@ def test_research_run_repository_roundtrip(monkeypatch):
         "metrics_present": True,
         "opinion_rows_emitted_or_limited": True,
     }
-    assert checks["signal_to_position"]["status"] == "warning"
+    assert checks["signal_to_position"]["status"] == "pass"
     assert checks["signal_to_position"]["result"] == {
         "checked_symbol_count": 4,
         "positive_count": 1,
-        "negative_count": 1,
-        "flat_count": 1,
-        "invalid_row_count": 1,
+        "negative_count": 0,
+        "flat_count": 3,
+        "invalid_row_count": 0,
     }
     assert checks["backtest_report_discipline"]["status"] == "pass"
     assert checks["backtest_report_discipline"]["result"]["metric_keys"] == [
@@ -222,15 +357,15 @@ def test_research_run_repository_roundtrip(monkeypatch):
     ]
     assert checks["robustness"]["status"] == "warning"
     assert checks["robustness"]["result"]["baseline_keys"] == []
-    assert checks["parameter_sensitivity"]["status"] == "warning"
+    assert checks["parameter_sensitivity"]["status"] == "pass"
     assert checks["parameter_sensitivity"]["result"]["base_candidate_symbols"] == [
         "2330"
     ]
     assert checks["parameter_sensitivity"]["result"]["scenario_candidate_counts"] == {
-        "strict_threshold": 1,
-        "loose_threshold": 1,
+        "strict_threshold": 2,
+        "loose_threshold": 2,
         "top_n_minus_1": 2,
-        "top_n_plus_1": 3,
+        "top_n_plus_1": 4,
     }
     assert checks["parameter_sensitivity"]["result"]["stable_symbols"] == ["2330"]
     assert checks["parameter_sensitivity"]["result"]["provisional_policy"]

--- a/tests/research/test_runs.py
+++ b/tests/research/test_runs.py
@@ -32,6 +32,7 @@ def make_request() -> ResearchRunCreateRequest:
         horizon_days=1,
         features=[{"name": "ma", "window": 5, "source": "close", "shift": 1}],
         model={"type": "xgboost", "params": {}},
+        direction_model={"type": "extra_trees", "params": {}},
         strategy={
             "type": "research_v1",
             "threshold": 0.003,
@@ -43,6 +44,14 @@ def make_request() -> ResearchRunCreateRequest:
     )
 
 
+def test_new_research_request_rejects_unshifted_features():
+    payload = make_request().model_dump(mode="json")
+    payload["features"][0]["shift"] = 0
+
+    with pytest.raises(ValidationError):
+        ResearchRunCreateRequest.model_validate(payload)
+
+
 def make_response(run_id: str = "run_123") -> ResearchRunResponse:
     return ResearchRunResponse(
         run_id=run_id,
@@ -51,7 +60,15 @@ def make_response(run_id: str = "run_123") -> ResearchRunResponse:
         ),
         equity_curve=[{"date": "2024-01-02", "equity": 1.0}],
         signals=[
-            {"date": "2024-01-02", "symbol": "2330", "score": 0.01, "position": 1.0}
+            {
+                "date": "2024-01-02",
+                "symbol": "2330",
+                "score": 0.01,
+                "position": 1.0,
+                "signal_kind": "forward_opinion",
+                "up_probability": 0.8,
+                "predicted_direction": "up",
+            }
         ],
         validation=None,
         model_diagnostics={
@@ -64,6 +81,10 @@ def make_response(run_id: str = "run_123") -> ResearchRunResponse:
             "actual_vs_predicted": [],
             "residuals": [],
             "feature_importance": [],
+            "direction_classification": {
+                "evaluation_status": "evaluated",
+                "sample_count": 2,
+            },
         },
         baselines={},
         warnings=[],
@@ -93,19 +114,57 @@ def make_response(run_id: str = "run_123") -> ResearchRunResponse:
     )
 
 
+def test_requested_missing_baseline_marks_response_partial():
+    request = make_request()
+    request.baselines = ["buy_and_hold", "naive_momentum"]
+    response = make_response("run_missing_baseline").model_copy(
+        update={"baselines": {"buy_and_hold": {"sharpe": 0.5}}}
+    )
+
+    response = research_run_service._response_with_artifact_summary(
+        response, request
+    )
+
+    assert response.artifact_completeness == "partial"
+    assert "baselines" in response.missing_artifacts
+    assert "baselines" not in response.present_artifacts
+
+
 def make_opinion_payload() -> dict:
     return {
         "status": "succeeded",
         "request_payload": {
             "symbols": ["2330", "2317"],
             "strategy": {"threshold": 0.003, "top_n": 2},
+            "direction_model": {"confirmation_probability_threshold": 0.5},
         },
         "effective_strategy": {"threshold": 0.003, "top_n": 2},
         "metrics": {"total_return": 0.12, "sharpe": 1.1},
-        "model_diagnostics": {"task": "regression", "sample_count": 2, "rmse": 0.1},
+        "model_diagnostics": {
+            "task": "regression",
+            "sample_count": 2,
+            "rmse": 0.1,
+            "direction_classification": {"evaluation_status": "evaluated"},
+        },
         "signals": [
-            {"date": "2024-01-02", "symbol": "2330", "score": 0.01, "position": 1.0},
-            {"date": "2024-01-02", "symbol": "2317", "score": -0.02, "position": -1.0},
+            {
+                "date": "2024-01-02",
+                "symbol": "2330",
+                "score": 0.01,
+                "position": 1.0,
+                "signal_kind": "forward_opinion",
+                "up_probability": 0.8,
+                "predicted_direction": "up",
+            },
+            {
+                "date": "2024-01-02",
+                "symbol": "2317",
+                "score": -0.02,
+                "position": 0.0,
+                "signal_kind": "forward_opinion",
+                "up_probability": 0.2,
+                "predicted_direction": "down",
+            },
         ],
         "validation": {"method": "walk_forward", "metrics": {"rmse": 0.1}},
         "baselines": {"buy_hold": {"total_return": 0.05}},
@@ -125,6 +184,9 @@ def test_opinion_contract_requires_source_artifact_references():
         "symbol": "2330",
         "model_score": 0.01,
         "position_signal": 1.0,
+        "signal_date": "2024-01-02",
+        "up_probability": 0.8,
+        "confirmation_state": "confirmed",
         "evidence_reason": "Latest persisted signal was checked.",
         "risk_or_warning": "Persisted warning was checked.",
         "invalidation_note": "Newer persisted data may supersede this signal.",
@@ -229,38 +291,12 @@ def test_opinion_builder_uses_latest_dated_signal_rows_for_actions_and_checks():
     artifact = build_opinion_artifact(payload)
     checks = {item["check"]: item for item in artifact["review_checks"]}
 
-    assert [row["symbol"] for row in artifact["buy_candidates"]] == ["2330"]
-    assert [row["symbol"] for row in artifact["sell_or_avoid"]] == ["2317"]
-    assert [row["symbol"] for row in artifact["watch"]] == ["2454"]
-    assert all(row["symbol"] != "8888" for row in artifact["buy_candidates"])
-    assert "warning_count=0 and caveat_count=0" in artifact["buy_candidates"][0][
-        "risk_or_warning"
-    ]
-    assert "on 2024-01-04 links" in artifact["buy_candidates"][0]["evidence_reason"]
-    assert "Row signal date: 2024-01-04 for 2330" in artifact["buy_candidates"][0][
-        "invalidation_note"
-    ]
-    assert {
-        (ref["field"], ref.get("symbol"), ref.get("date"))
-        for ref in artifact["buy_candidates"][0]["source_artifact_references"]
-        if ref["artifact"] == "signals" and ref["field"] in {"score", "position"}
-    } == {
-        ("score", "2330", "2024-01-04"),
-        ("position", "2330", "2024-01-04"),
-    }
-    assert checks["signal_to_position"]["result"] == {
-        "checked_symbol_count": 4,
-        "positive_count": 1,
-        "negative_count": 1,
-        "flat_count": 1,
-        "invalid_row_count": 3,
-    }
-    assert checks["parameter_sensitivity"]["result"]["base_candidate_symbols"] == [
-        "2330"
-    ]
-    assert checks["parameter_sensitivity"]["result"]["scenario_candidate_counts"][
-        "top_n_minus_1"
-    ] == 1
+    assert artifact["state"] == "no-opinion"
+    assert artifact["buy_candidates"] == []
+    assert checks["signal_to_position"]["status"] == "fail"
+    assert "holdout evaluation signals are not investment opinions" in " ".join(
+        artifact["evidence_limitations"]
+    )
 
 
 def test_opinion_builder_undeclared_signal_symbol_blocks_viability():
@@ -271,6 +307,9 @@ def test_opinion_builder_undeclared_signal_symbol_blocks_viability():
             "symbol": "2454",
             "score": 0.03,
             "position": 1.0,
+            "signal_kind": "forward_opinion",
+            "up_probability": 0.8,
+            "predicted_direction": "up",
         }
     )
 
@@ -283,36 +322,107 @@ def test_opinion_builder_undeclared_signal_symbol_blocks_viability():
     )
 
 
+@pytest.mark.parametrize(
+    "up_probability",
+    [float("nan"), float("inf"), float("-inf"), -0.01, 1.01],
+)
+def test_opinion_builder_rejects_invalid_persisted_up_probability(up_probability):
+    payload = make_opinion_payload()
+    payload["signals"][0]["up_probability"] = up_probability
+
+    artifact = build_opinion_artifact(payload)
+
+    assert artifact["state"] == "no-opinion"
+    assert artifact["buy_candidates"] == []
+    assert "exactly one valid row" in " ".join(artifact["evidence_limitations"])
+
+
 def test_opinion_builder_parameter_sensitivity_reports_partial_scenario_change():
     payload = make_opinion_payload()
     payload["signals"] = [
-        {"date": "2024-01-02", "symbol": "2330", "score": 0.004, "position": 1.0},
-        {"date": "2024-01-02", "symbol": "2317", "score": 0.003, "position": 1.0},
+        {
+            "date": "2024-01-02", "symbol": "2330", "score": 0.004,
+            "position": 1.0, "signal_kind": "forward_opinion",
+            "up_probability": 0.8, "predicted_direction": "up",
+        },
+        {
+            "date": "2024-01-02", "symbol": "2317", "score": 0.003,
+            "position": 1.0, "signal_kind": "forward_opinion",
+            "up_probability": 0.8, "predicted_direction": "up",
+        },
     ]
 
     checks = {
         item["check"]: item for item in build_opinion_artifact(payload)["review_checks"]
     }
 
-    assert checks["parameter_sensitivity"]["result"]["changed_symbols"] == ["2317"]
+    result = checks["parameter_sensitivity"]["result"]
+    assert result["scenario_candidate_counts"] == {
+        "strict_threshold": 1,
+        "loose_threshold": 2,
+        "top_n_minus_1": 1,
+        "top_n_plus_1": 2,
+    }
+    assert result["changed_symbols"] == ["2317"]
+
+
+def test_opinion_builder_uses_hybrid_action_rules():
+    payload = make_opinion_payload()
+    payload["request_payload"]["symbols"] = ["BUY", "CONFLICT", "SELL", "RANKED_OUT"]
+    payload["signals"] = [
+        {
+            "date": "2024-01-02", "symbol": "BUY", "score": 0.02,
+            "position": 1.0, "signal_kind": "forward_opinion",
+            "up_probability": 0.8, "predicted_direction": "up",
+        },
+        {
+            "date": "2024-01-02", "symbol": "CONFLICT", "score": 0.02,
+            "position": 0.0, "signal_kind": "forward_opinion",
+            "up_probability": 0.2, "predicted_direction": "down",
+        },
+        {
+            "date": "2024-01-02", "symbol": "SELL", "score": -0.01,
+            "position": 0.0, "signal_kind": "forward_opinion",
+            "up_probability": 0.2, "predicted_direction": "down",
+        },
+        {
+            "date": "2024-01-02", "symbol": "RANKED_OUT", "score": 0.01,
+            "position": 0.0, "signal_kind": "forward_opinion",
+            "up_probability": 0.8, "predicted_direction": "up",
+        },
+    ]
+
+    artifact = build_opinion_artifact(payload)
+
+    assert [row["symbol"] for row in artifact["buy_candidates"]] == ["BUY"]
+    assert [row["symbol"] for row in artifact["sell_or_avoid"]] == ["SELL"]
+    assert [row["symbol"] for row in artifact["watch"]] == [
+        "CONFLICT",
+        "RANKED_OUT",
+    ]
 
 
 def test_opinion_builder_keeps_each_symbol_latest_parseable_signal():
     payload = make_opinion_payload()
     payload["signals"] = [
-        {"date": "2024-01-01", "symbol": "2330", "score": 0.01, "position": 1.0},
-        {"date": "2024-01-02", "symbol": "2317", "score": 0.02, "position": 1.0},
+        {
+            "date": "2024-01-01", "symbol": "2330", "score": 0.01,
+            "position": 1.0, "signal_kind": "forward_opinion",
+            "up_probability": 0.8, "predicted_direction": "up",
+        },
+        {
+            "date": "2024-01-02", "symbol": "2317", "score": 0.02,
+            "position": 1.0, "signal_kind": "forward_opinion",
+            "up_probability": 0.8, "predicted_direction": "up",
+        },
     ]
 
     artifact = build_opinion_artifact(payload)
     checks = {item["check"]: item for item in artifact["review_checks"]}
 
-    assert [row["symbol"] for row in artifact["buy_candidates"]] == ["2317", "2330"]
-    assert checks["signal_to_position"]["result"]["checked_symbol_count"] == 2
-    assert checks["parameter_sensitivity"]["result"]["base_candidate_symbols"] == [
-        "2317",
-        "2330",
-    ]
+    assert artifact["state"] == "no-opinion"
+    assert artifact["buy_candidates"] == []
+    assert checks["signal_to_position"]["status"] == "warning"
 
 
 def test_opinion_builder_robustness_does_not_pass_empty_validation_metrics():
@@ -480,6 +590,15 @@ def test_opinion_builder_manual_boundary_allows_broker_metadata_description():
     assert checks["manual_adoption_boundary"]["status"] == "pass"
 
 
+def test_opinion_builder_manual_boundary_allows_research_only_tradability():
+    payload = make_opinion_payload()
+    payload["tradability_state"] = "research_only"
+
+    artifact = build_opinion_artifact(payload)
+
+    assert artifact["state"] == "viable"
+
+
 def test_opinion_builder_manual_boundary_scans_review_check_copy(monkeypatch):
     def fake_parameter_sensitivity(payload):
         return {
@@ -634,6 +753,10 @@ def test_opinion_builder_matches_each_row_against_all_symbol_warnings():
     )
 
     assert artifact["state"] == "viable"
+    assert "reviewable, traceable model output" in artifact["state_reason"]
+    assert "do not establish out-of-sample skill or investment viability" in artifact[
+        "state_reason"
+    ]
     assert check["result"]["concrete_risk_row_count"] == 2
     assert check["result"]["missing_risk_row_count"] == 0
 

--- a/tests/research/test_runs.py
+++ b/tests/research/test_runs.py
@@ -13,6 +13,7 @@ from backend.research.contracts.runs import (
     EffectiveStrategyConfig,
     FallbackAudit,
     Metrics,
+    OpinionArtifact,
     OpinionReviewCheck,
     OpinionRow,
     ResearchRunCreateRequest,
@@ -450,6 +451,33 @@ def _valid_opinion_row() -> dict:
     return deepcopy(
         build_opinion_artifact(make_opinion_payload())["buy_candidates"][0]
     )
+
+
+def test_opinion_artifact_rows_must_match_opinion_as_of():
+    row = _valid_opinion_row()
+    payload = {
+        "state": "viable",
+        "state_reason": "Persisted artifacts support a reviewable opinion.",
+        "buy_candidates": [row],
+    }
+
+    with pytest.raises(ValidationError, match="opinion_as_of"):
+        OpinionArtifact.model_validate(payload)
+    with pytest.raises(ValidationError, match="opinion_as_of"):
+        OpinionArtifact.model_validate({**payload, "opinion_as_of": "2024-01-03"})
+
+    artifact = OpinionArtifact.model_validate(
+        {**payload, "opinion_as_of": row["signal_date"]}
+    )
+    assert artifact.opinion_as_of == artifact.buy_candidates[0].signal_date
+
+    empty_artifact = OpinionArtifact.model_validate(
+        {
+            "state": "no-opinion",
+            "state_reason": "No reviewable rows are available.",
+        }
+    )
+    assert empty_artifact.opinion_as_of is None
 
 
 def _assert_self_review_blocks_viability(artifact: dict, check_name: str) -> None:

--- a/tests/research/test_tradability.py
+++ b/tests/research/test_tradability.py
@@ -234,8 +234,23 @@ def test_build_p3_summary_treats_deterministic_event_as_non_blocking(monkeypatch
     )
 
     assert result["corporate_event_state"] == "clear"
-    assert result["tradability_state"] == "execution_ready"
+    assert result["tradability_state"] == "research_only"
     assert result["execution_universe_count"] == 1
+
+    execution_result = p3_screening_service.build_p3_summary(
+        request=_make_request(
+            symbols=["2330"], execution_route="simulation_internal_v1"
+        ),
+        strategy=ResearchStrategyConfig(
+            type="research_v1",
+            threshold=0.003,
+            top_n=1,
+            allow_proactive_sells=True,
+        ),
+        weights=weights,
+        volume_df=volume_df,
+    )
+    assert execution_result["tradability_state"] == "execution_ready"
 
 
 def test_build_p3_summary_marks_listing_status_change_without_lifecycle_as_unresolved(
@@ -341,7 +356,7 @@ def test_build_p3_summary_resolves_ticker_change_to_successor_symbol(monkeypatch
     )
 
     assert result["corporate_event_state"] == "clear"
-    assert result["tradability_state"] == "execution_ready"
+    assert result["tradability_state"] == "research_only"
     assert result["execution_universe_count"] == 1
     assert result["liquidity_bucket_coverages"][2]["execution_universe_count"] == 1
 
@@ -472,5 +487,5 @@ def test_build_p3_summary_allows_dividend_with_resolved_ticker_change(monkeypatc
     )
 
     assert result["corporate_event_state"] == "clear"
-    assert result["tradability_state"] == "execution_ready"
+    assert result["tradability_state"] == "research_only"
     assert result["execution_universe_count"] == 1

--- a/tests/shared/test_backtest.py
+++ b/tests/shared/test_backtest.py
@@ -1,12 +1,14 @@
 import pandas as pd
 import pytest
 
+from backend.research.contracts.runs import ExecutionConfig, SignalPoint, StrategyConfig
 from backend.shared.analytics.backtest import (
     _build_execution_price,
     build_signals,
     compute_max_position_weight,
     compute_metrics,
     compute_turnover,
+    run_backtest,
 )
 from backend.shared.analytics.strategy import build_weights_from_scores
 
@@ -34,8 +36,9 @@ def test_build_signals_preserves_latest_flat_decision_surface():
         (idx[0].date(), "A", 0.8, 1.0),
         (idx[1].date(), "A", 0.2, 0.0),
         (idx[1].date(), "B", 0.1, 0.0),
-        (idx[1].date(), "C", 0.0, 0.4),
+        (idx[1].date(), "C", None, 0.4),
     ]
+    assert SignalPoint.model_validate(signals[-1]).score is None
 
 
 def test_build_weights_from_scores_proactive():
@@ -95,6 +98,69 @@ def test_build_weights_from_scores_empty():
         allow_proactive_sells=True,
     )
     assert weights.loc[idx[0]].sum() == pytest.approx(0.0)
+
+
+def test_build_weights_from_scores_requires_direction_confirmation():
+    idx = pd.to_datetime(["2024-01-02"])
+    scores = pd.DataFrame(
+        {"A": [0.02], "B": [0.01], "C": [float("inf")], "D": [0.03]},
+        index=idx,
+    )
+    probabilities = pd.DataFrame(
+        {"A": [0.4], "B": [0.8], "C": [0.8], "D": [float("inf")]},
+        index=idx,
+    )
+
+    weights = build_weights_from_scores(
+        scores=scores,
+        threshold=0.005,
+        top_n=2,
+        allow_proactive_sells=True,
+        confirmation_probabilities=probabilities,
+        confirmation_threshold=0.5,
+    )
+
+    assert weights.loc[idx[0], "A"] == 0.0
+    assert weights.loc[idx[0], "B"] == 1.0
+    assert weights.loc[idx[0], "C"] == 0.0
+    assert weights.loc[idx[0], "D"] == 0.0
+
+
+def test_run_backtest_with_unavailable_confirmation_stays_flat_and_finite():
+    idx = pd.to_datetime(["2024-01-02", "2024-01-03"])
+    scores = pd.DataFrame({"A": [0.02, 0.03]}, index=idx)
+    probabilities = pd.DataFrame({"A": [float("nan"), float("nan")]}, index=idx)
+    open_df = pd.DataFrame({"A": [100.0, 101.0]}, index=idx)
+    high_df = pd.DataFrame({"A": [102.0, 103.0]}, index=idx)
+    low_df = pd.DataFrame({"A": [99.0, 100.0]}, index=idx)
+    close_df = pd.DataFrame({"A": [101.0, 102.0]}, index=idx)
+
+    metrics, _, signals, _ = run_backtest(
+        scores=scores,
+        open_df=open_df,
+        high_df=high_df,
+        low_df=low_df,
+        close_df=close_df,
+        strategy=StrategyConfig(
+            type="research_v1",
+            threshold=0.005,
+            top_n=1,
+            allow_proactive_sells=True,
+        ),
+        execution=ExecutionConfig(),
+        market="TW",
+        return_target="open_to_open",
+        confirmation_probabilities=probabilities,
+    )
+
+    assert metrics == {
+        "total_return": 0.0,
+        "sharpe": 0.0,
+        "max_drawdown": 0.0,
+        "turnover": 0.0,
+        "max_position_weight": 0.0,
+    }
+    assert all(signal["position"] == 0.0 for signal in signals)
 
 
 def test_build_execution_price_us_buy():

--- a/tests/shared/test_models.py
+++ b/tests/shared/test_models.py
@@ -1,9 +1,14 @@
 import pandas as pd
 import pytest
 
+import backend.shared.analytics.models as model_service
+
 from backend.shared.analytics.models import (
+    build_classifier,
     compute_return_target,
+    fit_calibrated_direction_classifier,
     prepare_training_data,
+    target_lookahead,
     time_series_split,
 )
 
@@ -52,6 +57,21 @@ def test_compute_return_target_invalid():
         compute_return_target(df, "bad_target", 1)
 
 
+@pytest.mark.parametrize(
+    ("return_target", "horizon_days", "expected"),
+    [
+        ("open_to_open", 5, 5),
+        ("close_to_close", 5, 5),
+        ("open_to_close", 5, 4),
+        ("open_to_close", 1, 0),
+    ],
+)
+def test_target_lookahead_matches_target_window(
+    return_target, horizon_days, expected
+):
+    assert target_lookahead(return_target, horizon_days) == expected
+
+
 def test_time_series_split_basic():
     X = pd.DataFrame({"x": range(10)})
     y = pd.Series(range(10))
@@ -67,6 +87,101 @@ def test_time_series_split_invalid():
     y = pd.Series(range(10))
     with pytest.raises(ValueError):
         time_series_split(X, y, test_size=1.0)
+
+
+def test_time_series_split_purges_overlapping_training_targets():
+    X = pd.DataFrame({"x": range(10)})
+    y = pd.Series(range(10))
+
+    X_train, X_test, y_train, _ = time_series_split(
+        X, y, test_size=0.2, purge=2
+    )
+
+    assert list(X_train.index) == list(range(6))
+    assert list(y_train.index) == list(range(6))
+    assert list(X_test.index) == [8, 9]
+
+
+def test_direction_calibration_uses_chronological_tail_and_purge():
+    X = pd.DataFrame({"x": range(100)})
+    y = pd.Series([0, 1] * 50)
+
+    model, reason, calibration_size = fit_calibrated_direction_classifier(
+        model_type="extra_trees",
+        X_train=X,
+        y_train=y,
+        model_params={"n_estimators": 5},
+        purge=2,
+    )
+
+    train_indices, calibration_indices = model.cv[0]
+    assert reason is None
+    assert calibration_size == 20
+    assert list(train_indices) == list(range(78))
+    assert list(calibration_indices) == list(range(80, 100))
+    assert model.predict_proba(X.tail(1)).shape == (1, 2)
+
+
+@pytest.mark.parametrize("model_type", ["random_forest", "extra_trees"])
+def test_build_classifier_supports_regression_model_families(model_type):
+    model = build_classifier(model_type=model_type, model_params={"n_estimators": 5})
+
+    assert model.get_params()["n_estimators"] == 5
+
+
+def test_build_classifier_supports_xgboost_without_loading_native_runtime(monkeypatch):
+    class _Classifier:
+        def __init__(self, **params):
+            self.params = params
+
+        def get_params(self):
+            return self.params
+
+    monkeypatch.setattr(
+        model_service, "_load_xgboost_classifier", lambda: _Classifier
+    )
+
+    model = build_classifier(model_type="xgboost", model_params={"n_estimators": 5})
+
+    assert model.get_params()["n_estimators"] == 5
+
+
+def test_direction_calibration_requires_both_classes_in_calibration_tail():
+    X = pd.DataFrame({"x": range(100)})
+    y = pd.Series([0, 1] * 40 + [0] * 4 + [1] * 16)
+
+    model, reason, calibration_size = fit_calibrated_direction_classifier(
+        model_type="random_forest",
+        X_train=X,
+        y_train=y,
+        model_params={"n_estimators": 5},
+    )
+
+    assert model is None
+    assert reason == (
+        "Provisional direction model calibration window requires at least 5 rows "
+        "per class (chronological_tail_20pct_min20_class5_v1)."
+    )
+    assert calibration_size == 0
+
+
+def test_direction_calibration_requires_enough_rows_for_provisional_gate():
+    X = pd.DataFrame({"x": range(39)})
+    y = pd.Series([0, 1] * 19 + [0])
+
+    model, reason, calibration_size = fit_calibrated_direction_classifier(
+        model_type="random_forest",
+        X_train=X,
+        y_train=y,
+        model_params={"n_estimators": 5},
+    )
+
+    assert model is None
+    assert reason == (
+        "Insufficient rows for provisional chronological direction calibration "
+        "(chronological_tail_20pct_min20_class5_v1)."
+    )
+    assert calibration_size == 0
 
 
 def test_prepare_training_data_ignores_nullable_metadata_columns():

--- a/tests/shared/test_validation.py
+++ b/tests/shared/test_validation.py
@@ -71,3 +71,24 @@ def test_generate_splits_expanding_window():
 def test_generate_splits_invalid_method():
     with pytest.raises(ValueError):
         generate_splits(length=100, method="bad", splits=1, test_size=0.2)
+
+
+@pytest.mark.parametrize(
+    ("method", "expected_stops"),
+    [
+        ("holdout", [77]),
+        ("walk_forward", [57, 77]),
+        ("expanding_window", [57, 77]),
+        ("rolling_window", [57, 77]),
+    ],
+)
+def test_generate_splits_purges_training_targets(method, expected_stops):
+    splits = generate_splits(
+        length=100, method=method, splits=2, test_size=0.2, purge=3
+    )
+
+    assert [train_range.stop for train_range, _ in splits] == expected_stops
+    assert all(
+        test_range.start - train_range.stop == 3
+        for train_range, test_range in splits
+    )


### PR DESCRIPTION
## Summary
- add calibrated direction confirmation on top of regression ranking
- align purge-safe validation folds across the requested symbol universe and expose explicit unavailable reasons
- reject non-finite main metrics, degrade invalid baselines, and keep research-only runs non-executable

## Validation
- `rtk uv run pytest tests/research/test_execution.py tests/research/test_runs.py tests/research/test_run_repository.py tests/research/test_tradability.py tests/shared/test_validation.py tests/shared/test_backtest.py` (125 passed)
- `git diff --check`

## Notes
- full test suite and browser validation were not run
- pooled direction diagnostics and repeated forward-model training remain documented design tradeoffs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 研究執行新增方向分類模型的校準機率與方向診斷，並將確認機率納入策略權重判定。
  * 回傳結果新增混合式「意見摘要」工件：包含買進、觀察與避開建議，以及確認狀態與來源證據。
  * 審查畫面新增意見內容渲染，並顯示方向確認指標。
* **錯誤修正**
  * 改善無效數值/缺資料時的 fail-closed 與評估狀態呈現。
  * 修正訊號分數缺值顯示為 N/A，並強化回測切分與資料對齊保護。
* **文件**
  * 更新研究規格、驗收條件與目前實作狀態說明。
* **測試**
  * 擴充方向校準、意見工件、相容性與回測情境覆蓋。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->