### PR TITLE
feat: backfill TW market data universe

### DIFF
--- a/backend/market_data/api.py
+++ b/backend/market_data/api.py
@@ -115,7 +115,10 @@ def create_tw_company_crawl(
 ) -> TwCompanyCrawlerRunResponse:
     request = request or TwCompanyCrawlRequest()
     return TwCompanyCrawlerRunResponse(
-        **crawl_tw_company_profiles(include_tpex=request.include_tpex)
+        **crawl_tw_company_profiles(
+            include_tpex=request.include_tpex,
+            reconcile=False,
+        )
     )
 
 

--- a/backend/market_data/contracts/_legacy.py
+++ b/backend/market_data/contracts/_legacy.py
@@ -406,6 +406,7 @@ class TwCompanyCrawlRequest(RequestModel):
 class TwCompanyCrawlerRunResponse(BaseModel):
     market: MarketCode = "TW"
     source_names: list[str] = Field(default_factory=list)
+    source_summaries: list[dict[str, Any]] = Field(default_factory=list)
     raw_payload_ids: list[int] = Field(default_factory=list)
     processed_count: int
     upserted_count: int
@@ -413,6 +414,7 @@ class TwCompanyCrawlerRunResponse(BaseModel):
     updated_count: int = 0
     noop_count: int = 0
     inactivated_count: int = 0
+    reconciliation_requested: bool = True
     reconciliation_skipped: bool = False
     duplicate_symbol_count: int = 0
     conflict_count: int = 0

--- a/backend/market_data/contracts/_legacy.py
+++ b/backend/market_data/contracts/_legacy.py
@@ -413,6 +413,7 @@ class TwCompanyCrawlerRunResponse(BaseModel):
     updated_count: int = 0
     noop_count: int = 0
     inactivated_count: int = 0
+    reconciliation_skipped: bool = False
     duplicate_symbol_count: int = 0
     conflict_count: int = 0
     overwritten_count: int = 0

--- a/backend/market_data/contracts/_legacy.py
+++ b/backend/market_data/contracts/_legacy.py
@@ -412,6 +412,7 @@ class TwCompanyCrawlerRunResponse(BaseModel):
     created_count: int = 0
     updated_count: int = 0
     noop_count: int = 0
+    inactivated_count: int = 0
     duplicate_symbol_count: int = 0
     conflict_count: int = 0
     overwritten_count: int = 0

--- a/backend/market_data/repositories/company_profiles.py
+++ b/backend/market_data/repositories/company_profiles.py
@@ -95,19 +95,32 @@ def upsert_tw_company_profile(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def mark_missing_active_tw_company_profiles_inactive(
-    *, exchange: str, active_symbols: Iterable[str]
+    *,
+    exchange: str,
+    active_symbols: Iterable[str],
+    source_name: str,
+    raw_payload_id: int,
+    archive_object_reference: str,
 ) -> int:
     symbols = {symbol.strip().upper() for symbol in active_symbols if symbol.strip()}
     if not symbols:
         return 0
+    normalized_exchange = exchange.strip().upper()
     try:
         with SessionLocal() as session:
             result = session.execute(
                 update(TwCompanyProfile)
-                .where(TwCompanyProfile.exchange == exchange)
+                .where(TwCompanyProfile.market == "TW")
+                .where(TwCompanyProfile.exchange == normalized_exchange)
                 .where(TwCompanyProfile.trading_status == "active")
                 .where(~TwCompanyProfile.symbol.in_(symbols))
-                .values(trading_status="inactive", updated_at=func.now())
+                .values(
+                    trading_status="inactive",
+                    source_name=source_name,
+                    raw_payload_id=raw_payload_id,
+                    archive_object_reference=archive_object_reference,
+                    updated_at=func.now(),
+                )
             )
             session.commit()
             return int(result.rowcount or 0)

--- a/backend/market_data/repositories/company_profiles.py
+++ b/backend/market_data/repositories/company_profiles.py
@@ -145,16 +145,12 @@ def list_tw_company_profiles(
         raise DataAccessError("Failed to list TW company profiles.") from exc
 
 
-def count_tw_company_profiles(
-    *, trading_status: str | None = None, exchange: str | None = None
-) -> int:
+def count_tw_company_profiles(*, trading_status: str | None = None) -> int:
     try:
         with SessionLocal() as session:
             stmt = select(func.count(TwCompanyProfile.id))
             if trading_status is not None:
                 stmt = stmt.where(TwCompanyProfile.trading_status == trading_status)
-            if exchange is not None:
-                stmt = stmt.where(TwCompanyProfile.exchange == exchange)
             return int(session.execute(stmt).scalar_one() or 0)
     except Exception as exc:
         logger.exception("Failed to count TW company profiles")

--- a/backend/market_data/repositories/company_profiles.py
+++ b/backend/market_data/repositories/company_profiles.py
@@ -145,12 +145,16 @@ def list_tw_company_profiles(
         raise DataAccessError("Failed to list TW company profiles.") from exc
 
 
-def count_tw_company_profiles(*, trading_status: str | None = None) -> int:
+def count_tw_company_profiles(
+    *, trading_status: str | None = None, exchange: str | None = None
+) -> int:
     try:
         with SessionLocal() as session:
             stmt = select(func.count(TwCompanyProfile.id))
             if trading_status is not None:
                 stmt = stmt.where(TwCompanyProfile.trading_status == trading_status)
+            if exchange is not None:
+                stmt = stmt.where(TwCompanyProfile.exchange == exchange)
             return int(session.execute(stmt).scalar_one() or 0)
     except Exception as exc:
         logger.exception("Failed to count TW company profiles")

--- a/backend/market_data/repositories/company_profiles.py
+++ b/backend/market_data/repositories/company_profiles.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from typing import Any
 
-from sqlalchemy import desc, func, select
+from sqlalchemy import desc, func, select, update
 
 from backend.database import SessionLocal, TwCompanyProfile
 from backend.platform.db.repository_helpers import clone_payload, normalize_created_at
@@ -91,6 +92,33 @@ def upsert_tw_company_profile(payload: dict[str, Any]) -> dict[str, Any]:
             record.get("exchange"),
         )
         raise DataAccessError("Failed to persist TW company profile.") from exc
+
+
+def mark_missing_active_tw_company_profiles_inactive(
+    *, exchange: str, active_symbols: Iterable[str]
+) -> int:
+    symbols = {symbol.strip().upper() for symbol in active_symbols if symbol.strip()}
+    if not symbols:
+        return 0
+    try:
+        with SessionLocal() as session:
+            result = session.execute(
+                update(TwCompanyProfile)
+                .where(TwCompanyProfile.exchange == exchange)
+                .where(TwCompanyProfile.trading_status == "active")
+                .where(~TwCompanyProfile.symbol.in_(symbols))
+                .values(trading_status="inactive", updated_at=func.now())
+            )
+            session.commit()
+            return int(result.rowcount or 0)
+    except Exception as exc:
+        logger.exception(
+            "Failed to inactivate missing TW company profiles exchange=%s",
+            exchange,
+        )
+        raise DataAccessError(
+            "Failed to inactivate missing TW company profiles."
+        ) from exc
 
 
 def list_tw_company_profiles(

--- a/backend/market_data/services/company_crawlers.py
+++ b/backend/market_data/services/company_crawlers.py
@@ -140,6 +140,7 @@ def _fetch_company_feed(
         response.raise_for_status()
         payload_body = response.text
     except requests.exceptions.RequestException as exc:
+        error_type = type(exc).__name__
         try:
             persist_raw_ingest_record(
                 source_name=source_name,
@@ -153,7 +154,15 @@ def _fetch_company_feed(
             )
         except DataAccessError:
             logger.warning("Failed to record company crawler fetch failure")
-        raise ExternalFetchError(f"Failed to fetch TW company feed: {exc}") from exc
+        logger.warning(
+            "TW company feed fetch failed source=%s error_type=%s",
+            source_name,
+            error_type,
+        )
+        raise ExternalFetchError(
+            "Failed to fetch TW company feed.",
+            error_type=error_type,
+        ) from None
 
     try:
         payload = json.loads(payload_body)
@@ -323,6 +332,7 @@ def _crawl_single_source(
     source_name: str,
     exchange: str,
     board: str,
+    reconcile: bool = True,
 ) -> dict[str, Any]:
     raw_payload_id, records = _fetch_company_feed(
         url_env=url_env,
@@ -355,7 +365,7 @@ def _crawl_single_source(
         str(record["symbol"]).strip().upper()
         for record in list_active_tw_company_profiles(limit=0)
         if str(record.get("exchange") or "").upper() == exchange
-    } if records else set()
+    } if records and reconcile else set()
     upserted_count = 0
     created_count = 0
     updated_count = 0
@@ -378,11 +388,19 @@ def _crawl_single_source(
                 f"exchange={payload['exchange']} symbol={payload['symbol']}: {exc}"
             )
     inactivated_count = 0
-    reconciliation_skipped = True
-    if records and not errors:
+    reconciliation_skipped = False
+    if reconcile:
+        reconciliation_skipped = True
+    if reconcile and not records:
+        errors.append(
+            f"exchange={exchange} raw_payload_id={raw_payload_id} "
+            "reconciliation skipped: company feed is empty."
+        )
+    elif reconcile and not errors:
+        covered_symbol_count = len(active_symbols & existing_active_symbols)
         if (
             existing_active_symbols
-            and len(active_symbols & existing_active_symbols)
+            and covered_symbol_count
             < len(existing_active_symbols) * _RECONCILIATION_MINIMUM_COVERAGE_RATIO
         ):
             logger.warning(
@@ -390,19 +408,29 @@ def _crawl_single_source(
                 "exchange=%s existing_active_symbol_count=%s covered_symbol_count=%s",
                 exchange,
                 len(existing_active_symbols),
-                len(active_symbols & existing_active_symbols),
+                covered_symbol_count,
+            )
+            errors.append(
+                f"exchange={exchange} raw_payload_id={raw_payload_id} "
+                "reconciliation skipped: "
+                f"covered_symbol_count={covered_symbol_count} "
+                f"existing_active_symbol_count={len(existing_active_symbols)}."
             )
         else:
             try:
                 inactivated_count = mark_missing_active_tw_company_profiles_inactive(
                     exchange=exchange,
                     active_symbols=active_symbols,
+                    source_name=source_name,
+                    raw_payload_id=raw_payload_id,
+                    archive_object_reference=archive_reference,
                 )
                 reconciliation_skipped = False
             except Exception as exc:
                 errors.append(f"exchange={exchange} reconciliation: {exc}")
     return {
         "source_name": source_name,
+        "exchange": exchange,
         "raw_payload_id": raw_payload_id,
         "processed_count": len(records),
         "upserted_count": upserted_count,
@@ -410,6 +438,7 @@ def _crawl_single_source(
         "updated_count": updated_count,
         "noop_count": noop_count,
         "inactivated_count": inactivated_count,
+        "reconciliation_requested": reconcile,
         "reconciliation_skipped": reconciliation_skipped,
         "duplicate_symbol_count": dedupe_summary["duplicate_symbol_count"],
         "conflict_count": dedupe_summary["conflict_count"],
@@ -418,7 +447,9 @@ def _crawl_single_source(
     }
 
 
-def crawl_tw_company_profiles(*, include_tpex: bool = True) -> dict[str, Any]:
+def crawl_tw_company_profiles(
+    *, include_tpex: bool = True, reconcile: bool = True
+) -> dict[str, Any]:
     summaries = [
         _crawl_single_source(
             url_env=TWSE_COMPANY_SOURCE_URL_ENV,
@@ -426,6 +457,7 @@ def crawl_tw_company_profiles(*, include_tpex: bool = True) -> dict[str, Any]:
             source_name=TWSE_COMPANY_SOURCE_NAME,
             exchange="TWSE",
             board="listed",
+            reconcile=reconcile,
         )
     ]
     if include_tpex:
@@ -436,12 +468,14 @@ def crawl_tw_company_profiles(*, include_tpex: bool = True) -> dict[str, Any]:
                 source_name=TPEX_COMPANY_SOURCE_NAME,
                 exchange="TPEX",
                 board="otc",
+                reconcile=reconcile,
             )
         )
 
     return {
         "market": "TW",
         "source_names": [item["source_name"] for item in summaries],
+        "source_summaries": summaries,
         "raw_payload_ids": [item["raw_payload_id"] for item in summaries],
         "processed_count": sum(item["processed_count"] for item in summaries),
         "upserted_count": sum(item["upserted_count"] for item in summaries),
@@ -449,6 +483,7 @@ def crawl_tw_company_profiles(*, include_tpex: bool = True) -> dict[str, Any]:
         "updated_count": sum(item["updated_count"] for item in summaries),
         "noop_count": sum(item["noop_count"] for item in summaries),
         "inactivated_count": sum(item["inactivated_count"] for item in summaries),
+        "reconciliation_requested": reconcile,
         "reconciliation_skipped": any(
             item["reconciliation_skipped"] for item in summaries
         ),

--- a/backend/market_data/services/company_crawlers.py
+++ b/backend/market_data/services/company_crawlers.py
@@ -8,6 +8,9 @@ from typing import Any
 
 import requests
 
+from backend.market_data.repositories.company_profiles import (
+    mark_missing_active_tw_company_profiles_inactive,
+)
 from backend.market_data.repositories.raw_ingest import (
     FETCH_STATUS_FAILED,
     FETCH_STATUS_SUCCESS,
@@ -350,9 +353,11 @@ def _crawl_single_source(
     created_count = 0
     updated_count = 0
     noop_count = 0
+    active_symbols: set[str] = set()
     for payload in deduped_profiles:
         try:
             saved = save_tw_company_profile(payload)
+            active_symbols.add(saved["symbol"])
             upserted_count += 1
             write_action = saved.get("write_action")
             if write_action == "created":
@@ -365,6 +370,15 @@ def _crawl_single_source(
             errors.append(
                 f"exchange={payload['exchange']} symbol={payload['symbol']}: {exc}"
             )
+    inactivated_count = 0
+    if records and not errors:
+        try:
+            inactivated_count = mark_missing_active_tw_company_profiles_inactive(
+                exchange=exchange,
+                active_symbols=active_symbols,
+            )
+        except Exception as exc:
+            errors.append(f"exchange={exchange} reconciliation: {exc}")
     return {
         "source_name": source_name,
         "raw_payload_id": raw_payload_id,
@@ -373,6 +387,7 @@ def _crawl_single_source(
         "created_count": created_count,
         "updated_count": updated_count,
         "noop_count": noop_count,
+        "inactivated_count": inactivated_count,
         "duplicate_symbol_count": dedupe_summary["duplicate_symbol_count"],
         "conflict_count": dedupe_summary["conflict_count"],
         "overwritten_count": dedupe_summary["overwritten_count"],
@@ -410,6 +425,7 @@ def crawl_tw_company_profiles(*, include_tpex: bool = True) -> dict[str, Any]:
         "created_count": sum(item["created_count"] for item in summaries),
         "updated_count": sum(item["updated_count"] for item in summaries),
         "noop_count": sum(item["noop_count"] for item in summaries),
+        "inactivated_count": sum(item["inactivated_count"] for item in summaries),
         "duplicate_symbol_count": sum(
             item["duplicate_symbol_count"] for item in summaries
         ),

--- a/backend/market_data/services/company_crawlers.py
+++ b/backend/market_data/services/company_crawlers.py
@@ -40,6 +40,7 @@ TWSE_COMPANY_SOURCE_NAME = "twse_company_profile"
 TPEX_COMPANY_SOURCE_NAME = "tpex_company_profile"
 TW_COMPANY_PARSER_VERSION = "tw_company_profile_v1"
 TW_COMPANY_SYMBOL = "TW_COMPANY_UNIVERSE"
+_RECONCILIATION_MINIMUM_COVERAGE_RATIO = 0.95
 _PAYLOAD_RECORD_KEYS = ("records", "data", "items", "result", "results", "response")
 
 
@@ -349,6 +350,9 @@ def _crawl_single_source(
             )
             errors.append(f"exchange={exchange} symbol={symbol}: {exc}")
     deduped_profiles, dedupe_summary = _dedupe_profile_payloads(built_profiles)
+    existing_active_count = (
+        count_active_tw_company_profiles(exchange=exchange) if records else 0
+    )
     upserted_count = 0
     created_count = 0
     updated_count = 0
@@ -372,13 +376,26 @@ def _crawl_single_source(
             )
     inactivated_count = 0
     if records and not errors:
-        try:
-            inactivated_count = mark_missing_active_tw_company_profiles_inactive(
-                exchange=exchange,
-                active_symbols=active_symbols,
+        if (
+            existing_active_count
+            and len(active_symbols)
+            < existing_active_count * _RECONCILIATION_MINIMUM_COVERAGE_RATIO
+        ):
+            logger.warning(
+                "Skipped TW company profile reconciliation due to low coverage "
+                "exchange=%s active_symbols=%s existing_active_count=%s",
+                exchange,
+                len(active_symbols),
+                existing_active_count,
             )
-        except Exception as exc:
-            errors.append(f"exchange={exchange} reconciliation: {exc}")
+        else:
+            try:
+                inactivated_count = mark_missing_active_tw_company_profiles_inactive(
+                    exchange=exchange,
+                    active_symbols=active_symbols,
+                )
+            except Exception as exc:
+                errors.append(f"exchange={exchange} reconciliation: {exc}")
     return {
         "source_name": source_name,
         "raw_payload_id": raw_payload_id,

--- a/backend/market_data/services/company_crawlers.py
+++ b/backend/market_data/services/company_crawlers.py
@@ -18,6 +18,7 @@ from backend.market_data.repositories.raw_ingest import (
 )
 from backend.market_data.services.company_profiles import (
     count_active_tw_company_profiles,
+    list_active_tw_company_profiles,
     save_tw_company_profile,
 )
 from backend.market_data.services.tls_helpers import request_with_tls_fallback
@@ -350,9 +351,11 @@ def _crawl_single_source(
             )
             errors.append(f"exchange={exchange} symbol={symbol}: {exc}")
     deduped_profiles, dedupe_summary = _dedupe_profile_payloads(built_profiles)
-    existing_active_count = (
-        count_active_tw_company_profiles(exchange=exchange) if records else 0
-    )
+    existing_active_symbols = {
+        str(record["symbol"]).strip().upper()
+        for record in list_active_tw_company_profiles(limit=0)
+        if str(record.get("exchange") or "").upper() == exchange
+    } if records else set()
     upserted_count = 0
     created_count = 0
     updated_count = 0
@@ -375,18 +378,19 @@ def _crawl_single_source(
                 f"exchange={payload['exchange']} symbol={payload['symbol']}: {exc}"
             )
     inactivated_count = 0
+    reconciliation_skipped = True
     if records and not errors:
         if (
-            existing_active_count
-            and len(active_symbols)
-            < existing_active_count * _RECONCILIATION_MINIMUM_COVERAGE_RATIO
+            existing_active_symbols
+            and len(active_symbols & existing_active_symbols)
+            < len(existing_active_symbols) * _RECONCILIATION_MINIMUM_COVERAGE_RATIO
         ):
             logger.warning(
                 "Skipped TW company profile reconciliation due to low coverage "
-                "exchange=%s active_symbols=%s existing_active_count=%s",
+                "exchange=%s existing_active_symbol_count=%s covered_symbol_count=%s",
                 exchange,
-                len(active_symbols),
-                existing_active_count,
+                len(existing_active_symbols),
+                len(active_symbols & existing_active_symbols),
             )
         else:
             try:
@@ -394,6 +398,7 @@ def _crawl_single_source(
                     exchange=exchange,
                     active_symbols=active_symbols,
                 )
+                reconciliation_skipped = False
             except Exception as exc:
                 errors.append(f"exchange={exchange} reconciliation: {exc}")
     return {
@@ -405,6 +410,7 @@ def _crawl_single_source(
         "updated_count": updated_count,
         "noop_count": noop_count,
         "inactivated_count": inactivated_count,
+        "reconciliation_skipped": reconciliation_skipped,
         "duplicate_symbol_count": dedupe_summary["duplicate_symbol_count"],
         "conflict_count": dedupe_summary["conflict_count"],
         "overwritten_count": dedupe_summary["overwritten_count"],
@@ -443,6 +449,9 @@ def crawl_tw_company_profiles(*, include_tpex: bool = True) -> dict[str, Any]:
         "updated_count": sum(item["updated_count"] for item in summaries),
         "noop_count": sum(item["noop_count"] for item in summaries),
         "inactivated_count": sum(item["inactivated_count"] for item in summaries),
+        "reconciliation_skipped": any(
+            item["reconciliation_skipped"] for item in summaries
+        ),
         "duplicate_symbol_count": sum(
             item["duplicate_symbol_count"] for item in summaries
         ),

--- a/backend/market_data/services/company_profiles.py
+++ b/backend/market_data/services/company_profiles.py
@@ -52,9 +52,7 @@ def list_active_tw_company_profiles(*, limit: int = 500, offset: int = 0) -> lis
     return records
 
 
-def count_active_tw_company_profiles(*, exchange: str | None = None) -> int:
-    total = count_tw_company_profiles(trading_status="active", exchange=exchange)
-    logger.info(
-        "Counted active TW company profiles total=%s exchange=%s", total, exchange
-    )
+def count_active_tw_company_profiles() -> int:
+    total = count_tw_company_profiles(trading_status="active")
+    logger.info("Counted active TW company profiles total=%s", total)
     return total

--- a/backend/market_data/services/company_profiles.py
+++ b/backend/market_data/services/company_profiles.py
@@ -52,7 +52,9 @@ def list_active_tw_company_profiles(*, limit: int = 500, offset: int = 0) -> lis
     return records
 
 
-def count_active_tw_company_profiles() -> int:
-    total = count_tw_company_profiles(trading_status="active")
-    logger.info("Counted active TW company profiles total=%s", total)
+def count_active_tw_company_profiles(*, exchange: str | None = None) -> int:
+    total = count_tw_company_profiles(trading_status="active", exchange=exchange)
+    logger.info(
+        "Counted active TW company profiles total=%s exchange=%s", total, exchange
+    )
     return total

--- a/backend/market_data/services/ingestion.py
+++ b/backend/market_data/services/ingestion.py
@@ -10,6 +10,13 @@ from scripts import market_data_ingestion as scraper
 
 logger = logging.getLogger(__name__)
 
+BATCH_STATUS_SUCCEEDED = scraper.BATCH_STATUS_SUCCEEDED
+BATCH_STATUS_PARTIAL = scraper.BATCH_STATUS_PARTIAL
+BATCH_STATUS_FAILED = scraper.BATCH_STATUS_FAILED
+BATCH_STATUS_SKIPPED_NON_TRADING_DAY = (
+    scraper.BATCH_STATUS_SKIPPED_NON_TRADING_DAY
+)
+
 
 def ingest_tw_market_batch(
     *,

--- a/backend/market_data/services/official_crawlers.py
+++ b/backend/market_data/services/official_crawlers.py
@@ -71,6 +71,7 @@ def _fetch_official_feed(
         response.raise_for_status()
         payload_body = response.text
     except requests.exceptions.RequestException as exc:
+        error_type = type(exc).__name__
         try:
             persist_raw_ingest_record(
                 source_name=source_name,
@@ -86,7 +87,15 @@ def _fetch_official_feed(
             logger.warning(
                 "Failed to record crawler fetch failure source=%s", source_name
             )
-        raise ExternalFetchError(f"Failed to fetch official feed: {exc}") from exc
+        logger.warning(
+            "Official feed fetch failed source=%s error_type=%s",
+            source_name,
+            error_type,
+        )
+        raise ExternalFetchError(
+            "Failed to fetch official feed.",
+            error_type=error_type,
+        ) from None
 
     try:
         payload = json.loads(payload_body)

--- a/backend/market_data/services/tick_archive_provider.py
+++ b/backend/market_data/services/tick_archive_provider.py
@@ -192,7 +192,8 @@ def fetch_twse_public_snapshot(
             verify=verify,
         )
         response.raise_for_status()
-    except requests.exceptions.SSLError:
+    except requests.exceptions.SSLError as exc:
+        error_type = type(exc).__name__
         response = None
         if _ca_auto_download_enabled():
             try:
@@ -203,15 +204,21 @@ def fetch_twse_public_snapshot(
                     verify=downloaded_verify,
                 )
                 response.raise_for_status()
-            except requests.RequestException:
-                logger.exception(
-                    "Failed to fetch TWSE public snapshot after CA download symbol_count=%s",
+            except requests.RequestException as exc:
+                error_type = type(exc).__name__
+                logger.error(
+                    "Failed to fetch TWSE public snapshot after CA download "
+                    "symbol_count=%s error_type=%s",
                     len(symbols),
+                    error_type,
                 )
-            except Exception:
-                logger.exception(
-                    "Failed to download TWSE MIS CA bundle symbol_count=%s",
+            except Exception as exc:
+                error_type = type(exc).__name__
+                logger.error(
+                    "Failed to download TWSE MIS CA bundle "
+                    "symbol_count=%s error_type=%s",
                     len(symbols),
+                    error_type,
                 )
 
         if response is None and _insecure_tls_fallback_enabled():
@@ -227,27 +234,44 @@ def fetch_twse_public_snapshot(
                 )
                 response.raise_for_status()
             except requests.RequestException as exc:
-                logger.exception(
-                    "Failed to fetch TWSE public snapshot with insecure fallback symbol_count=%s",
+                error_type = type(exc).__name__
+                logger.error(
+                    "Failed to fetch TWSE public snapshot with insecure fallback "
+                    "symbol_count=%s error_type=%s",
                     len(symbols),
+                    error_type,
                 )
                 raise ExternalFetchError(
-                    "Failed to fetch TWSE public snapshot."
-                ) from exc
+                    "Failed to fetch TWSE public snapshot.",
+                    error_type=error_type,
+                ) from None
 
         if response is None:
-            logger.exception(
-                "TWSE public snapshot TLS verification failed symbol_count=%s auto_download=%s insecure_fallback=%s",
+            logger.error(
+                "TWSE public snapshot TLS verification failed "
+                "symbol_count=%s auto_download=%s insecure_fallback=%s "
+                "error_type=%s",
                 len(symbols),
                 _ca_auto_download_enabled(),
                 _insecure_tls_fallback_enabled(),
+                error_type,
             )
-            raise ExternalFetchError("Failed to fetch TWSE public snapshot.") from None
+            raise ExternalFetchError(
+                "Failed to fetch TWSE public snapshot.",
+                error_type=error_type,
+            ) from None
     except requests.RequestException as exc:
-        logger.exception(
-            "Failed to fetch TWSE public snapshot symbol_count=%s", len(symbols)
+        error_type = type(exc).__name__
+        logger.error(
+            "Failed to fetch TWSE public snapshot "
+            "symbol_count=%s error_type=%s",
+            len(symbols),
+            error_type,
         )
-        raise ExternalFetchError("Failed to fetch TWSE public snapshot.") from exc
+        raise ExternalFetchError(
+            "Failed to fetch TWSE public snapshot.",
+            error_type=error_type,
+        ) from None
 
     payload_body = response.text
     observations = parse_snapshot_payload(

--- a/backend/market_data/services/tick_archive_provider.py
+++ b/backend/market_data/services/tick_archive_provider.py
@@ -206,6 +206,7 @@ def fetch_twse_public_snapshot(
                 response.raise_for_status()
             except requests.RequestException as exc:
                 error_type = type(exc).__name__
+                response = None
                 logger.error(
                     "Failed to fetch TWSE public snapshot after CA download "
                     "symbol_count=%s error_type=%s",

--- a/backend/market_data/services/tls_helpers.py
+++ b/backend/market_data/services/tls_helpers.py
@@ -164,24 +164,23 @@ def request_with_tls_fallback(
                     timeout_seconds=timeout_seconds,
                     verify=downloaded_verify,
                 )
-            except requests.RequestException:
-                logger.exception(
-                    "Failed %s after CA download url=%s",
+            except requests.RequestException as exc:
+                logger.error(
+                    "Failed %s after CA download error_type=%s",
                     context_label,
-                    url,
+                    type(exc).__name__,
                 )
-            except Exception:
-                logger.exception(
-                    "Failed to download CA bundle for %s url=%s",
+            except Exception as exc:
+                logger.error(
+                    "Failed to download CA bundle for %s error_type=%s",
                     context_label,
-                    url,
+                    type(exc).__name__,
                 )
 
         if response is None and insecure_tls_fallback_enabled():
             logger.warning(
-                "Retrying %s without TLS verification url=%s",
+                "Retrying %s without TLS verification",
                 context_label,
-                url,
             )
             response = perform_tls_request(
                 method=method,

--- a/backend/platform/errors.py
+++ b/backend/platform/errors.py
@@ -17,6 +17,10 @@ class UnsupportedConfigurationError(BacktestError):
 class ExternalFetchError(BacktestError):
     status_code = 502
 
+    def __init__(self, message: str, *, error_type: str | None = None) -> None:
+        super().__init__(message)
+        self.error_type = error_type or type(self).__name__
+
 
 class DataAccessError(Exception):
     pass

--- a/docs/decision-register.md
+++ b/docs/decision-register.md
@@ -49,6 +49,7 @@ stable across multiple implementation tasks.
 | `DEC-PHASE-008` | Prospective opinions use regression ranking plus calibrated direction confirmation | accepted | Holdout signals remain evaluation-only; a viable opinion requires a complete common-date forward snapshot and manual adoption review |
 | `DEC-PHASE-009` | Retain the existing hybrid review UI while Phase 2 remains backend-first | accepted | The current Opinion, direction-diagnostic, workflow-payload, and frontend type integration stays in place, but no further frontend feature or browser-acceptance work is part of the active backend phase |
 | `DEC-PHASE-010` | Current direction diagnostics are pooled across symbols | accepted | Pooled holdout metrics and summed calibration samples are research-level diagnostics, not per-symbol skill claims; per-symbol diagnostics and training-cost optimization remain deferred pending evidence |
+| `DEC-PHASE-011` | Official TWSE/TPEX profile-filled and reconciled `tw_company_profiles` is the canonical current-active universe for broad daily batches; `ingestion_watchlist` remains explicitly heavier per-symbol scheduling | accepted | Broad daily batch ingestion uses the current-active profile universe; per-symbol scheduling uses `ingestion_watchlist`; this decision does not claim a historical point-in-time or delisted universe |
 
 ## Open V1 Decisions
 

--- a/docs/decision-register.md
+++ b/docs/decision-register.md
@@ -50,6 +50,8 @@ stable across multiple implementation tasks.
 | `DEC-PHASE-009` | Retain the existing hybrid review UI while Phase 2 remains backend-first | accepted | The current Opinion, direction-diagnostic, workflow-payload, and frontend type integration stays in place, but no further frontend feature or browser-acceptance work is part of the active backend phase |
 | `DEC-PHASE-010` | Current direction diagnostics are pooled across symbols | accepted | Pooled holdout metrics and summed calibration samples are research-level diagnostics, not per-symbol skill claims; per-symbol diagnostics and training-cost optimization remain deferred pending evidence |
 | `DEC-PHASE-011` | Official TWSE/TPEX profile-filled and reconciled `tw_company_profiles` is the canonical current-active universe for broad daily batches; `ingestion_watchlist` remains explicitly heavier per-symbol scheduling | accepted | Broad daily batch ingestion uses the current-active profile universe; per-symbol scheduling uses `ingestion_watchlist`; this decision does not claim a historical point-in-time or delisted universe |
+| `DEC-PHASE-012` | TW daily batch no-data detection fails closed on ambiguous provider payloads | accepted | A date is skipped only when both TWSE and TPEX explicitly declare no data; empty or malformed table containers remain ingestion failures until an authoritative provider contract proves otherwise |
+| `DEC-PHASE-013` | Company-profile reconciliation remains an internal ingestion operation until an authenticated API boundary exists | accepted | Local scripts and internal ingestion may reconcile the active universe; the unauthenticated company-crawl HTTP endpoint may fetch and upsert profiles but must not mark missing profiles inactive |
 
 ## Open V1 Decisions
 

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -129,7 +129,9 @@ Backfill a weekday date range with bounded universe refresh retries:
 ```
 
 Range runs emit one progress JSON object per attempted date to stderr and one
-final aggregate JSON object to stdout. The aggregate field
+final aggregate JSON object to stdout. `--delay-seconds` defaults to `1.0` and
+controls the pause between attempted dates; adjust it when throttling long
+range backfills. The aggregate field
 `universe_refresh_succeeded` is `true` only after a confirmed refresh, `false`
 after an attempted refresh without confirmed success, and `null` when the range
 runner did not attempt its bounded refresh.

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -119,6 +119,21 @@ Run TW market daily batch ingestion when a broader local dataset is needed:
 .venv/bin/python -m scripts.crawl_tw_daily_batch 2026-03-20 --refresh-universe
 ```
 
+Backfill a weekday date range with bounded universe refresh retries:
+
+```bash
+.venv/bin/python -m scripts.crawl_tw_daily_batch \
+  --start-date 2023-01-01 \
+  --end-date 2025-12-31 \
+  --refresh-universe
+```
+
+Range runs emit one progress JSON object per attempted date to stderr and one
+final aggregate JSON object to stdout. The aggregate field
+`universe_refresh_succeeded` is `true` only after a confirmed refresh, `false`
+after an attempted refresh without confirmed success, and `null` when the range
+runner did not attempt its bounded refresh.
+
 ## V1 Usable-Loop Verification
 
 The core manual path is:

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -15,7 +15,7 @@ in the v1 product navigation.
 
 ## Status Scope
 
-- status date: `2026-07-22`
+- status date: `2026-07-27`
 - status terms:
   - `implemented`: behavior exists and is usable in the current codebase
   - `partial`: meaningful foundation exists, but the v1 product expectation is
@@ -116,6 +116,14 @@ unless `docs/plan.md` explicitly promotes them into a v1 milestone.
   workflows exist
 - raw payload preservation exists through raw ingest audit records
 - data repair and operational panels exist under secondary data surfaces
+- migration `0008` is current; the reconciled current-active profile universe
+  contains `1,983` symbols (`TWSE 1,092`, `TPEX 891`)
+- verified TW daily range `2023-07-24..2026-07-24` contains `1,349,401` rows
+  across `1,983` symbols; raw traceability, duplicate groups, and invalid or
+  null normalized OHLCV checks are clean
+- date reconciliation recorded `785` attempted dates, `729` final successes,
+  `56` explicit skips, and `0` unresolved dates; six transient TPEX transfer
+  failures were retry-resolved
 
 ### Hidden Advanced Foundations
 
@@ -168,6 +176,20 @@ These foundations are implementation inventory, not v1 product scope.
   decision
 
 ## Latest Local Verification
+
+- authoritative data-readiness verification (`2026-07-27`):
+  - migration `0008` is current
+  - current-active profiles: `1,983` (`TWSE 1,092`, `TPEX 891`)
+  - TW daily range `2023-07-24..2026-07-24`: `1,349,401` rows across `1,983`
+    symbols
+  - date reconciliation: `785` attempted, `729` final-success, `56`
+    explicit-skip, `0` unresolved; six transient TPEX transfers were
+    retry-resolved
+  - raw traceability, duplicate groups, and invalid normalized OHLCV checks:
+    clean
+  - caveats: current-active survivorship; `891` TPEX profiles have null
+    `listing_date`; this is not a complete daily-coverage, total-return, or
+    model-viability claim
 
 - usable-loop verification:
   - `main` was synced to `origin/main` at `5b042e0`

--- a/scripts/crawl_tw_daily_batch.py
+++ b/scripts/crawl_tw_daily_batch.py
@@ -86,13 +86,17 @@ def main() -> int:
         "upserted_rows": 0,
         "errors": [],
     }
+    refresh_attempts_left = 3 if args.refresh_universe else 0
     for index, trading_date in enumerate(trading_dates):
         trading_date_text = trading_date.isoformat()
         aggregate["attempted_dates"].append(trading_date_text)
+        should_refresh = refresh_attempts_left > 0
+        if should_refresh:
+            refresh_attempts_left -= 1
         try:
             summary = ingest_tw_market_batch(
                 trading_date=trading_date,
-                refresh_universe=args.refresh_universe and index == 0,
+                refresh_universe=should_refresh,
             )
         except Exception as exc:
             aggregate["failed_dates"].append(trading_date_text)
@@ -106,6 +110,12 @@ def main() -> int:
             if index + 1 < len(trading_dates):
                 time.sleep(args.delay_seconds)
             continue
+        if should_refresh and not any(
+            isinstance(error, dict)
+            and error.get("source_name") == "universe_refresh"
+            for error in summary["errors"]
+        ):
+            refresh_attempts_left = 0
         aggregate["upserted_rows"] += int(summary["upserted_rows"])
         if summary.get("status") == "skipped_non_trading_day":
             aggregate["skipped_non_trading_dates"].append(trading_date_text)

--- a/scripts/crawl_tw_daily_batch.py
+++ b/scripts/crawl_tw_daily_batch.py
@@ -3,16 +3,47 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import sys
 import time
 from datetime import date, datetime, timedelta
 from zoneinfo import ZoneInfo
 
-from backend.market_data.services.ingestion import ingest_tw_market_batch
+from backend.market_data.services.ingestion import (
+    BATCH_STATUS_FAILED,
+    BATCH_STATUS_SKIPPED_NON_TRADING_DAY,
+    BATCH_STATUS_SUCCEEDED,
+    ingest_tw_market_batch,
+)
 
 _TW_TZ = ZoneInfo("Asia/Taipei")
 
 
-def _parse_trading_date(value: str | None) -> date:
+def _print_progress(
+    *,
+    trading_date: str,
+    status: str,
+    upserted_rows: int,
+    error_count: int,
+) -> None:
+    print(
+        json.dumps(
+            {
+                "event": "tw_market_batch_progress",
+                "trading_date": trading_date,
+                "status": status,
+                "upserted_rows": upserted_rows,
+                "error_count": error_count,
+            },
+            ensure_ascii=True,
+        ),
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+def _parse_trading_date(
+    value: str | None, *, argument_name: str = "INGEST_DATE"
+) -> date:
     if not value:
         return datetime.now(_TW_TZ).date()
     normalized = value.strip()
@@ -24,7 +55,7 @@ def _parse_trading_date(value: str | None) -> date:
             return parser(normalized)
         except ValueError:
             continue
-    raise ValueError("INGEST_DATE must be YYYY-MM-DD or YYYYMMDD.")
+    raise ValueError(f"{argument_name} must be YYYY-MM-DD or YYYYMMDD.")
 
 
 def main() -> int:
@@ -61,8 +92,10 @@ def main() -> int:
         return 1 if summary["errors"] else 0
 
     try:
-        start_date = _parse_trading_date(args.start_date)
-        end_date = _parse_trading_date(args.end_date)
+        start_date = _parse_trading_date(
+            args.start_date, argument_name="--start-date"
+        )
+        end_date = _parse_trading_date(args.end_date, argument_name="--end-date")
     except ValueError as exc:
         parser.error(str(exc))
     if start_date > end_date:
@@ -84,6 +117,7 @@ def main() -> int:
         "skipped_non_trading_dates": [],
         "failed_dates": [],
         "upserted_rows": 0,
+        "universe_refresh_succeeded": None,
         "errors": [],
     }
     refresh_attempts_left = 3 if args.refresh_universe else 0
@@ -93,11 +127,23 @@ def main() -> int:
         should_refresh = refresh_attempts_left > 0
         if should_refresh:
             refresh_attempts_left -= 1
+            aggregate["universe_refresh_succeeded"] = False
+        summary_upserted_rows = 0
         try:
             summary = ingest_tw_market_batch(
                 trading_date=trading_date,
                 refresh_universe=should_refresh,
             )
+            summary_upserted_rows = int(summary["upserted_rows"])
+            aggregate["upserted_rows"] += summary_upserted_rows
+            summary_errors = summary["errors"]
+            if not isinstance(summary_errors, list):
+                raise TypeError("Batch summary errors must be a list.")
+            summary_status = summary["status"]
+            dated_errors = [
+                {"trading_date": trading_date_text, **error}
+                for error in summary_errors
+            ]
         except Exception as exc:
             aggregate["failed_dates"].append(trading_date_text)
             aggregate["errors"].append(
@@ -107,26 +153,51 @@ def main() -> int:
                     "message": str(exc) or "Batch ingestion failed.",
                 }
             )
+            _print_progress(
+                trading_date=trading_date_text,
+                status=BATCH_STATUS_FAILED,
+                upserted_rows=summary_upserted_rows,
+                error_count=1,
+            )
             if index + 1 < len(trading_dates):
                 time.sleep(args.delay_seconds)
             continue
-        if should_refresh and not any(
-            isinstance(error, dict)
-            and error.get("source_name") == "universe_refresh"
-            for error in summary["errors"]
-        ):
-            refresh_attempts_left = 0
-        aggregate["upserted_rows"] += int(summary["upserted_rows"])
-        if summary.get("status") == "skipped_non_trading_day":
-            aggregate["skipped_non_trading_dates"].append(trading_date_text)
-        elif summary["errors"]:
-            aggregate["failed_dates"].append(trading_date_text)
-            aggregate["errors"].extend(
-                {"trading_date": trading_date_text, **error}
-                for error in summary["errors"]
+        if should_refresh:
+            refresh_failed = any(
+                isinstance(error, dict)
+                and error.get("source_name") == "universe_refresh"
+                for error in summary_errors
             )
-        else:
+            if not refresh_failed:
+                aggregate["universe_refresh_succeeded"] = True
+                refresh_attempts_left = 0
+        if summary_errors:
+            aggregate["failed_dates"].append(trading_date_text)
+            aggregate["errors"].extend(dated_errors)
+            progress_status = BATCH_STATUS_FAILED
+        elif summary_status == BATCH_STATUS_SKIPPED_NON_TRADING_DAY:
+            aggregate["skipped_non_trading_dates"].append(trading_date_text)
+            progress_status = BATCH_STATUS_SKIPPED_NON_TRADING_DAY
+        elif summary_status == BATCH_STATUS_SUCCEEDED:
             aggregate["succeeded_dates"].append(trading_date_text)
+            progress_status = BATCH_STATUS_SUCCEEDED
+        else:
+            aggregate["failed_dates"].append(trading_date_text)
+            progress_status = BATCH_STATUS_FAILED
+            dated_errors = [
+                {
+                    "trading_date": trading_date_text,
+                    "source_name": "batch",
+                    "message": f"Batch ingestion status={summary_status}.",
+                }
+            ]
+            aggregate["errors"].extend(dated_errors)
+        _print_progress(
+            trading_date=trading_date_text,
+            status=progress_status,
+            upserted_rows=summary_upserted_rows,
+            error_count=len(dated_errors),
+        )
         if index + 1 < len(trading_dates):
             time.sleep(args.delay_seconds)
 

--- a/scripts/crawl_tw_daily_batch.py
+++ b/scripts/crawl_tw_daily_batch.py
@@ -150,7 +150,8 @@ def main() -> int:
                 {
                     "trading_date": trading_date_text,
                     "source_name": "batch",
-                    "message": str(exc) or "Batch ingestion failed.",
+                    "error_type": type(exc).__name__,
+                    "message": "Batch ingestion failed.",
                 }
             )
             _print_progress(

--- a/scripts/crawl_tw_daily_batch.py
+++ b/scripts/crawl_tw_daily_batch.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import argparse
 import json
 import os
-from datetime import date, datetime
+import time
+from datetime import date, datetime, timedelta
 from zoneinfo import ZoneInfo
 
 from backend.market_data.services.ingestion import ingest_tw_market_batch
@@ -28,7 +29,10 @@ def _parse_trading_date(value: str | None) -> date:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Ingest TW market daily batch data.")
-    parser.add_argument("trading_date", nargs="?", default=os.getenv("INGEST_DATE"))
+    parser.add_argument("trading_date", nargs="?")
+    parser.add_argument("--start-date")
+    parser.add_argument("--end-date")
+    parser.add_argument("--delay-seconds", type=float, default=1.0)
     parser.add_argument(
         "--refresh-universe",
         action="store_true",
@@ -36,14 +40,88 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    summary = ingest_tw_market_batch(
-        trading_date=_parse_trading_date(args.trading_date),
-        refresh_universe=args.refresh_universe,
-    )
-    print(json.dumps(summary, ensure_ascii=True, default=str))
-    if summary["errors"]:
-        return 1
-    return 0
+    if bool(args.start_date) != bool(args.end_date):
+        parser.error("--start-date and --end-date must be provided together.")
+    if args.start_date and args.trading_date:
+        parser.error("trading_date cannot be combined with a date range.")
+    if args.delay_seconds < 0:
+        parser.error("--delay-seconds must be nonnegative.")
+
+    if not args.start_date:
+        trading_date_value = args.trading_date or os.getenv("INGEST_DATE")
+        try:
+            trading_date = _parse_trading_date(trading_date_value)
+        except ValueError as exc:
+            parser.error(str(exc))
+        summary = ingest_tw_market_batch(
+            trading_date=trading_date,
+            refresh_universe=args.refresh_universe,
+        )
+        print(json.dumps(summary, ensure_ascii=True, default=str))
+        return 1 if summary["errors"] else 0
+
+    try:
+        start_date = _parse_trading_date(args.start_date)
+        end_date = _parse_trading_date(args.end_date)
+    except ValueError as exc:
+        parser.error(str(exc))
+    if start_date > end_date:
+        parser.error("--start-date must not be after --end-date.")
+
+    trading_dates = []
+    current_date = start_date
+    while current_date <= end_date:
+        if current_date.weekday() < 5:
+            trading_dates.append(current_date)
+        current_date += timedelta(days=1)
+
+    aggregate = {
+        "market": "TW",
+        "start_date": start_date.isoformat(),
+        "end_date": end_date.isoformat(),
+        "attempted_dates": [],
+        "succeeded_dates": [],
+        "skipped_non_trading_dates": [],
+        "failed_dates": [],
+        "upserted_rows": 0,
+        "errors": [],
+    }
+    for index, trading_date in enumerate(trading_dates):
+        trading_date_text = trading_date.isoformat()
+        aggregate["attempted_dates"].append(trading_date_text)
+        try:
+            summary = ingest_tw_market_batch(
+                trading_date=trading_date,
+                refresh_universe=args.refresh_universe and index == 0,
+            )
+        except Exception as exc:
+            aggregate["failed_dates"].append(trading_date_text)
+            aggregate["errors"].append(
+                {
+                    "trading_date": trading_date_text,
+                    "source_name": "batch",
+                    "message": str(exc) or "Batch ingestion failed.",
+                }
+            )
+            if index + 1 < len(trading_dates):
+                time.sleep(args.delay_seconds)
+            continue
+        aggregate["upserted_rows"] += int(summary["upserted_rows"])
+        if summary.get("status") == "skipped_non_trading_day":
+            aggregate["skipped_non_trading_dates"].append(trading_date_text)
+        elif summary["errors"]:
+            aggregate["failed_dates"].append(trading_date_text)
+            aggregate["errors"].extend(
+                {"trading_date": trading_date_text, **error}
+                for error in summary["errors"]
+            )
+        else:
+            aggregate["succeeded_dates"].append(trading_date_text)
+        if index + 1 < len(trading_dates):
+            time.sleep(args.delay_seconds)
+
+    print(json.dumps(aggregate, ensure_ascii=True, default=str))
+    return 1 if aggregate["failed_dates"] else 0
 
 
 if __name__ == "__main__":

--- a/scripts/market_data_ingestion.py
+++ b/scripts/market_data_ingestion.py
@@ -114,6 +114,7 @@ class BatchFetchResult:
     raw_row_count: int
     metadata: RawTraceMetadata | None = None
     error_message: str | None = None
+    provider_no_data: bool = False
 
 
 def persist_raw_ingest_record(
@@ -229,15 +230,51 @@ def _build_ohlcv_frame(
 
 
 def _empty_batch_result(
-    source_name: str, error_message: str | None = None
+    source_name: str,
+    error_message: str | None = None,
+    *,
+    metadata: RawTraceMetadata | None = None,
+    provider_no_data: bool = False,
 ) -> BatchFetchResult:
     return BatchFetchResult(
         source_name=source_name,
         dataframe=pd.DataFrame(),
         raw_row_count=0,
-        metadata=None,
+        metadata=metadata,
         error_message=error_message,
+        provider_no_data=provider_no_data,
     )
+
+
+def _payload_declares_no_data(payload_body: str) -> bool:
+    try:
+        payload = json.loads(payload_body)
+    except (TypeError, ValueError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    detail = " ".join(
+        str(payload.get(key) or "") for key in ("stat", "message", "msg")
+    ).lower()
+    if any(
+        marker in detail
+        for marker in ("沒有符合條件", "查無資料", "no data")
+    ):
+        return True
+    if str(payload.get("stat") or "").strip().lower() != "ok":
+        return False
+    for table in payload.get("tables") or []:
+        if not isinstance(table, dict) or table.get("data") != []:
+            continue
+        total_count = table.get("totalCount")
+        if isinstance(total_count, bool):
+            continue
+        try:
+            if float(total_count) == 0:
+                return True
+        except (TypeError, ValueError):
+            continue
+    return False
 
 
 def validate_ohlcv_with_report(
@@ -1040,6 +1077,16 @@ def fetch_twse_market_batch(trading_date: date) -> BatchFetchResult:
         fetch_status=FETCH_STATUS_SUCCESS,
         payload_body=payload_body,
     )
+    metadata = RawTraceMetadata.from_ingest(
+        raw_payload_id, TWSE_MI_INDEX_PARSER_VERSION
+    )
+
+    if _payload_declares_no_data(payload_body):
+        return _empty_batch_result(
+            SOURCE_TWSE_MI_INDEX,
+            metadata=metadata,
+            provider_no_data=True,
+        )
 
     try:
         dataframe, metadata = parse_twse_mi_index_payload_body(
@@ -1059,11 +1106,25 @@ def fetch_twse_market_batch(trading_date: date) -> BatchFetchResult:
             error_message=f"TWSE batch parse failed: {exc}",
         )
 
+    if dataframe.empty:
+        _try_persist(
+            _persist,
+            fetch_status=FETCH_STATUS_FAILED,
+            payload_body=payload_body,
+            context_label=f"{SOURCE_TWSE_MI_INDEX} empty result",
+        )
+        return _empty_batch_result(
+            SOURCE_TWSE_MI_INDEX,
+            metadata=metadata,
+            error_message="TWSE batch returned no rows without declaring no data.",
+        )
+
     return BatchFetchResult(
         source_name=SOURCE_TWSE_MI_INDEX,
         dataframe=dataframe,
         raw_row_count=len(dataframe),
         metadata=metadata,
+        provider_no_data=False,
     )
 
 
@@ -1118,6 +1179,16 @@ def fetch_tpex_market_batch(trading_date: date) -> BatchFetchResult:
         fetch_status=FETCH_STATUS_SUCCESS,
         payload_body=payload_body,
     )
+    metadata = RawTraceMetadata.from_ingest(
+        raw_payload_id, TPEX_AFTERTRADING_OTC_PARSER_VERSION
+    )
+
+    if _payload_declares_no_data(payload_body):
+        return _empty_batch_result(
+            SOURCE_TPEX_AFTERTRADING_OTC,
+            metadata=metadata,
+            provider_no_data=True,
+        )
 
     try:
         dataframe, metadata = parse_tpex_aftertrading_payload_body(
@@ -1137,11 +1208,25 @@ def fetch_tpex_market_batch(trading_date: date) -> BatchFetchResult:
             error_message=f"TPEX batch parse failed: {exc}",
         )
 
+    if dataframe.empty:
+        _try_persist(
+            _persist,
+            fetch_status=FETCH_STATUS_FAILED,
+            payload_body=payload_body,
+            context_label=f"{SOURCE_TPEX_AFTERTRADING_OTC} empty result",
+        )
+        return _empty_batch_result(
+            SOURCE_TPEX_AFTERTRADING_OTC,
+            metadata=metadata,
+            error_message="TPEX batch returned no rows without declaring no data.",
+        )
+
     return BatchFetchResult(
         source_name=SOURCE_TPEX_AFTERTRADING_OTC,
         dataframe=dataframe,
         raw_row_count=len(dataframe),
         metadata=metadata,
+        provider_no_data=False,
     )
 
 
@@ -1678,17 +1763,48 @@ def ingest_tw_market_batch(
 
     universe_by_exchange = resolve_tw_active_universe()
     universe_count = sum(len(symbols) for symbols in universe_by_exchange.values())
+    if universe_count == 0 and not refresh_universe:
+        universe_refresh_summary = crawl_tw_company_profiles()
+        universe_by_exchange = resolve_tw_active_universe()
+        universe_count = sum(
+            len(symbols) for symbols in universe_by_exchange.values()
+        )
     if universe_count == 0:
         raise ValueError("Active TW company universe is empty.")
 
     twse_result = fetch_twse_market_batch(trading_date)
     tpex_result = fetch_tpex_market_batch(trading_date)
+    source_results = (("TWSE", twse_result), ("TPEX", tpex_result))
+    skipped_non_trading_day = all(
+        result.provider_no_data for _, result in source_results
+    )
 
     filtered_frames = []
-    errors = []
+    errors = [
+        {
+            "source_name": "universe_refresh",
+            "message": str(error),
+        }
+        for error in (
+            universe_refresh_summary.get("errors", [])
+            if universe_refresh_summary is not None
+            else []
+        )
+    ]
     missing_symbol_count = 0
-    for exchange, result in (("TWSE", twse_result), ("TPEX", tpex_result)):
+    successful_source_count = 0
+    for exchange, result in source_results:
         allowed_symbols = universe_by_exchange[exchange]
+        if result.provider_no_data:
+            if not skipped_non_trading_day:
+                errors.append(
+                    {
+                        "source_name": result.source_name,
+                        "message": "Provider declared no data.",
+                    }
+                )
+                missing_symbol_count += len(allowed_symbols)
+            continue
         if result.error_message:
             errors.append(
                 {
@@ -1699,6 +1815,7 @@ def ingest_tw_market_batch(
             missing_symbol_count += len(allowed_symbols)
             continue
 
+        successful_source_count += 1
         filtered = _filter_batch_frame_to_universe(
             result.dataframe,
             allowed_symbols=allowed_symbols,
@@ -1716,9 +1833,16 @@ def ingest_tw_market_batch(
         else pd.DataFrame()
     )
     load_summary = load_to_db(combined_df)
+    if errors:
+        status = "partial" if successful_source_count else "failed"
+    elif skipped_non_trading_day:
+        status = "skipped_non_trading_day"
+    else:
+        status = "succeeded"
     summary = {
         "market": MARKET_TW,
         "trading_date": trading_date.isoformat(),
+        "status": status,
         "refresh_universe": refresh_universe,
         "universe_count": universe_count,
         "twse_rows": twse_result.raw_row_count,

--- a/scripts/market_data_ingestion.py
+++ b/scripts/market_data_ingestion.py
@@ -263,18 +263,21 @@ def _payload_declares_no_data(payload_body: str) -> bool:
         return True
     if str(payload.get("stat") or "").strip().lower() != "ok":
         return False
-    for table in payload.get("tables") or []:
-        if not isinstance(table, dict) or table.get("data") != []:
-            continue
+    tables = [item for item in (payload.get("tables") or []) if isinstance(item, dict)]
+    if not tables:
+        return False
+    for table in tables:
+        if table.get("data") != []:
+            return False
         total_count = table.get("totalCount")
         if isinstance(total_count, bool):
-            continue
+            return False
         try:
-            if float(total_count) == 0:
-                return True
+            if float(total_count) != 0:
+                return False
         except (TypeError, ValueError):
-            continue
-    return False
+            return False
+    return True
 
 
 def validate_ohlcv_with_report(

--- a/scripts/market_data_ingestion.py
+++ b/scripts/market_data_ingestion.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import re
+import re
 import sys
 import uuid
 from dataclasses import asdict, dataclass
@@ -256,9 +257,10 @@ def _payload_declares_no_data(payload_body: str) -> bool:
     detail = " ".join(
         str(payload.get(key) or "") for key in ("stat", "message", "msg")
     ).lower()
-    if any(
-        marker in detail
-        for marker in ("沒有符合條件", "查無資料", "no data")
+    if (
+        "沒有符合條件" in detail
+        or "查無資料" in detail
+        or re.search(r"\bno data\b", detail)
     ):
         return True
     if str(payload.get("stat") or "").strip().lower() != "ok":

--- a/scripts/market_data_ingestion.py
+++ b/scripts/market_data_ingestion.py
@@ -30,6 +30,11 @@ try:
     from backend.market_data.services.tls_helpers import (
         request_with_tls_fallback,
     )
+    from backend.platform.errors import (
+        DataAccessError,
+        ExternalFetchError,
+        UnsupportedConfigurationError,
+    )
     from backend.platform.time import utc_now
 except ImportError:
     print(
@@ -42,6 +47,12 @@ logging.basicConfig(
     format="%(asctime)s %(levelname)s %(name)s %(message)s",
 )
 logger = logging.getLogger(__name__)
+
+BATCH_STATUS_SUCCEEDED = "succeeded"
+BATCH_STATUS_PARTIAL = "partial"
+BATCH_STATUS_FAILED = "failed"
+BATCH_STATUS_SKIPPED_NON_TRADING_DAY = "skipped_non_trading_day"
+UNIVERSE_REFRESH_FAILED_CODE = "UNIVERSE_REFRESH_FAILED"
 
 SOURCE_TWSE = "twse"
 SOURCE_YFINANCE = "yfinance"
@@ -78,6 +89,24 @@ class QualityReport:
 
     def to_dict(self) -> dict:
         return asdict(self)
+
+
+def _universe_refresh_error(exc: Exception) -> dict[str, str]:
+    if isinstance(exc, ExternalFetchError):
+        reason = "external_fetch"
+    elif isinstance(exc, UnsupportedConfigurationError):
+        reason = "invalid_payload_or_config"
+    elif isinstance(exc, DataAccessError):
+        reason = "persistence"
+    else:
+        reason = "unexpected"
+    return {
+        "source_name": "universe_refresh",
+        "code": UNIVERSE_REFRESH_FAILED_CODE,
+        "reason": reason,
+        "error_type": getattr(exc, "error_type", type(exc).__name__),
+        "message": "TW company universe refresh failed.",
+    }
 
 
 @dataclass
@@ -1075,7 +1104,7 @@ def fetch_twse_market_batch(trading_date: date) -> BatchFetchResult:
         )
         return _empty_batch_result(
             SOURCE_TWSE_MI_INDEX,
-            error_message=f"TWSE batch fetch failed: {exc}",
+            error_message=f"TWSE batch fetch failed ({type(exc).__name__}).",
         )
 
     raw_payload_id = _persist(
@@ -1108,7 +1137,7 @@ def fetch_twse_market_batch(trading_date: date) -> BatchFetchResult:
         )
         return _empty_batch_result(
             SOURCE_TWSE_MI_INDEX,
-            error_message=f"TWSE batch parse failed: {exc}",
+            error_message=f"TWSE batch parse failed ({type(exc).__name__}).",
         )
 
     if dataframe.empty:
@@ -1177,7 +1206,7 @@ def fetch_tpex_market_batch(trading_date: date) -> BatchFetchResult:
         )
         return _empty_batch_result(
             SOURCE_TPEX_AFTERTRADING_OTC,
-            error_message=f"TPEX batch fetch failed: {exc}",
+            error_message=f"TPEX batch fetch failed ({type(exc).__name__}).",
         )
 
     raw_payload_id = _persist(
@@ -1210,7 +1239,7 @@ def fetch_tpex_market_batch(trading_date: date) -> BatchFetchResult:
         )
         return _empty_batch_result(
             SOURCE_TPEX_AFTERTRADING_OTC,
-            error_message=f"TPEX batch parse failed: {exc}",
+            error_message=f"TPEX batch parse failed ({type(exc).__name__}).",
         )
 
     if dataframe.empty:
@@ -1763,18 +1792,44 @@ def ingest_tw_market_batch(
     refresh_universe: bool = False,
 ) -> dict:
     universe_refresh_summary = None
+    universe_refresh_errors: list[dict[str, str]] = []
     if refresh_universe:
-        universe_refresh_summary = crawl_tw_company_profiles()
+        try:
+            universe_refresh_summary = crawl_tw_company_profiles()
+        except Exception as exc:
+            refresh_error = _universe_refresh_error(exc)
+            logger.error(
+                "Failed to refresh TW company universe before market ingestion "
+                "code=%s reason=%s",
+                refresh_error["code"],
+                refresh_error["reason"],
+            )
+            universe_refresh_errors.append(refresh_error)
 
     universe_by_exchange = resolve_tw_active_universe()
     universe_count = sum(len(symbols) for symbols in universe_by_exchange.values())
     if universe_count == 0 and not refresh_universe:
-        universe_refresh_summary = crawl_tw_company_profiles()
+        try:
+            universe_refresh_summary = crawl_tw_company_profiles()
+        except Exception as exc:
+            refresh_error = _universe_refresh_error(exc)
+            logger.error(
+                "Failed to bootstrap TW company universe before market ingestion "
+                "code=%s reason=%s",
+                refresh_error["code"],
+                refresh_error["reason"],
+            )
+            universe_refresh_errors.append(refresh_error)
         universe_by_exchange = resolve_tw_active_universe()
         universe_count = sum(
             len(symbols) for symbols in universe_by_exchange.values()
         )
     if universe_count == 0:
+        if universe_refresh_errors:
+            raise ValueError(
+                "Active TW company universe is empty after universe refresh "
+                f"failed (reason={universe_refresh_errors[-1]['reason']})."
+            )
         raise ValueError("Active TW company universe is empty.")
 
     twse_result = fetch_twse_market_batch(trading_date)
@@ -1786,15 +1841,18 @@ def ingest_tw_market_batch(
 
     filtered_frames = []
     errors = [
-        {
-            "source_name": "universe_refresh",
-            "message": str(error),
-        }
-        for error in (
-            universe_refresh_summary.get("errors", [])
-            if universe_refresh_summary is not None
-            else []
-        )
+        *universe_refresh_errors,
+        *[
+            {
+                "source_name": "universe_refresh",
+                "message": str(error),
+            }
+            for error in (
+                universe_refresh_summary.get("errors", [])
+                if universe_refresh_summary is not None
+                else []
+            )
+        ],
     ]
     missing_symbol_count = 0
     successful_source_count = 0
@@ -1839,11 +1897,15 @@ def ingest_tw_market_batch(
     )
     load_summary = load_to_db(combined_df)
     if errors:
-        status = "partial" if successful_source_count else "failed"
+        status = (
+            BATCH_STATUS_PARTIAL
+            if successful_source_count
+            else BATCH_STATUS_FAILED
+        )
     elif skipped_non_trading_day:
-        status = "skipped_non_trading_day"
+        status = BATCH_STATUS_SKIPPED_NON_TRADING_DAY
     else:
-        status = "succeeded"
+        status = BATCH_STATUS_SUCCEEDED
     summary = {
         "market": MARKET_TW,
         "trading_date": trading_date.isoformat(),

--- a/scripts/market_data_ingestion.py
+++ b/scripts/market_data_ingestion.py
@@ -2,7 +2,6 @@ import json
 import logging
 import os
 import re
-import re
 import sys
 import uuid
 from dataclasses import asdict, dataclass

--- a/tests/market_data/test_company_profile_repository.py
+++ b/tests/market_data/test_company_profile_repository.py
@@ -1,0 +1,74 @@
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+import backend.market_data.repositories.company_profiles as company_profile_repository
+from backend.database import Base, TwCompanyProfile
+
+
+def test_reconciliation_updates_lineage_for_inactivated_profiles(monkeypatch):
+    engine = create_engine("sqlite:///:memory:")
+    testing_session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine, tables=[TwCompanyProfile.__table__])
+    monkeypatch.setattr(
+        company_profile_repository,
+        "SessionLocal",
+        testing_session_local,
+    )
+    with testing_session_local() as session:
+        session.add_all(
+            [
+                TwCompanyProfile(
+                    symbol="2330",
+                    market="TW",
+                    exchange="TWSE",
+                    board="listed",
+                    company_name="TSMC",
+                    trading_status="active",
+                    source_name="old_feed",
+                ),
+                TwCompanyProfile(
+                    symbol="2317",
+                    market="TW",
+                    exchange="TWSE",
+                    board="listed",
+                    company_name="Hon Hai",
+                    trading_status="active",
+                    source_name="old_feed",
+                ),
+                TwCompanyProfile(
+                    symbol="US01",
+                    market="US",
+                    exchange="TWSE",
+                    board="listed",
+                    company_name="Different Market",
+                    trading_status="active",
+                    source_name="old_feed",
+                ),
+            ]
+        )
+        session.commit()
+
+    updated_count = (
+        company_profile_repository.mark_missing_active_tw_company_profiles_inactive(
+            exchange="twse",
+            active_symbols={"2330"},
+            source_name="twse_company_profile",
+            raw_payload_id=42,
+            archive_object_reference="raw_ingest_audit:42",
+        )
+    )
+
+    with testing_session_local() as session:
+        profiles = {
+            (profile.market, profile.symbol): profile
+            for profile in session.scalars(select(TwCompanyProfile)).all()
+        }
+
+    assert updated_count == 1
+    assert profiles[("TW", "2330")].trading_status == "active"
+    assert profiles[("US", "US01")].trading_status == "active"
+    inactivated = profiles[("TW", "2317")]
+    assert inactivated.trading_status == "inactive"
+    assert inactivated.source_name == "twse_company_profile"
+    assert inactivated.raw_payload_id == 42
+    assert inactivated.archive_object_reference == "raw_ingest_audit:42"

--- a/tests/market_data/test_market_data_api.py
+++ b/tests/market_data/test_market_data_api.py
@@ -83,6 +83,7 @@ def test_tw_company_crawl_response_includes_inactivated_count(monkeypatch):
             "processed_count": 2,
             "upserted_count": 2,
             "inactivated_count": 1,
+            "reconciliation_skipped": True,
             "active_symbol_count": 2,
             "errors": [],
         },
@@ -95,6 +96,7 @@ def test_tw_company_crawl_response_includes_inactivated_count(monkeypatch):
 
     assert response.status_code == 200
     assert response.json()["inactivated_count"] == 1
+    assert response.json()["reconciliation_skipped"] is True
 
 
 def test_replay_and_replay_list(monkeypatch):

--- a/tests/market_data/test_market_data_api.py
+++ b/tests/market_data/test_market_data_api.py
@@ -72,6 +72,31 @@ def test_create_data_ingestion(monkeypatch):
     assert response.json()["minute_supplement"]["status"] == "succeeded"
 
 
+def test_tw_company_crawl_response_includes_inactivated_count(monkeypatch):
+    monkeypatch.setattr(
+        data_plane_api,
+        "crawl_tw_company_profiles",
+        lambda **kwargs: {
+            "market": "TW",
+            "source_names": ["twse_company_profile"],
+            "raw_payload_ids": [1],
+            "processed_count": 2,
+            "upserted_count": 2,
+            "inactivated_count": 1,
+            "active_symbol_count": 2,
+            "errors": [],
+        },
+    )
+
+    response = client.post(
+        "/api/v1/data/tw-company-crawls",
+        json={"include_tpex": False},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["inactivated_count"] == 1
+
+
 def test_replay_and_replay_list(monkeypatch):
     replay_payload = {
         "id": 9,

--- a/tests/market_data/test_market_data_api.py
+++ b/tests/market_data/test_market_data_api.py
@@ -1,13 +1,22 @@
 from datetime import date, datetime, timezone
 
+import requests
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
 import backend.market_data.api as data_plane_api
+import backend.market_data.repositories.company_profiles as company_profile_repository
+import backend.market_data.services.company_crawlers as company_crawlers
 import backend.market_data.services.readiness as readiness_service
 from backend.app import app
-from backend.database import Base, DailyOHLCV, RawIngestAudit
+from backend.database import (
+    Base,
+    DailyOHLCV,
+    RawIngestAudit,
+    TwCompanyProfile,
+)
 
 client = TestClient(app)
 
@@ -73,16 +82,26 @@ def test_create_data_ingestion(monkeypatch):
 
 
 def test_tw_company_crawl_response_includes_inactivated_count(monkeypatch):
+    calls = []
     monkeypatch.setattr(
         data_plane_api,
         "crawl_tw_company_profiles",
-        lambda **kwargs: {
+        lambda **kwargs: calls.append(kwargs) or {
             "market": "TW",
             "source_names": ["twse_company_profile"],
+            "source_summaries": [
+                {
+                    "source_name": "twse_company_profile",
+                    "exchange": "TWSE",
+                    "reconciliation_requested": False,
+                    "reconciliation_skipped": False,
+                }
+            ],
             "raw_payload_ids": [1],
             "processed_count": 2,
             "upserted_count": 2,
             "inactivated_count": 1,
+            "reconciliation_requested": False,
             "reconciliation_skipped": True,
             "active_symbol_count": 2,
             "errors": [],
@@ -95,8 +114,107 @@ def test_tw_company_crawl_response_includes_inactivated_count(monkeypatch):
     )
 
     assert response.status_code == 200
+    assert calls == [{"include_tpex": False, "reconcile": False}]
     assert response.json()["inactivated_count"] == 1
+    assert response.json()["reconciliation_requested"] is False
     assert response.json()["reconciliation_skipped"] is True
+    assert response.json()["source_summaries"][0]["exchange"] == "TWSE"
+
+
+def test_tw_company_crawl_does_not_expose_request_url(
+    caplog,
+    monkeypatch,
+):
+    secret_url = "https://feed.test/company?token=secret"
+    monkeypatch.setenv(company_crawlers.TWSE_COMPANY_SOURCE_URL_ENV, secret_url)
+    monkeypatch.setattr(
+        company_crawlers,
+        "_request_company_feed_with_tls_fallback",
+        lambda **kwargs: (_ for _ in ()).throw(
+            requests.HTTPError(f"Forbidden for url: {kwargs['url']}")
+        ),
+    )
+    monkeypatch.setattr(
+        company_crawlers,
+        "persist_raw_ingest_record",
+        lambda **kwargs: 1,
+    )
+
+    response = client.post(
+        "/api/v1/data/tw-company-crawls",
+        json={"include_tpex": False},
+    )
+
+    assert response.status_code == 502
+    assert response.json()["error"]["code"] == "EXTERNAL_FETCH_FAILED"
+    assert response.json()["error"]["message"] == "Failed to fetch TW company feed."
+    assert "HTTPError" in caplog.text
+    assert "token=secret" not in response.text
+    assert "token=secret" not in caplog.text
+
+
+def test_tw_company_crawl_endpoint_does_not_reconcile_profiles(
+    monkeypatch,
+):
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine, tables=[TwCompanyProfile.__table__])
+    testing_session_local = sessionmaker(bind=engine)
+    monkeypatch.setattr(
+        company_profile_repository,
+        "SessionLocal",
+        testing_session_local,
+    )
+    monkeypatch.setattr(
+        company_crawlers,
+        "_fetch_company_feed",
+        lambda **kwargs: (
+            99,
+            [{"CompanyCode": "2330", "CompanyName": "TSMC"}],
+        ),
+    )
+    with testing_session_local() as session:
+        session.add_all(
+            [
+                TwCompanyProfile(
+                    symbol="2330",
+                    market="TW",
+                    exchange="TWSE",
+                    board="listed",
+                    company_name="TSMC",
+                    trading_status="active",
+                    source_name="existing",
+                ),
+                TwCompanyProfile(
+                    symbol="2317",
+                    market="TW",
+                    exchange="TWSE",
+                    board="listed",
+                    company_name="Hon Hai",
+                    trading_status="active",
+                    source_name="existing",
+                ),
+            ]
+        )
+        session.commit()
+
+    response = client.post(
+        "/api/v1/data/tw-company-crawls",
+        json={"include_tpex": False},
+    )
+
+    with testing_session_local() as session:
+        profiles = session.query(TwCompanyProfile).all()
+
+    assert response.status_code == 200
+    assert response.json()["inactivated_count"] == 0
+    assert {profile.symbol: profile.trading_status for profile in profiles} == {
+        "2317": "active",
+        "2330": "active",
+    }
 
 
 def test_replay_and_replay_list(monkeypatch):

--- a/tests/market_data/test_market_data_api.py
+++ b/tests/market_data/test_market_data_api.py
@@ -125,7 +125,7 @@ def test_tw_company_crawl_does_not_expose_request_url(
     caplog,
     monkeypatch,
 ):
-    feed_url_with_token = "https://feed.test/company?token=secret"
+    feed_url_with_token = "https://feed.test/company?token=secret"  # noqa: S105
     monkeypatch.setenv(
         company_crawlers.TWSE_COMPANY_SOURCE_URL_ENV,
         feed_url_with_token,

--- a/tests/market_data/test_market_data_api.py
+++ b/tests/market_data/test_market_data_api.py
@@ -125,8 +125,11 @@ def test_tw_company_crawl_does_not_expose_request_url(
     caplog,
     monkeypatch,
 ):
-    secret_url = "https://feed.test/company?token=secret"
-    monkeypatch.setenv(company_crawlers.TWSE_COMPANY_SOURCE_URL_ENV, secret_url)
+    feed_url_with_token = "https://feed.test/company?token=secret"
+    monkeypatch.setenv(
+        company_crawlers.TWSE_COMPANY_SOURCE_URL_ENV,
+        feed_url_with_token,
+    )
     monkeypatch.setattr(
         company_crawlers,
         "_request_company_feed_with_tls_fallback",

--- a/tests/market_data/test_official_crawlers.py
+++ b/tests/market_data/test_official_crawlers.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import traceback
 from datetime import datetime, timezone
 
+import pytest
+import requests
+
 import backend.market_data.services.official_crawlers as official_event_crawler_service
+from backend.platform.errors import ExternalFetchError
 
 
 def test_crawl_lifecycle_records_links_raw_payload(monkeypatch):
@@ -71,3 +76,39 @@ def test_crawl_important_events_links_raw_payload(monkeypatch):
     assert captured_requests[0].event_publication_ts == datetime(
         2026, 3, 19, tzinfo=timezone.utc
     )
+
+
+def test_official_feed_failure_does_not_expose_request_url(
+    caplog,
+    monkeypatch,
+):
+    secret_url = "https://feed.test/events?token=secret"
+    monkeypatch.setenv(
+        official_event_crawler_service.LIFECYCLE_SOURCE_URL_ENV,
+        secret_url,
+    )
+    monkeypatch.setattr(
+        official_event_crawler_service.requests,
+        "get",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            requests.HTTPError(f"Forbidden for url: {secret_url}")
+        ),
+    )
+    monkeypatch.setattr(
+        official_event_crawler_service,
+        "persist_raw_ingest_record",
+        lambda **kwargs: 1,
+    )
+
+    with pytest.raises(ExternalFetchError) as exc_info:
+        official_event_crawler_service._fetch_official_feed(
+            official_event_crawler_service.LIFECYCLE_SOURCE_URL_ENV,
+            official_event_crawler_service.LIFECYCLE_SOURCE_NAME,
+        )
+
+    assert str(exc_info.value) == "Failed to fetch official feed."
+    assert exc_info.value.error_type == "HTTPError"
+    assert "token=secret" not in "".join(
+        traceback.format_exception(exc_info.value)
+    )
+    assert "token=secret" not in caplog.text

--- a/tests/market_data/test_tick_archive.py
+++ b/tests/market_data/test_tick_archive.py
@@ -188,6 +188,63 @@ def test_fetch_twse_public_snapshot_auto_downloads_ca_on_tls_failure(monkeypatch
     ]
 
 
+def test_fetch_twse_public_snapshot_rejects_http_error_after_ca_download(
+    caplog,
+    monkeypatch,
+):
+    calls: list[bool | str] = []
+    response_url_with_token = "https://snapshot.test/data?token=secret"
+
+    def raise_http_error():
+        raise tick_archive_provider.requests.HTTPError(
+            f"Forbidden for url: {response_url_with_token}"
+        )
+
+    def fake_request_snapshot(*, params, timeout_seconds, verify):
+        calls.append(verify)
+        if len(calls) == 1:
+            raise tick_archive_provider.requests.exceptions.SSLError("bad cert")
+        return SimpleNamespace(
+            status_code=403,
+            url=response_url_with_token,
+            text='{"msgArray":[]}',
+            raise_for_status=raise_http_error,
+        )
+
+    monkeypatch.setattr(
+        tick_archive_provider,
+        "_resolve_tls_verify",
+        lambda: "/tmp/initial-ca.pem",
+    )
+    monkeypatch.setenv("TWSE_MIS_CA_AUTO_DOWNLOAD", "true")
+    monkeypatch.delenv("TWSE_MIS_ENABLE_INSECURE_FALLBACK", raising=False)
+    monkeypatch.setattr(
+        tick_archive_provider,
+        "_download_ca_bundle",
+        lambda: "/tmp/downloaded-ca.pem",
+    )
+    monkeypatch.setattr(
+        tick_archive_provider,
+        "_request_snapshot",
+        fake_request_snapshot,
+    )
+    monkeypatch.setattr(
+        tick_archive_provider,
+        "parse_snapshot_payload",
+        lambda *args, **kwargs: pytest.fail("failed responses must not be parsed"),
+    )
+
+    with pytest.raises(ExternalFetchError) as exc_info:
+        tick_archive_provider.fetch_twse_public_snapshot(["2330"])
+
+    assert exc_info.value.error_type == "HTTPError"
+    assert calls == ["/tmp/initial-ca.pem", "/tmp/downloaded-ca.pem"]
+    assert "token=secret" not in "".join(
+        traceback.format_exception(exc_info.value)
+    )
+    assert "token=secret" not in caplog.text
+
+
 def test_fetch_twse_public_snapshot_insecure_fallback_requires_explicit_opt_in(
     monkeypatch,
 ):
@@ -224,14 +281,14 @@ def test_fetch_twse_public_snapshot_failure_does_not_expose_request_url(
     caplog,
     monkeypatch,
 ):
-    secret_url = "https://snapshot.test/data?token=secret"
+    snapshot_url_with_token = "https://snapshot.test/data?token=secret"
     monkeypatch.setattr(tick_archive_provider, "_resolve_tls_verify", lambda: True)
     monkeypatch.setattr(
         tick_archive_provider,
         "_request_snapshot",
         lambda **kwargs: (_ for _ in ()).throw(
             tick_archive_provider.requests.HTTPError(
-                f"Forbidden for url: {secret_url}"
+                f"Forbidden for url: {snapshot_url_with_token}"
             )
         ),
     )

--- a/tests/market_data/test_tick_archive.py
+++ b/tests/market_data/test_tick_archive.py
@@ -1,3 +1,4 @@
+import traceback
 from datetime import date, datetime, timezone
 from types import SimpleNamespace
 
@@ -217,6 +218,33 @@ def test_fetch_twse_public_snapshot_insecure_fallback_requires_explicit_opt_in(
         tick_archive_provider.fetch_twse_public_snapshot(["2330"])
 
     assert calls == [tick_archive_provider.certifi.where()]
+
+
+def test_fetch_twse_public_snapshot_failure_does_not_expose_request_url(
+    caplog,
+    monkeypatch,
+):
+    secret_url = "https://snapshot.test/data?token=secret"
+    monkeypatch.setattr(tick_archive_provider, "_resolve_tls_verify", lambda: True)
+    monkeypatch.setattr(
+        tick_archive_provider,
+        "_request_snapshot",
+        lambda **kwargs: (_ for _ in ()).throw(
+            tick_archive_provider.requests.HTTPError(
+                f"Forbidden for url: {secret_url}"
+            )
+        ),
+    )
+
+    with pytest.raises(ExternalFetchError) as exc_info:
+        tick_archive_provider.fetch_twse_public_snapshot(["2330"])
+
+    assert str(exc_info.value) == "Failed to fetch TWSE public snapshot."
+    assert exc_info.value.error_type == "HTTPError"
+    assert "token=secret" not in "".join(
+        traceback.format_exception(exc_info.value)
+    )
+    assert "token=secret" not in caplog.text
 
 
 def test_fetch_twse_public_snapshot_can_use_explicit_insecure_fallback(monkeypatch):

--- a/tests/market_data/test_tls_helpers.py
+++ b/tests/market_data/test_tls_helpers.py
@@ -1,0 +1,39 @@
+import logging
+
+import pytest
+import requests
+
+import backend.market_data.services.tls_helpers as tls_helpers
+
+
+def test_tls_fallback_logs_do_not_expose_request_url(caplog, monkeypatch):
+    secret_url = "https://feed.test/data?token=secret"
+    outcomes = iter(
+        [
+            requests.exceptions.SSLError(f"TLS failed for {secret_url}"),
+            requests.exceptions.HTTPError(f"Forbidden for url: {secret_url}"),
+        ]
+    )
+
+    def fake_request(**kwargs):
+        outcome = next(outcomes)
+        raise outcome
+
+    monkeypatch.setattr(tls_helpers, "resolve_tls_verify", lambda: "default.pem")
+    monkeypatch.setattr(tls_helpers, "perform_tls_request", fake_request)
+    monkeypatch.setattr(tls_helpers, "ca_auto_download_enabled", lambda: True)
+    monkeypatch.setattr(tls_helpers, "download_ca_bundle", lambda: "downloaded.pem")
+    monkeypatch.setattr(tls_helpers, "insecure_tls_fallback_enabled", lambda: False)
+    caplog.set_level(logging.ERROR)
+
+    with pytest.raises(requests.exceptions.SSLError):
+        tls_helpers.request_with_tls_fallback(
+            method="GET",
+            url=secret_url,
+            timeout_seconds=30,
+            logger=logging.getLogger("test_tls_fallback"),
+            context_label="company feed fetch",
+        )
+
+    assert "HTTPError" in caplog.text
+    assert "token=secret" not in caplog.text

--- a/tests/scripts/test_crawl_tw_company_profiles.py
+++ b/tests/scripts/test_crawl_tw_company_profiles.py
@@ -83,9 +83,13 @@ def test_crawl_tw_company_profiles_reconciles_each_exchange(monkeypatch):
     )
     monkeypatch.setattr(
         company_crawlers,
-        "count_active_tw_company_profiles",
-        lambda **kwargs: 1 if kwargs else 2,
+        "list_active_tw_company_profiles",
+        lambda **kwargs: [
+            {"symbol": "2330", "exchange": "TWSE"},
+            {"symbol": "8049", "exchange": "TPEX"},
+        ],
     )
+    monkeypatch.setattr(company_crawlers, "count_active_tw_company_profiles", lambda: 2)
 
     summary = company_crawlers.crawl_tw_company_profiles()
 
@@ -94,6 +98,7 @@ def test_crawl_tw_company_profiles_reconciles_each_exchange(monkeypatch):
         {"exchange": "TPEX", "active_symbols": {"8049"}},
     ]
     assert summary["inactivated_count"] == 2
+    assert summary["reconciliation_skipped"] is False
     assert summary["active_symbol_count"] == 2
     assert summary["errors"] == []
 
@@ -101,9 +106,13 @@ def test_crawl_tw_company_profiles_reconciles_each_exchange(monkeypatch):
 def test_crawl_single_source_skips_reconciliation_when_feed_coverage_is_low(
     monkeypatch, caplog
 ):
+    existing_symbols = {str(1000 + index) for index in range(100)}
     records = [
         {"CompanyCode": str(1000 + index), "CompanyName": "Test Company"}
-        for index in range(94)
+        for index in range(90)
+    ] + [
+        {"CompanyCode": str(2000 + index), "CompanyName": "New Company"}
+        for index in range(5)
     ]
     monkeypatch.setattr(
         company_crawlers,
@@ -116,7 +125,11 @@ def test_crawl_single_source_skips_reconciliation_when_feed_coverage_is_low(
         lambda payload: {**payload, "write_action": "created"},
     )
     monkeypatch.setattr(
-        company_crawlers, "count_active_tw_company_profiles", lambda **kwargs: 100
+        company_crawlers,
+        "list_active_tw_company_profiles",
+        lambda **kwargs: [
+            {"symbol": symbol, "exchange": "TWSE"} for symbol in existing_symbols
+        ],
     )
     monkeypatch.setattr(
         company_crawlers,
@@ -133,6 +146,7 @@ def test_crawl_single_source_skips_reconciliation_when_feed_coverage_is_low(
     )
 
     assert summary["inactivated_count"] == 0
+    assert summary["reconciliation_skipped"] is True
     assert "Skipped TW company profile reconciliation due to low coverage" in (
         caplog.text
     )
@@ -143,6 +157,7 @@ def test_crawl_single_source_reconciles_at_minimum_feed_coverage(monkeypatch):
         {"CompanyCode": str(1000 + index), "CompanyName": "Test Company"}
         for index in range(95)
     ]
+    existing_symbols = {str(1000 + index) for index in range(100)}
     reconciliations = []
     monkeypatch.setattr(
         company_crawlers, "_fetch_company_feed", lambda **kwargs: (1, records)
@@ -153,7 +168,11 @@ def test_crawl_single_source_reconciles_at_minimum_feed_coverage(monkeypatch):
         lambda payload: {**payload, "write_action": "created"},
     )
     monkeypatch.setattr(
-        company_crawlers, "count_active_tw_company_profiles", lambda **kwargs: 100
+        company_crawlers,
+        "list_active_tw_company_profiles",
+        lambda **kwargs: [
+            {"symbol": symbol, "exchange": "TWSE"} for symbol in existing_symbols
+        ],
     )
     monkeypatch.setattr(
         company_crawlers,
@@ -172,6 +191,7 @@ def test_crawl_single_source_reconciles_at_minimum_feed_coverage(monkeypatch):
     assert len(reconciliations) == 1
     assert len(reconciliations[0]["active_symbols"]) == 95
     assert summary["inactivated_count"] == 1
+    assert summary["reconciliation_skipped"] is False
 
 
 def test_crawl_single_source_does_not_reconcile_empty_feed(monkeypatch):
@@ -193,6 +213,7 @@ def test_crawl_single_source_does_not_reconcile_empty_feed(monkeypatch):
     )
 
     assert summary["inactivated_count"] == 0
+    assert summary["reconciliation_skipped"] is True
     assert summary["errors"] == []
 
 
@@ -211,7 +232,9 @@ def test_crawl_single_source_does_not_reconcile_after_write_error(monkeypatch):
         lambda payload: (_ for _ in ()).throw(RuntimeError("write failed")),
     )
     monkeypatch.setattr(
-        company_crawlers, "count_active_tw_company_profiles", lambda **kwargs: 1
+        company_crawlers,
+        "list_active_tw_company_profiles",
+        lambda **kwargs: [{"symbol": "2330", "exchange": "TWSE"}],
     )
     monkeypatch.setattr(
         company_crawlers,
@@ -228,4 +251,40 @@ def test_crawl_single_source_does_not_reconcile_after_write_error(monkeypatch):
     )
 
     assert summary["inactivated_count"] == 0
+    assert summary["reconciliation_skipped"] is True
     assert summary["errors"] == ["exchange=TWSE symbol=2330: write failed"]
+
+
+def test_crawl_single_source_reports_failed_reconciliation(monkeypatch):
+    monkeypatch.setattr(
+        company_crawlers,
+        "_fetch_company_feed",
+        lambda **kwargs: (1, [{"CompanyCode": "2330", "CompanyName": "TSMC"}]),
+    )
+    monkeypatch.setattr(
+        company_crawlers,
+        "save_tw_company_profile",
+        lambda payload: {**payload, "write_action": "noop"},
+    )
+    monkeypatch.setattr(
+        company_crawlers,
+        "list_active_tw_company_profiles",
+        lambda **kwargs: [{"symbol": "2330", "exchange": "TWSE"}],
+    )
+    monkeypatch.setattr(
+        company_crawlers,
+        "mark_missing_active_tw_company_profiles_inactive",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("write failed")),
+    )
+
+    summary = company_crawlers._crawl_single_source(
+        url_env="TEST_URL",
+        default_url="https://example.test",
+        source_name="test_company_profile",
+        exchange="TWSE",
+        board="listed",
+    )
+
+    assert summary["inactivated_count"] == 0
+    assert summary["reconciliation_skipped"] is True
+    assert summary["errors"] == ["exchange=TWSE reconciliation: write failed"]

--- a/tests/scripts/test_crawl_tw_company_profiles.py
+++ b/tests/scripts/test_crawl_tw_company_profiles.py
@@ -82,7 +82,9 @@ def test_crawl_tw_company_profiles_reconciles_each_exchange(monkeypatch):
         lambda **kwargs: reconciliations.append(kwargs) or 1,
     )
     monkeypatch.setattr(
-        company_crawlers, "count_active_tw_company_profiles", lambda: 2
+        company_crawlers,
+        "count_active_tw_company_profiles",
+        lambda **kwargs: 1 if kwargs else 2,
     )
 
     summary = company_crawlers.crawl_tw_company_profiles()
@@ -94,6 +96,82 @@ def test_crawl_tw_company_profiles_reconciles_each_exchange(monkeypatch):
     assert summary["inactivated_count"] == 2
     assert summary["active_symbol_count"] == 2
     assert summary["errors"] == []
+
+
+def test_crawl_single_source_skips_reconciliation_when_feed_coverage_is_low(
+    monkeypatch, caplog
+):
+    records = [
+        {"CompanyCode": str(1000 + index), "CompanyName": "Test Company"}
+        for index in range(94)
+    ]
+    monkeypatch.setattr(
+        company_crawlers,
+        "_fetch_company_feed",
+        lambda **kwargs: (1, records),
+    )
+    monkeypatch.setattr(
+        company_crawlers,
+        "save_tw_company_profile",
+        lambda payload: {**payload, "write_action": "created"},
+    )
+    monkeypatch.setattr(
+        company_crawlers, "count_active_tw_company_profiles", lambda **kwargs: 100
+    )
+    monkeypatch.setattr(
+        company_crawlers,
+        "mark_missing_active_tw_company_profiles_inactive",
+        lambda **kwargs: pytest.fail("truncated feed must not inactivate profiles"),
+    )
+
+    summary = company_crawlers._crawl_single_source(
+        url_env="TEST_URL",
+        default_url="https://example.test",
+        source_name="test_company_profile",
+        exchange="TWSE",
+        board="listed",
+    )
+
+    assert summary["inactivated_count"] == 0
+    assert "Skipped TW company profile reconciliation due to low coverage" in (
+        caplog.text
+    )
+
+
+def test_crawl_single_source_reconciles_at_minimum_feed_coverage(monkeypatch):
+    records = [
+        {"CompanyCode": str(1000 + index), "CompanyName": "Test Company"}
+        for index in range(95)
+    ]
+    reconciliations = []
+    monkeypatch.setattr(
+        company_crawlers, "_fetch_company_feed", lambda **kwargs: (1, records)
+    )
+    monkeypatch.setattr(
+        company_crawlers,
+        "save_tw_company_profile",
+        lambda payload: {**payload, "write_action": "created"},
+    )
+    monkeypatch.setattr(
+        company_crawlers, "count_active_tw_company_profiles", lambda **kwargs: 100
+    )
+    monkeypatch.setattr(
+        company_crawlers,
+        "mark_missing_active_tw_company_profiles_inactive",
+        lambda **kwargs: reconciliations.append(kwargs) or 1,
+    )
+
+    summary = company_crawlers._crawl_single_source(
+        url_env="TEST_URL",
+        default_url="https://example.test",
+        source_name="test_company_profile",
+        exchange="TWSE",
+        board="listed",
+    )
+
+    assert len(reconciliations) == 1
+    assert len(reconciliations[0]["active_symbols"]) == 95
+    assert summary["inactivated_count"] == 1
 
 
 def test_crawl_single_source_does_not_reconcile_empty_feed(monkeypatch):
@@ -131,6 +209,9 @@ def test_crawl_single_source_does_not_reconcile_after_write_error(monkeypatch):
         company_crawlers,
         "save_tw_company_profile",
         lambda payload: (_ for _ in ()).throw(RuntimeError("write failed")),
+    )
+    monkeypatch.setattr(
+        company_crawlers, "count_active_tw_company_profiles", lambda **kwargs: 1
     )
     monkeypatch.setattr(
         company_crawlers,

--- a/tests/scripts/test_crawl_tw_company_profiles.py
+++ b/tests/scripts/test_crawl_tw_company_profiles.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import pytest
+
+from backend.market_data.services import company_crawlers
+
 
 def test_crawl_tw_company_profiles_main_returns_zero(capsys, monkeypatch, load_script):
     module = load_script(
@@ -49,3 +53,98 @@ def test_crawl_tw_company_profiles_main_returns_one_on_error(
     captured = capsys.readouterr()
     assert exit_code == 1
     assert '"errors": ["bad payload"]' in captured.out
+
+
+def test_crawl_tw_company_profiles_reconciles_each_exchange(monkeypatch):
+    records = {
+        company_crawlers.TWSE_COMPANY_SOURCE_NAME: [
+            {"CompanyCode": "2330", "CompanyName": "TSMC"},
+        ],
+        company_crawlers.TPEX_COMPANY_SOURCE_NAME: [
+            {"CompanyCode": "8049", "CompanyName": "Amita"},
+        ],
+    }
+    reconciliations = []
+
+    monkeypatch.setattr(
+        company_crawlers,
+        "_fetch_company_feed",
+        lambda **kwargs: (1, records[kwargs["source_name"]]),
+    )
+    monkeypatch.setattr(
+        company_crawlers,
+        "save_tw_company_profile",
+        lambda payload: {**payload, "write_action": "created"},
+    )
+    monkeypatch.setattr(
+        company_crawlers,
+        "mark_missing_active_tw_company_profiles_inactive",
+        lambda **kwargs: reconciliations.append(kwargs) or 1,
+    )
+    monkeypatch.setattr(
+        company_crawlers, "count_active_tw_company_profiles", lambda: 2
+    )
+
+    summary = company_crawlers.crawl_tw_company_profiles()
+
+    assert reconciliations == [
+        {"exchange": "TWSE", "active_symbols": {"2330"}},
+        {"exchange": "TPEX", "active_symbols": {"8049"}},
+    ]
+    assert summary["inactivated_count"] == 2
+    assert summary["active_symbol_count"] == 2
+    assert summary["errors"] == []
+
+
+def test_crawl_single_source_does_not_reconcile_empty_feed(monkeypatch):
+    monkeypatch.setattr(
+        company_crawlers, "_fetch_company_feed", lambda **kwargs: (1, [])
+    )
+    monkeypatch.setattr(
+        company_crawlers,
+        "mark_missing_active_tw_company_profiles_inactive",
+        lambda **kwargs: pytest.fail("empty feed must not inactivate profiles"),
+    )
+
+    summary = company_crawlers._crawl_single_source(
+        url_env="TEST_URL",
+        default_url="https://example.test",
+        source_name="test_company_profile",
+        exchange="TWSE",
+        board="listed",
+    )
+
+    assert summary["inactivated_count"] == 0
+    assert summary["errors"] == []
+
+
+def test_crawl_single_source_does_not_reconcile_after_write_error(monkeypatch):
+    monkeypatch.setattr(
+        company_crawlers,
+        "_fetch_company_feed",
+        lambda **kwargs: (
+            1,
+            [{"CompanyCode": "2330", "CompanyName": "TSMC"}],
+        ),
+    )
+    monkeypatch.setattr(
+        company_crawlers,
+        "save_tw_company_profile",
+        lambda payload: (_ for _ in ()).throw(RuntimeError("write failed")),
+    )
+    monkeypatch.setattr(
+        company_crawlers,
+        "mark_missing_active_tw_company_profiles_inactive",
+        lambda **kwargs: pytest.fail("failed crawl must not inactivate profiles"),
+    )
+
+    summary = company_crawlers._crawl_single_source(
+        url_env="TEST_URL",
+        default_url="https://example.test",
+        source_name="test_company_profile",
+        exchange="TWSE",
+        board="listed",
+    )
+
+    assert summary["inactivated_count"] == 0
+    assert summary["errors"] == ["exchange=TWSE symbol=2330: write failed"]

--- a/tests/scripts/test_crawl_tw_company_profiles.py
+++ b/tests/scripts/test_crawl_tw_company_profiles.py
@@ -94,11 +94,27 @@ def test_crawl_tw_company_profiles_reconciles_each_exchange(monkeypatch):
     summary = company_crawlers.crawl_tw_company_profiles()
 
     assert reconciliations == [
-        {"exchange": "TWSE", "active_symbols": {"2330"}},
-        {"exchange": "TPEX", "active_symbols": {"8049"}},
+        {
+            "exchange": "TWSE",
+            "active_symbols": {"2330"},
+            "source_name": company_crawlers.TWSE_COMPANY_SOURCE_NAME,
+            "raw_payload_id": 1,
+            "archive_object_reference": "raw_ingest_audit:1",
+        },
+        {
+            "exchange": "TPEX",
+            "active_symbols": {"8049"},
+            "source_name": company_crawlers.TPEX_COMPANY_SOURCE_NAME,
+            "raw_payload_id": 1,
+            "archive_object_reference": "raw_ingest_audit:1",
+        },
     ]
     assert summary["inactivated_count"] == 2
+    assert summary["reconciliation_requested"] is True
     assert summary["reconciliation_skipped"] is False
+    assert [
+        item["exchange"] for item in summary["source_summaries"]
+    ] == ["TWSE", "TPEX"]
     assert summary["active_symbol_count"] == 2
     assert summary["errors"] == []
 
@@ -147,6 +163,10 @@ def test_crawl_single_source_skips_reconciliation_when_feed_coverage_is_low(
 
     assert summary["inactivated_count"] == 0
     assert summary["reconciliation_skipped"] is True
+    assert summary["errors"] == [
+        "exchange=TWSE raw_payload_id=1 reconciliation skipped: "
+        "covered_symbol_count=90 existing_active_symbol_count=100."
+    ]
     assert "Skipped TW company profile reconciliation due to low coverage" in (
         caplog.text
     )
@@ -214,6 +234,46 @@ def test_crawl_single_source_does_not_reconcile_empty_feed(monkeypatch):
 
     assert summary["inactivated_count"] == 0
     assert summary["reconciliation_skipped"] is True
+    assert summary["errors"] == [
+        "exchange=TWSE raw_payload_id=1 reconciliation skipped: "
+        "company feed is empty."
+    ]
+
+
+def test_crawl_tw_company_profiles_can_disable_reconciliation(monkeypatch):
+    monkeypatch.setattr(
+        company_crawlers,
+        "_fetch_company_feed",
+        lambda **kwargs: (
+            1,
+            [{"CompanyCode": "2330", "CompanyName": "TSMC"}],
+        ),
+    )
+    monkeypatch.setattr(
+        company_crawlers,
+        "save_tw_company_profile",
+        lambda payload: {**payload, "write_action": "created"},
+    )
+    monkeypatch.setattr(
+        company_crawlers,
+        "list_active_tw_company_profiles",
+        lambda **kwargs: pytest.fail("reconciliation is disabled"),
+    )
+    monkeypatch.setattr(
+        company_crawlers,
+        "mark_missing_active_tw_company_profiles_inactive",
+        lambda **kwargs: pytest.fail("reconciliation is disabled"),
+    )
+    monkeypatch.setattr(company_crawlers, "count_active_tw_company_profiles", lambda: 1)
+
+    summary = company_crawlers.crawl_tw_company_profiles(
+        include_tpex=False,
+        reconcile=False,
+    )
+
+    assert summary["reconciliation_requested"] is False
+    assert summary["reconciliation_skipped"] is False
+    assert summary["inactivated_count"] == 0
     assert summary["errors"] == []
 
 

--- a/tests/scripts/test_crawl_tw_daily_batch.py
+++ b/tests/scripts/test_crawl_tw_daily_batch.py
@@ -270,8 +270,12 @@ def test_crawl_tw_daily_batch_range_continues_after_malformed_summary(
     assert summary["failed_dates"] == ["2026-03-20"]
     assert summary["succeeded_dates"] == ["2026-03-23"]
     assert summary["upserted_rows"] == 7
-    assert summary["errors"][0]["source_name"] == "batch"
-    assert "errors" in summary["errors"][0]["message"]
+    assert summary["errors"][0] == {
+        "trading_date": "2026-03-20",
+        "source_name": "batch",
+        "error_type": "KeyError",
+        "message": "Batch ingestion failed.",
+    }
     assert progress == [
         {
             "event": "tw_market_batch_progress",
@@ -298,6 +302,7 @@ def test_crawl_tw_daily_batch_range_aggregates_skip_and_failures(
         "crawl_tw_daily_batch_script_range_failures",
     )
     calls = []
+    sensitive_exception_detail = "https://feed.test/market?token=secret"
     summaries = iter(
         [
             {
@@ -310,7 +315,7 @@ def test_crawl_tw_daily_batch_range_aggregates_skip_and_failures(
                 "errors": [{"source_name": "twse_mi_index", "message": "timeout"}],
                 "status": "partial",
             },
-            RuntimeError("network unavailable"),
+            RuntimeError(sensitive_exception_detail),
         ]
     )
 
@@ -349,6 +354,14 @@ def test_crawl_tw_daily_batch_range_aggregates_skip_and_failures(
         "2026-03-23",
         "2026-03-24",
     ]
+    assert summary["errors"][1] == {
+        "trading_date": "2026-03-24",
+        "source_name": "batch",
+        "error_type": "RuntimeError",
+        "message": "Batch ingestion failed.",
+    }
+    assert sensitive_exception_detail not in captured.out
+    assert sensitive_exception_detail not in captured.err
     assert [call["refresh_universe"] for call in calls] == [True, False, False]
     assert summary["universe_refresh_succeeded"] is True
     assert [item["status"] for item in progress] == [

--- a/tests/scripts/test_crawl_tw_daily_batch.py
+++ b/tests/scripts/test_crawl_tw_daily_batch.py
@@ -161,8 +161,9 @@ def test_crawl_tw_daily_batch_rejects_invalid_range_arguments(
     )
     monkeypatch.setattr(sys, "argv", argv)
 
-    with pytest.raises(SystemExit, match="2"):
+    with pytest.raises(SystemExit) as exc_info:
         module.main()
+    assert exc_info.value.code == 2
 
     assert message in capsys.readouterr().err
 

--- a/tests/scripts/test_crawl_tw_daily_batch.py
+++ b/tests/scripts/test_crawl_tw_daily_batch.py
@@ -130,6 +130,26 @@ def test_parse_trading_date_defaults_to_taipei_timezone(load_script, monkeypatch
             ],
             "--delay-seconds must be nonnegative",
         ),
+        (
+            [
+                "crawl_tw_daily_batch.py",
+                "--start-date",
+                "invalid",
+                "--end-date",
+                "2026-03-20",
+            ],
+            "--start-date must be YYYY-MM-DD or YYYYMMDD",
+        ),
+        (
+            [
+                "crawl_tw_daily_batch.py",
+                "--start-date",
+                "2026-03-20",
+                "--end-date",
+                "invalid",
+            ],
+            "--end-date must be YYYY-MM-DD or YYYYMMDD",
+        ),
     ],
 )
 def test_crawl_tw_daily_batch_rejects_invalid_range_arguments(
@@ -179,7 +199,9 @@ def test_crawl_tw_daily_batch_range_attempts_weekdays_and_delays(
 
     exit_code = module.main()
 
-    summary = json.loads(capsys.readouterr().out)
+    captured = capsys.readouterr()
+    summary = json.loads(captured.out)
+    progress = [json.loads(line) for line in captured.err.splitlines()]
     assert exit_code == 0
     assert [call["trading_date"].isoformat() for call in calls] == [
         "2026-03-20",
@@ -188,7 +210,84 @@ def test_crawl_tw_daily_batch_range_attempts_weekdays_and_delays(
     assert summary["attempted_dates"] == ["2026-03-20", "2026-03-23"]
     assert summary["succeeded_dates"] == ["2026-03-20", "2026-03-23"]
     assert summary["upserted_rows"] == 4
+    assert summary["universe_refresh_succeeded"] is None
+    assert progress == [
+        {
+            "event": "tw_market_batch_progress",
+            "trading_date": "2026-03-20",
+            "status": "succeeded",
+            "upserted_rows": 2,
+            "error_count": 0,
+        },
+        {
+            "event": "tw_market_batch_progress",
+            "trading_date": "2026-03-23",
+            "status": "succeeded",
+            "upserted_rows": 2,
+            "error_count": 0,
+        },
+    ]
     assert delays == [0.25]
+
+
+def test_crawl_tw_daily_batch_range_continues_after_malformed_summary(
+    capsys, monkeypatch, load_script
+):
+    module = load_script(
+        "crawl_tw_daily_batch.py",
+        "crawl_tw_daily_batch_script_malformed_summary",
+    )
+    summaries = iter(
+        [
+            {"upserted_rows": 5, "status": "succeeded"},
+            {"upserted_rows": 2, "errors": [], "status": "succeeded"},
+        ]
+    )
+    monkeypatch.setattr(
+        module,
+        "ingest_tw_market_batch",
+        lambda **kwargs: next(summaries),
+    )
+    monkeypatch.setattr(module.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "crawl_tw_daily_batch.py",
+            "--start-date",
+            "2026-03-20",
+            "--end-date",
+            "2026-03-23",
+        ],
+    )
+
+    exit_code = module.main()
+
+    captured = capsys.readouterr()
+    summary = json.loads(captured.out)
+    progress = [json.loads(line) for line in captured.err.splitlines()]
+    assert exit_code == 1
+    assert summary["failed_dates"] == ["2026-03-20"]
+    assert summary["succeeded_dates"] == ["2026-03-23"]
+    assert summary["upserted_rows"] == 7
+    assert summary["errors"][0]["source_name"] == "batch"
+    assert "errors" in summary["errors"][0]["message"]
+    assert progress == [
+        {
+            "event": "tw_market_batch_progress",
+            "trading_date": "2026-03-20",
+            "status": "failed",
+            "upserted_rows": 5,
+            "error_count": 1,
+        },
+        {
+            "event": "tw_market_batch_progress",
+            "trading_date": "2026-03-23",
+            "status": "succeeded",
+            "upserted_rows": 2,
+            "error_count": 0,
+        },
+    ]
 
 
 def test_crawl_tw_daily_batch_range_aggregates_skip_and_failures(
@@ -239,7 +338,9 @@ def test_crawl_tw_daily_batch_range_aggregates_skip_and_failures(
 
     exit_code = module.main()
 
-    summary = json.loads(capsys.readouterr().out)
+    captured = capsys.readouterr()
+    summary = json.loads(captured.out)
+    progress = [json.loads(line) for line in captured.err.splitlines()]
     assert exit_code == 1
     assert summary["skipped_non_trading_dates"] == ["2026-03-20"]
     assert summary["failed_dates"] == ["2026-03-23", "2026-03-24"]
@@ -249,6 +350,12 @@ def test_crawl_tw_daily_batch_range_aggregates_skip_and_failures(
         "2026-03-24",
     ]
     assert [call["refresh_universe"] for call in calls] == [True, False, False]
+    assert summary["universe_refresh_succeeded"] is True
+    assert [item["status"] for item in progress] == [
+        "skipped_non_trading_day",
+        "failed",
+        "failed",
+    ]
 
 
 def test_crawl_tw_daily_batch_range_fails_on_universe_refresh_error(
@@ -290,6 +397,7 @@ def test_crawl_tw_daily_batch_range_fails_on_universe_refresh_error(
     summary = json.loads(capsys.readouterr().out)
     assert exit_code == 1
     assert summary["failed_dates"] == ["2026-03-20"]
+    assert summary["universe_refresh_succeeded"] is False
     assert summary["errors"] == [
         {
             "trading_date": "2026-03-20",
@@ -356,6 +464,7 @@ def test_crawl_tw_daily_batch_range_retries_universe_refresh_after_error(
     summary = json.loads(capsys.readouterr().out)
     assert exit_code == 1
     assert summary["failed_dates"] == ["2026-03-20"]
+    assert summary["universe_refresh_succeeded"] is True
     assert [call["refresh_universe"] for call in calls] == [True, True, False]
 
 
@@ -411,4 +520,5 @@ def test_crawl_tw_daily_batch_range_limits_refresh_attempts_after_exceptions(
         "2026-03-23",
         "2026-03-24",
     ]
+    assert summary["universe_refresh_succeeded"] is False
     assert [call["refresh_universe"] for call in calls] == [True, True, True, False]

--- a/tests/scripts/test_crawl_tw_daily_batch.py
+++ b/tests/scripts/test_crawl_tw_daily_batch.py
@@ -297,3 +297,118 @@ def test_crawl_tw_daily_batch_range_fails_on_universe_refresh_error(
             "message": "exchange=TWSE reconciliation: write failed",
         }
     ]
+
+
+def test_crawl_tw_daily_batch_range_retries_universe_refresh_after_error(
+    capsys, monkeypatch, load_script
+):
+    module = load_script(
+        "crawl_tw_daily_batch.py",
+        "crawl_tw_daily_batch_script_retries_universe_refresh",
+    )
+    calls = []
+    summaries = iter(
+        [
+            {
+                "upserted_rows": 0,
+                "status": "partial",
+                "errors": [
+                    {
+                        "source_name": "universe_refresh",
+                        "message": "exchange=TWSE reconciliation: write failed",
+                    }
+                ],
+            },
+            {
+                "upserted_rows": 1,
+                "status": "succeeded",
+                "errors": [],
+            },
+            {
+                "upserted_rows": 1,
+                "status": "succeeded",
+                "errors": [],
+            },
+        ]
+    )
+
+    def fake_ingest(**kwargs):
+        calls.append(kwargs)
+        return next(summaries)
+
+    monkeypatch.setattr(module, "ingest_tw_market_batch", fake_ingest)
+    monkeypatch.setattr(module.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "crawl_tw_daily_batch.py",
+            "--start-date",
+            "2026-03-20",
+            "--end-date",
+            "2026-03-24",
+            "--refresh-universe",
+        ],
+    )
+
+    exit_code = module.main()
+
+    summary = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert summary["failed_dates"] == ["2026-03-20"]
+    assert [call["refresh_universe"] for call in calls] == [True, True, False]
+
+
+def test_crawl_tw_daily_batch_range_limits_refresh_attempts_after_exceptions(
+    capsys, monkeypatch, load_script
+):
+    module = load_script(
+        "crawl_tw_daily_batch.py",
+        "crawl_tw_daily_batch_script_limits_refresh_attempts",
+    )
+    calls = []
+    outcomes = iter(
+        [
+            RuntimeError("network unavailable"),
+            RuntimeError("network unavailable"),
+            RuntimeError("network unavailable"),
+            {
+                "upserted_rows": 1,
+                "status": "succeeded",
+                "errors": [],
+            },
+        ]
+    )
+
+    def fake_ingest(**kwargs):
+        calls.append(kwargs)
+        outcome = next(outcomes)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    monkeypatch.setattr(module, "ingest_tw_market_batch", fake_ingest)
+    monkeypatch.setattr(module.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "crawl_tw_daily_batch.py",
+            "--start-date",
+            "2026-03-20",
+            "--end-date",
+            "2026-03-25",
+            "--refresh-universe",
+        ],
+    )
+
+    exit_code = module.main()
+
+    summary = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert summary["failed_dates"] == [
+        "2026-03-20",
+        "2026-03-23",
+        "2026-03-24",
+    ]
+    assert [call["refresh_universe"] for call in calls] == [True, True, True, False]

--- a/tests/scripts/test_crawl_tw_daily_batch.py
+++ b/tests/scripts/test_crawl_tw_daily_batch.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import json
 import sys
 from datetime import datetime
+
+import pytest
 
 
 def test_crawl_tw_daily_batch_main_returns_zero(capsys, monkeypatch, load_script):
@@ -9,10 +12,12 @@ def test_crawl_tw_daily_batch_main_returns_zero(capsys, monkeypatch, load_script
         "crawl_tw_daily_batch.py",
         "crawl_tw_daily_batch_script",
     )
+    calls = []
     monkeypatch.setattr(
         module,
         "ingest_tw_market_batch",
-        lambda **kwargs: {
+        lambda **kwargs: calls.append(kwargs)
+        or {
             "market": "TW",
             "trading_date": "2026-03-20",
             "upserted_rows": 2,
@@ -29,6 +34,12 @@ def test_crawl_tw_daily_batch_main_returns_zero(capsys, monkeypatch, load_script
 
     captured = capsys.readouterr()
     assert exit_code == 0
+    assert calls == [
+        {
+            "trading_date": module.date(2026, 3, 20),
+            "refresh_universe": True,
+        }
+    ]
     assert '"upserted_rows": 2' in captured.out
 
 
@@ -77,3 +88,212 @@ def test_parse_trading_date_defaults_to_taipei_timezone(load_script, monkeypatch
 
     assert str(captured["tz"]) == "Asia/Taipei"
     assert trading_date.isoformat() == "2026-03-24"
+
+
+@pytest.mark.parametrize(
+    ("argv", "message"),
+    [
+        (
+            ["crawl_tw_daily_batch.py", "--start-date", "2026-03-20"],
+            "--start-date and --end-date must be provided together",
+        ),
+        (
+            [
+                "crawl_tw_daily_batch.py",
+                "2026-03-20",
+                "--start-date",
+                "2026-03-20",
+                "--end-date",
+                "2026-03-23",
+            ],
+            "trading_date cannot be combined with a date range",
+        ),
+        (
+            [
+                "crawl_tw_daily_batch.py",
+                "--start-date",
+                "2026-03-23",
+                "--end-date",
+                "2026-03-20",
+            ],
+            "--start-date must not be after --end-date",
+        ),
+        (
+            [
+                "crawl_tw_daily_batch.py",
+                "--start-date",
+                "2026-03-20",
+                "--end-date",
+                "2026-03-23",
+                "--delay-seconds",
+                "-1",
+            ],
+            "--delay-seconds must be nonnegative",
+        ),
+    ],
+)
+def test_crawl_tw_daily_batch_rejects_invalid_range_arguments(
+    capsys, monkeypatch, load_script, argv, message
+):
+    module = load_script(
+        "crawl_tw_daily_batch.py",
+        "crawl_tw_daily_batch_invalid_range",
+    )
+    monkeypatch.setattr(sys, "argv", argv)
+
+    with pytest.raises(SystemExit, match="2"):
+        module.main()
+
+    assert message in capsys.readouterr().err
+
+
+def test_crawl_tw_daily_batch_range_attempts_weekdays_and_delays(
+    capsys, monkeypatch, load_script
+):
+    module = load_script(
+        "crawl_tw_daily_batch.py",
+        "crawl_tw_daily_batch_script_range",
+    )
+    calls = []
+    delays = []
+    monkeypatch.setattr(
+        module,
+        "ingest_tw_market_batch",
+        lambda **kwargs: calls.append(kwargs)
+        or {"upserted_rows": 2, "errors": [], "status": "succeeded"},
+    )
+    monkeypatch.setattr(module.time, "sleep", delays.append)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "crawl_tw_daily_batch.py",
+            "--start-date",
+            "2026-03-20",
+            "--end-date",
+            "2026-03-23",
+            "--delay-seconds",
+            "0.25",
+        ],
+    )
+
+    exit_code = module.main()
+
+    summary = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert [call["trading_date"].isoformat() for call in calls] == [
+        "2026-03-20",
+        "2026-03-23",
+    ]
+    assert summary["attempted_dates"] == ["2026-03-20", "2026-03-23"]
+    assert summary["succeeded_dates"] == ["2026-03-20", "2026-03-23"]
+    assert summary["upserted_rows"] == 4
+    assert delays == [0.25]
+
+
+def test_crawl_tw_daily_batch_range_aggregates_skip_and_failures(
+    capsys, monkeypatch, load_script
+):
+    module = load_script(
+        "crawl_tw_daily_batch.py",
+        "crawl_tw_daily_batch_script_range_failures",
+    )
+    calls = []
+    summaries = iter(
+        [
+            {
+                "upserted_rows": 0,
+                "errors": [],
+                "status": "skipped_non_trading_day",
+            },
+            {
+                "upserted_rows": 1,
+                "errors": [{"source_name": "twse_mi_index", "message": "timeout"}],
+                "status": "partial",
+            },
+            RuntimeError("network unavailable"),
+        ]
+    )
+
+    def fake_ingest(**kwargs):
+        calls.append(kwargs)
+        result = next(summaries)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(module, "ingest_tw_market_batch", fake_ingest)
+    monkeypatch.setattr(module.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "crawl_tw_daily_batch.py",
+            "--start-date",
+            "2026-03-20",
+            "--end-date",
+            "2026-03-24",
+            "--refresh-universe",
+        ],
+    )
+
+    exit_code = module.main()
+
+    summary = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert summary["skipped_non_trading_dates"] == ["2026-03-20"]
+    assert summary["failed_dates"] == ["2026-03-23", "2026-03-24"]
+    assert summary["upserted_rows"] == 1
+    assert [error["trading_date"] for error in summary["errors"]] == [
+        "2026-03-23",
+        "2026-03-24",
+    ]
+    assert [call["refresh_universe"] for call in calls] == [True, False, False]
+
+
+def test_crawl_tw_daily_batch_range_fails_on_universe_refresh_error(
+    capsys, monkeypatch, load_script
+):
+    module = load_script(
+        "crawl_tw_daily_batch.py",
+        "crawl_tw_daily_batch_script_universe_refresh_error",
+    )
+    monkeypatch.setattr(
+        module,
+        "ingest_tw_market_batch",
+        lambda **kwargs: {
+            "upserted_rows": 0,
+            "status": "failed",
+            "errors": [
+                {
+                    "source_name": "universe_refresh",
+                    "message": "exchange=TWSE reconciliation: write failed",
+                }
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "crawl_tw_daily_batch.py",
+            "--start-date",
+            "2026-03-20",
+            "--end-date",
+            "2026-03-20",
+            "--refresh-universe",
+        ],
+    )
+
+    exit_code = module.main()
+
+    summary = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert summary["failed_dates"] == ["2026-03-20"]
+    assert summary["errors"] == [
+        {
+            "trading_date": "2026-03-20",
+            "source_name": "universe_refresh",
+            "message": "exchange=TWSE reconciliation: write failed",
+        }
+    ]

--- a/tests/scripts/test_market_data_ingestion.py
+++ b/tests/scripts/test_market_data_ingestion.py
@@ -1564,7 +1564,7 @@ def test_market_batch_failures_do_not_expose_exception_details(
     monkeypatch,
     stage,
 ):
-    secret_url = "https://feed.test/market?token=secret"
+    feed_url_with_token = "https://feed.test/market?token=secret"
     request_name = (
         "_request_twse_daily_report"
         if exchange == "TWSE"
@@ -1587,7 +1587,7 @@ def test_market_batch_failures_do_not_expose_exception_details(
             scraper,
             request_name,
             lambda **kwargs: (_ for _ in ()).throw(
-                requests.HTTPError(f"Forbidden for url: {secret_url}")
+                requests.HTTPError(f"Forbidden for url: {feed_url_with_token}")
             ),
         )
     else:
@@ -1601,7 +1601,7 @@ def test_market_batch_failures_do_not_expose_exception_details(
             scraper,
             parser_name,
             lambda *args, **kwargs: (_ for _ in ()).throw(
-                ValueError(f"Invalid payload from {secret_url}")
+                ValueError(f"Invalid payload from {feed_url_with_token}")
             ),
         )
 

--- a/tests/scripts/test_market_data_ingestion.py
+++ b/tests/scripts/test_market_data_ingestion.py
@@ -457,6 +457,17 @@ def test_payload_declares_provider_no_data_markers_and_explicit_zero(payload_bod
     assert scraper._payload_declares_no_data(payload_body) is True
 
 
+def test_payload_declares_no_data_requires_all_tables_to_be_empty():
+    payload_body = (
+        '{"stat":"OK","tables":['
+        '{"totalCount":1,"data":[["row"]]},'
+        '{"totalCount":0,"data":[]}'
+        ']}'
+    )
+
+    assert scraper._payload_declares_no_data(payload_body) is False
+
+
 @pytest.mark.parametrize(
     "payload_body",
     [

--- a/tests/scripts/test_market_data_ingestion.py
+++ b/tests/scripts/test_market_data_ingestion.py
@@ -439,6 +439,39 @@ def test_sanitize_numeric_value_strips_html_tags():
     assert scraper._sanitize_numeric_value("<span>--</span>") == 0.0
 
 
+@pytest.mark.parametrize("payload_body", ["[]", '"no data"'])
+def test_payload_declares_no_data_ignores_non_mapping_json(payload_body):
+    assert scraper._payload_declares_no_data(payload_body) is False
+
+
+@pytest.mark.parametrize(
+    "payload_body",
+    [
+        '{"stat":"OK","message":"查無資料"}',
+        '{"stat":"OK","msg":"no data"}',
+        '{"stat":"OK","tables":[{"totalCount":0,"data":[]}]}',
+        '{"stat":"ok","tables":[{"totalCount":"0","data":[]}]}',
+    ],
+)
+def test_payload_declares_provider_no_data_markers_and_explicit_zero(payload_body):
+    assert scraper._payload_declares_no_data(payload_body) is True
+
+
+@pytest.mark.parametrize(
+    "payload_body",
+    [
+        '{"stat":"OK","tables":[{"data":[]}]}',
+        '{"stat":"OK","tables":[{"totalCount":1,"data":[]}]}',
+        '{"stat":"OK","tables":[{"totalCount":"0","data":[["row"]]}]}',
+        '{"stat":"OK","tables":[{"totalCount":"x","data":[]}]}',
+        '{"stat":"ERROR","tables":[{"totalCount":0,"data":[]}]}',
+        '{"stat":"OK","tables":[]}',
+    ],
+)
+def test_payload_declares_no_data_requires_explicit_structural_shape(payload_body):
+    assert scraper._payload_declares_no_data(payload_body) is False
+
+
 def test_ingest_symbol_tw_calls_daily_update(monkeypatch):
     backfill_df = pd.DataFrame(
         [
@@ -1107,6 +1140,11 @@ def test_ingest_tw_market_batch_filters_to_active_universe(monkeypatch):
     )
     monkeypatch.setattr(
         scraper,
+        "crawl_tw_company_profiles",
+        lambda: pytest.fail("non-empty universe must not be refreshed"),
+    )
+    monkeypatch.setattr(
+        scraper,
         "fetch_twse_market_batch",
         lambda trading_date: scraper.BatchFetchResult(
             source_name=scraper.SOURCE_TWSE_MI_INDEX,
@@ -1162,6 +1200,173 @@ def test_ingest_tw_market_batch_filters_to_active_universe(monkeypatch):
     assert summary["missing_symbol_count"] == 1
     assert summary["upserted_rows"] == 2
     assert summary["raw_payload_ids"] == [401, 402]
+    assert summary["errors"] == []
+
+
+def test_ingest_tw_market_batch_bootstraps_empty_universe_once(monkeypatch):
+    universes = iter(
+        [
+            {"TWSE": set(), "TPEX": set()},
+            {"TWSE": {"2330"}, "TPEX": set()},
+        ]
+    )
+    refresh_summary = {"inactivated_count": 0, "errors": []}
+    refresh_calls = []
+
+    monkeypatch.setattr(scraper, "resolve_tw_active_universe", lambda: next(universes))
+    monkeypatch.setattr(
+        scraper,
+        "crawl_tw_company_profiles",
+        lambda: refresh_calls.append(True) or refresh_summary,
+    )
+    monkeypatch.setattr(
+        scraper,
+        "fetch_twse_market_batch",
+        lambda trading_date: scraper.BatchFetchResult(
+            source_name=scraper.SOURCE_TWSE_MI_INDEX,
+            dataframe=pd.DataFrame(),
+            raw_row_count=0,
+            provider_no_data=True,
+        ),
+    )
+    monkeypatch.setattr(
+        scraper,
+        "fetch_tpex_market_batch",
+        lambda trading_date: scraper.BatchFetchResult(
+            source_name=scraper.SOURCE_TPEX_AFTERTRADING_OTC,
+            dataframe=pd.DataFrame(),
+            raw_row_count=0,
+            provider_no_data=True,
+        ),
+    )
+    monkeypatch.setattr(
+        scraper,
+        "load_to_db",
+        lambda df, metadata=None: {
+            "upserted_rows": 0,
+            "validated_rows": 0,
+            "official_overrides": 0,
+        },
+    )
+
+    summary = scraper.ingest_tw_market_batch(trading_date=date(2024, 1, 2))
+
+    assert refresh_calls == [True]
+    assert summary["universe_refresh"] == refresh_summary
+    assert summary["universe_count"] == 1
+
+
+def test_ingest_tw_market_batch_refresh_error_takes_precedence_over_no_data(
+    monkeypatch,
+):
+    refresh_summary = {
+        "inactivated_count": 0,
+        "errors": ["exchange=TWSE reconciliation: write failed"],
+    }
+    refresh_calls = []
+
+    monkeypatch.setattr(
+        scraper,
+        "crawl_tw_company_profiles",
+        lambda: refresh_calls.append(True) or refresh_summary,
+    )
+    monkeypatch.setattr(
+        scraper,
+        "resolve_tw_active_universe",
+        lambda: {"TWSE": {"2330"}, "TPEX": {"8049"}},
+    )
+    monkeypatch.setattr(
+        scraper,
+        "fetch_twse_market_batch",
+        lambda trading_date: scraper.BatchFetchResult(
+            source_name=scraper.SOURCE_TWSE_MI_INDEX,
+            dataframe=pd.DataFrame(),
+            raw_row_count=0,
+            provider_no_data=True,
+        ),
+    )
+    monkeypatch.setattr(
+        scraper,
+        "fetch_tpex_market_batch",
+        lambda trading_date: scraper.BatchFetchResult(
+            source_name=scraper.SOURCE_TPEX_AFTERTRADING_OTC,
+            dataframe=pd.DataFrame(),
+            raw_row_count=0,
+            provider_no_data=True,
+        ),
+    )
+    monkeypatch.setattr(
+        scraper,
+        "load_to_db",
+        lambda df, metadata=None: {
+            "upserted_rows": 0,
+            "validated_rows": 0,
+            "official_overrides": 0,
+        },
+    )
+
+    summary = scraper.ingest_tw_market_batch(
+        trading_date=date(2024, 1, 2),
+        refresh_universe=True,
+    )
+
+    assert refresh_calls == [True]
+    assert summary["status"] == "failed"
+    assert summary["refresh_universe"] is True
+    assert summary["universe_refresh"] == refresh_summary
+    assert summary["errors"] == [
+        {
+            "source_name": "universe_refresh",
+            "message": "exchange=TWSE reconciliation: write failed",
+        }
+    ]
+
+
+def test_ingest_tw_market_batch_skips_when_both_sources_report_no_data(monkeypatch):
+    monkeypatch.setattr(
+        scraper,
+        "resolve_tw_active_universe",
+        lambda: {"TWSE": {"2330"}, "TPEX": {"8049"}},
+    )
+    monkeypatch.setattr(
+        scraper,
+        "crawl_tw_company_profiles",
+        lambda: pytest.fail("non-empty universe must not be refreshed"),
+    )
+    monkeypatch.setattr(
+        scraper,
+        "fetch_twse_market_batch",
+        lambda trading_date: scraper.BatchFetchResult(
+            source_name=scraper.SOURCE_TWSE_MI_INDEX,
+            dataframe=pd.DataFrame(),
+            raw_row_count=0,
+            provider_no_data=True,
+        ),
+    )
+    monkeypatch.setattr(
+        scraper,
+        "fetch_tpex_market_batch",
+        lambda trading_date: scraper.BatchFetchResult(
+            source_name=scraper.SOURCE_TPEX_AFTERTRADING_OTC,
+            dataframe=pd.DataFrame(),
+            raw_row_count=0,
+            provider_no_data=True,
+        ),
+    )
+    monkeypatch.setattr(
+        scraper,
+        "load_to_db",
+        lambda df, metadata=None: {
+            "upserted_rows": 0,
+            "validated_rows": 0,
+            "official_overrides": 0,
+        },
+    )
+
+    summary = scraper.ingest_tw_market_batch(trading_date=date(2024, 1, 6))
+
+    assert summary["status"] == "skipped_non_trading_day"
+    assert summary["missing_symbol_count"] == 0
     assert summary["errors"] == []
 
 
@@ -1230,6 +1435,7 @@ def test_ingest_tw_market_batch_collects_source_errors(monkeypatch):
     summary = scraper.ingest_tw_market_batch(trading_date=date(2024, 1, 2))
 
     assert summary["filtered_rows"] == 1
+    assert summary["status"] == "partial"
     assert summary["missing_symbol_count"] == 1
     assert summary["raw_payload_ids"] == [501]
     assert summary["errors"] == [

--- a/tests/scripts/test_market_data_ingestion.py
+++ b/tests/scripts/test_market_data_ingestion.py
@@ -4,6 +4,11 @@ import pandas as pd
 import pytest
 import requests
 
+from backend.platform.errors import (
+    DataAccessError,
+    ExternalFetchError,
+    UnsupportedConfigurationError,
+)
 from scripts import market_data_ingestion as scraper
 
 
@@ -1335,6 +1340,168 @@ def test_ingest_tw_market_batch_refresh_error_takes_precedence_over_no_data(
     ]
 
 
+@pytest.mark.parametrize(
+    ("error", "reason", "error_type"),
+    [
+        (
+            ExternalFetchError(
+                "Failed to fetch TW company feed.",
+                error_type="HTTPError",
+            ),
+            "external_fetch",
+            "HTTPError",
+        ),
+        (
+            UnsupportedConfigurationError("/private/provider-payload.json"),
+            "invalid_payload_or_config",
+            "UnsupportedConfigurationError",
+        ),
+        (
+            DataAccessError("postgresql://secret@database"),
+            "persistence",
+            "DataAccessError",
+        ),
+        (RuntimeError("unexpected secret"), "unexpected", "RuntimeError"),
+    ],
+)
+def test_universe_refresh_error_uses_safe_structured_reason(
+    error,
+    reason,
+    error_type,
+):
+    assert scraper._universe_refresh_error(error) == {
+        "source_name": "universe_refresh",
+        "code": scraper.UNIVERSE_REFRESH_FAILED_CODE,
+        "reason": reason,
+        "error_type": error_type,
+        "message": "TW company universe refresh failed.",
+    }
+
+
+def test_ingest_tw_market_batch_continues_after_refresh_exception(
+    monkeypatch,
+    caplog,
+):
+    def market_frame(symbol, source):
+        return pd.DataFrame(
+            [
+                {
+                    "date": date(2024, 1, 2),
+                    "symbol": symbol,
+                    "market": "TW",
+                    "source": source,
+                    "open": 10.0,
+                    "high": 11.0,
+                    "low": 9.0,
+                    "close": 10.5,
+                    "volume": 100,
+                }
+            ]
+        )
+
+    monkeypatch.setattr(
+        scraper,
+        "crawl_tw_company_profiles",
+        lambda: (_ for _ in ()).throw(
+            ExternalFetchError("https://feed.test?token=secret")
+        ),
+    )
+    monkeypatch.setattr(
+        scraper,
+        "resolve_tw_active_universe",
+        lambda: {"TWSE": {"2330"}, "TPEX": {"8049"}},
+    )
+    monkeypatch.setattr(
+        scraper,
+        "fetch_twse_market_batch",
+        lambda trading_date: scraper.BatchFetchResult(
+            source_name=scraper.SOURCE_TWSE_MI_INDEX,
+            dataframe=market_frame("2330", scraper.SOURCE_TWSE_MI_INDEX),
+            raw_row_count=1,
+            metadata=scraper.RawTraceMetadata(
+                raw_payload_id=401,
+                archive_object_reference="raw_ingest_audit:401",
+                parser_version=scraper.TWSE_MI_INDEX_PARSER_VERSION,
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        scraper,
+        "fetch_tpex_market_batch",
+        lambda trading_date: scraper.BatchFetchResult(
+            source_name=scraper.SOURCE_TPEX_AFTERTRADING_OTC,
+            dataframe=market_frame(
+                "8049",
+                scraper.SOURCE_TPEX_AFTERTRADING_OTC,
+            ),
+            raw_row_count=1,
+            metadata=scraper.RawTraceMetadata(
+                raw_payload_id=402,
+                archive_object_reference="raw_ingest_audit:402",
+                parser_version=scraper.TPEX_AFTERTRADING_OTC_PARSER_VERSION,
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        scraper,
+        "load_to_db",
+        lambda df, metadata=None: {
+            "upserted_rows": len(df),
+            "validated_rows": len(df),
+            "official_overrides": 0,
+        },
+    )
+
+    summary = scraper.ingest_tw_market_batch(
+        trading_date=date(2024, 1, 2),
+        refresh_universe=True,
+    )
+
+    assert summary["status"] == scraper.BATCH_STATUS_PARTIAL
+    assert summary["upserted_rows"] == 2
+    assert summary["filtered_rows"] == 2
+    assert summary["errors"] == [
+        {
+            "source_name": "universe_refresh",
+            "code": scraper.UNIVERSE_REFRESH_FAILED_CODE,
+            "reason": "external_fetch",
+            "error_type": "ExternalFetchError",
+            "message": "TW company universe refresh failed.",
+        }
+    ]
+    assert "token=secret" not in str(summary)
+    assert "token=secret" not in caplog.text
+
+
+def test_ingest_tw_market_batch_still_fails_without_usable_universe(monkeypatch):
+    monkeypatch.setattr(
+        scraper,
+        "crawl_tw_company_profiles",
+        lambda: (_ for _ in ()).throw(
+            ExternalFetchError("https://feed.test?token=secret")
+        ),
+    )
+    monkeypatch.setattr(
+        scraper,
+        "resolve_tw_active_universe",
+        lambda: {"TWSE": set(), "TPEX": set()},
+    )
+    monkeypatch.setattr(
+        scraper,
+        "fetch_twse_market_batch",
+        lambda trading_date: pytest.fail("market fetch requires a usable universe"),
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        scraper.ingest_tw_market_batch(trading_date=date(2024, 1, 2))
+
+    assert str(exc_info.value) == (
+        "Active TW company universe is empty after universe refresh failed "
+        "(reason=external_fetch)."
+    )
+    assert "token=secret" not in str(exc_info.value)
+
+
 def test_ingest_tw_market_batch_skips_when_both_sources_report_no_data(monkeypatch):
     monkeypatch.setattr(
         scraper,
@@ -1383,6 +1550,67 @@ def test_ingest_tw_market_batch_skips_when_both_sources_report_no_data(monkeypat
     assert summary["errors"] == []
 
 
+@pytest.mark.parametrize(
+    ("exchange", "stage", "expected_message"),
+    [
+        ("TWSE", "parse", "TWSE batch parse failed (ValueError)."),
+        ("TPEX", "fetch", "TPEX batch fetch failed (HTTPError)."),
+        ("TPEX", "parse", "TPEX batch parse failed (ValueError)."),
+    ],
+)
+def test_market_batch_failures_do_not_expose_exception_details(
+    exchange,
+    expected_message,
+    monkeypatch,
+    stage,
+):
+    secret_url = "https://feed.test/market?token=secret"
+    request_name = (
+        "_request_twse_daily_report"
+        if exchange == "TWSE"
+        else "_request_tpex_daily_report"
+    )
+    fetcher = (
+        scraper.fetch_twse_market_batch
+        if exchange == "TWSE"
+        else scraper.fetch_tpex_market_batch
+    )
+    parser_name = (
+        "parse_twse_mi_index_payload_body"
+        if exchange == "TWSE"
+        else "parse_tpex_aftertrading_payload_body"
+    )
+    monkeypatch.setattr(scraper, "persist_raw_ingest_record", lambda **kwargs: 1)
+
+    if stage == "fetch":
+        monkeypatch.setattr(
+            scraper,
+            request_name,
+            lambda **kwargs: (_ for _ in ()).throw(
+                requests.HTTPError(f"Forbidden for url: {secret_url}")
+            ),
+        )
+    else:
+        response = requests.Response()
+        response.status_code = 200
+        response._content = (
+            b'{"stat":"OK","tables":[{"totalCount":1,"data":[["row"]]}]}'
+        )
+        monkeypatch.setattr(scraper, request_name, lambda **kwargs: response)
+        monkeypatch.setattr(
+            scraper,
+            parser_name,
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                ValueError(f"Invalid payload from {secret_url}")
+            ),
+        )
+
+    result = fetcher(date(2024, 1, 2))
+
+    assert result.error_message == expected_message
+    assert "token=secret" not in str(result)
+
+
 def test_ingest_tw_market_batch_collects_source_errors(monkeypatch):
     tpex_df = pd.DataFrame(
         [
@@ -1405,14 +1633,14 @@ def test_ingest_tw_market_batch_collects_source_errors(monkeypatch):
         "resolve_tw_active_universe",
         lambda: {"TWSE": {"2330"}, "TPEX": {"8049"}},
     )
+    monkeypatch.setattr(scraper, "persist_raw_ingest_record", lambda **kwargs: 1)
     monkeypatch.setattr(
         scraper,
-        "fetch_twse_market_batch",
-        lambda trading_date: scraper.BatchFetchResult(
-            source_name=scraper.SOURCE_TWSE_MI_INDEX,
-            dataframe=pd.DataFrame(),
-            raw_row_count=0,
-            error_message="TWSE batch fetch failed: timeout",
+        "_request_twse_daily_report",
+        lambda **kwargs: (_ for _ in ()).throw(
+            requests.HTTPError(
+                "Forbidden for url: https://feed.test/market?token=secret"
+            )
         ),
     )
     monkeypatch.setattr(
@@ -1454,9 +1682,10 @@ def test_ingest_tw_market_batch_collects_source_errors(monkeypatch):
     assert summary["errors"] == [
         {
             "source_name": scraper.SOURCE_TWSE_MI_INDEX,
-            "message": "TWSE batch fetch failed: timeout",
+            "message": "TWSE batch fetch failed (HTTPError).",
         }
     ]
+    assert "token=secret" not in str(summary)
 
 
 def test_ingest_symbol_summary_includes_stage_metadata(monkeypatch):

--- a/tests/scripts/test_market_data_ingestion.py
+++ b/tests/scripts/test_market_data_ingestion.py
@@ -1564,7 +1564,7 @@ def test_market_batch_failures_do_not_expose_exception_details(
     monkeypatch,
     stage,
 ):
-    feed_url_with_token = "https://feed.test/market?token=secret"
+    feed_url_with_token = "https://feed.test/market?token=secret"  # noqa: S105
     request_name = (
         "_request_twse_daily_report"
         if exchange == "TWSE"

--- a/tests/scripts/test_market_data_ingestion.py
+++ b/tests/scripts/test_market_data_ingestion.py
@@ -449,6 +449,7 @@ def test_payload_declares_no_data_ignores_non_mapping_json(payload_body):
     [
         '{"stat":"OK","message":"查無資料"}',
         '{"stat":"OK","msg":"no data"}',
+        '{"stat":"很抱歉，沒有符合條件的資料!","type":"ALL"}',
         '{"stat":"OK","tables":[{"totalCount":0,"data":[]}]}',
         '{"stat":"ok","tables":[{"totalCount":"0","data":[]}]}',
     ],
@@ -476,6 +477,7 @@ def test_payload_declares_no_data_requires_all_tables_to_be_empty():
         '{"stat":"OK","tables":[{"totalCount":"0","data":[["row"]]}]}',
         '{"stat":"OK","tables":[{"totalCount":"x","data":[]}]}',
         '{"stat":"ERROR","tables":[{"totalCount":0,"data":[]}]}',
+        '{"stat":"OK","message":"no database available"}',
         '{"stat":"OK","tables":[]}',
     ],
 )


### PR DESCRIPTION
## Summary

- backfill the TW company universe and daily market-data workflow
- add batch ingestion support and regression coverage

## Verification

- focused market-data tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 公司爬取 reconciliation 回填：新增 `inactivated_count`、`reconciliation_skipped`，並支援關閉 reconciliation（`reconcile=false`）。
  * 台股每日批次：新增單日/交易日區間處理、進度輸出、延遲控制；摘要更細緻（含非交易日跳過與 provider 宣告無資料）。
* **錯誤修正**
  * 失敗日誌與錯誤訊息不再外洩含 token 的請求 URL，並提供結構化錯誤類型資訊。
* **文件**
  * 更新決策登錄、資料就緒驗證與回填指令說明。
* **測試**
  * 擴充 API 與批次/回補流程測試，覆蓋無資料判定與敏感資訊隱蔽。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->