### PR TITLE
fix: harden research opinion eligibility

### DIFF
--- a/backend/research/domain/opinion.py
+++ b/backend/research/domain/opinion.py
@@ -195,8 +195,8 @@ def _latest_signals(
         _as_mapping(payload.get("request_payload")).get("symbols")
     )
     allowed_symbols = {str(symbol) for symbol in declared if symbol}
-    forward_by_symbol: dict[str, Mapping[str, Any]] = {}
-    forward_dates: set[str] = set()
+    forward_by_symbol: dict[str, tuple[str, Mapping[str, Any]]] = {}
+    latest_date_counts: dict[str, int] = {}
     unexpected_symbols: set[str] = set()
     unexpected_signal_count = 0
     malformed_signal_count = 0
@@ -209,7 +209,7 @@ def _latest_signals(
             malformed_signal_count += 1
             continue
         symbol_key = str(symbol)
-        if allowed_symbols and symbol_key not in allowed_symbols:
+        if symbol_key not in allowed_symbols:
             unexpected_symbols.add(symbol_key)
             unexpected_signal_count += 1
             continue
@@ -217,22 +217,26 @@ def _latest_signals(
         if signal_date is None:
             malformed_signal_count += 1
             continue
-        if symbol_key in forward_by_symbol:
+        if not _is_number(signal.get("score")) or not _is_number(
+            signal.get("position")
+        ):
             malformed_signal_count += 1
-            continue
-        forward_by_symbol[symbol_key] = signal
-        forward_dates.add(signal_date)
-    latest = [forward_by_symbol[symbol] for symbol in sorted(forward_by_symbol)]
-    if allowed_symbols and set(forward_by_symbol) != allowed_symbols:
-        malformed_signal_count += len(allowed_symbols.symmetric_difference(forward_by_symbol))
+        current = forward_by_symbol.get(symbol_key)
+        if current is None or signal_date > current[0]:
+            forward_by_symbol[symbol_key] = (signal_date, signal)
+            latest_date_counts[symbol_key] = 1
+        elif signal_date == current[0]:
+            latest_date_counts[symbol_key] += 1
+    latest = [forward_by_symbol[symbol][1] for symbol in sorted(forward_by_symbol)]
+    malformed_signal_count += sum(count - 1 for count in latest_date_counts.values())
+    malformed_signal_count += len(allowed_symbols.difference(forward_by_symbol))
+    forward_dates = {item[0] for item in forward_by_symbol.values()}
     if len(forward_dates) > 1:
         malformed_signal_count += len(forward_dates)
     invalid_count = sum(
         1
         for item in latest
-        if not _is_number(item.get("score"))
-        or not _is_number(item.get("position"))
-        or not _is_probability(item.get("up_probability"))
+        if not _is_probability(item.get("up_probability"))
         or item.get("predicted_direction") not in {"up", "down"}
     )
     return (

--- a/backend/research/domain/opinion.py
+++ b/backend/research/domain/opinion.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import math
 import re
 from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import date, datetime
 from typing import Any
 
@@ -29,6 +30,14 @@ BOUNDARY_RISK = (
     "Checked no-warning result: warning_count=0 and caveat_count=0; manual adoption "
     "review is still required."
 )
+
+
+@dataclass(frozen=True)
+class _LatestSignalSelection:
+    latest: list[Mapping[str, Any]]
+    invalid_row_count: int
+    unexpected_symbols: list[str]
+    snapshot_complete: bool
 
 
 def _as_mapping(value: Any) -> Mapping[str, Any]:
@@ -190,64 +199,79 @@ def _invalidation_context(payload: Mapping[str, Any]) -> tuple[str, list[dict[st
 
 def _latest_signals(
     payload: Mapping[str, Any],
-) -> tuple[list[Mapping[str, Any]], int, list[str]]:
+) -> _LatestSignalSelection:
     declared = _as_list(payload.get("symbols")) or _as_list(
         _as_mapping(payload.get("request_payload")).get("symbols")
     )
     allowed_symbols = {str(symbol) for symbol in declared if symbol}
-    forward_by_symbol: dict[str, tuple[str, Mapping[str, Any]]] = {}
-    latest_date_counts: dict[str, int] = {}
+    forward_by_symbol: dict[
+        str, tuple[str, list[tuple[int, Mapping[str, Any]]]]
+    ] = {}
+    invalid_row_indices: set[int] = set()
     unexpected_symbols: set[str] = set()
-    unexpected_signal_count = 0
-    malformed_signal_count = 0
-    for item in _as_list(payload.get("signals")):
+    for row_index, item in enumerate(_as_list(payload.get("signals"))):
         signal = _as_mapping(item)
         if signal.get("signal_kind") != "forward_opinion":
             continue
         symbol = signal.get("symbol")
         if not symbol:
-            malformed_signal_count += 1
+            invalid_row_indices.add(row_index)
             continue
         symbol_key = str(symbol)
         if symbol_key not in allowed_symbols:
             unexpected_symbols.add(symbol_key)
-            unexpected_signal_count += 1
+            invalid_row_indices.add(row_index)
             continue
         signal_date = _signal_date_key(signal)
         if signal_date is None:
-            malformed_signal_count += 1
+            invalid_row_indices.add(row_index)
             continue
-        if not _is_number(signal.get("score")) or not _is_number(
-            signal.get("position")
-        ):
-            malformed_signal_count += 1
         current = forward_by_symbol.get(symbol_key)
         if current is None or signal_date > current[0]:
-            forward_by_symbol[symbol_key] = (signal_date, signal)
-            latest_date_counts[symbol_key] = 1
+            forward_by_symbol[symbol_key] = (
+                signal_date,
+                [(row_index, signal)],
+            )
         elif signal_date == current[0]:
-            latest_date_counts[symbol_key] += 1
-    latest = [forward_by_symbol[symbol][1] for symbol in sorted(forward_by_symbol)]
-    malformed_signal_count += sum(count - 1 for count in latest_date_counts.values())
-    malformed_signal_count += len(allowed_symbols.difference(forward_by_symbol))
-    forward_dates = {item[0] for item in forward_by_symbol.values()}
-    if len(forward_dates) > 1:
-        malformed_signal_count += len(forward_dates)
-    invalid_count = sum(
-        1
-        for item in latest
-        if not _is_probability(item.get("up_probability"))
-        or item.get("predicted_direction") not in {"up", "down"}
+            current[1].append((row_index, signal))
+
+    forward_dates = {selection[0] for selection in forward_by_symbol.values()}
+    common_as_of = max(forward_dates) if forward_dates else None
+    latest: list[Mapping[str, Any]] = []
+    for symbol in sorted(forward_by_symbol):
+        signal_date, candidates = forward_by_symbol[symbol]
+        selected_index, selected_signal = candidates[0]
+        latest.append(selected_signal)
+        invalid_row_indices.update(index for index, _ in candidates[1:])
+        if signal_date != common_as_of:
+            invalid_row_indices.add(selected_index)
+        if (
+            not _is_number(selected_signal.get("score"))
+            or not _is_number(selected_signal.get("position"))
+            or not _is_probability(selected_signal.get("up_probability"))
+            or selected_signal.get("predicted_direction") not in {"up", "down"}
+        ):
+            invalid_row_indices.add(selected_index)
+
+    # Keep structural invariants explicit even though invalid rows currently
+    # encode mixed dates and duplicate latest candidates.
+    snapshot_complete = (
+        bool(allowed_symbols)
+        and set(forward_by_symbol) == allowed_symbols
+        and len(forward_dates) == 1
+        and all(len(candidates) == 1 for _, candidates in forward_by_symbol.values())
+        and not invalid_row_indices
     )
-    return (
-        latest,
-        invalid_count + unexpected_signal_count + malformed_signal_count,
-        sorted(unexpected_symbols),
+    return _LatestSignalSelection(
+        latest=latest,
+        invalid_row_count=len(invalid_row_indices),
+        unexpected_symbols=sorted(unexpected_symbols),
+        snapshot_complete=snapshot_complete,
     )
 
 
 def _valid_latest_signals(payload: Mapping[str, Any]) -> list[Mapping[str, Any]]:
-    latest, _, _ = _latest_signals(payload)
+    latest = _latest_signals(payload).latest
     return [
         item
         for item in latest
@@ -535,7 +559,8 @@ def _summary_checks() -> list[dict[str, Any]]:
 
 
 def _parameter_sensitivity(payload: Mapping[str, Any]) -> dict[str, Any]:
-    latest, invalid_count, _ = _latest_signals(payload)
+    selection = _latest_signals(payload)
+    latest = selection.latest
     valid = _valid_latest_signals(payload)
     threshold = _strategy_threshold(payload)
     top_n = _strategy_top_n(payload)
@@ -625,8 +650,13 @@ def _parameter_sensitivity(payload: Mapping[str, Any]) -> dict[str, Any]:
         )
     )
     return {
-        "status": "warning" if invalid_count else "pass",
-        "reason": "Local provisional sensitivity scenarios were computed.",
+        "status": "pass" if selection.snapshot_complete else "warning",
+        "reason": (
+            "Local provisional sensitivity scenarios were computed."
+            if selection.snapshot_complete
+            else "Sensitivity scenarios were computed from valid latest rows, but "
+            "the latest signal snapshot is incomplete or invalid."
+        ),
         "result": {
             "base_candidate_symbols": base,
             "scenario_candidate_counts": {
@@ -654,7 +684,9 @@ def _review_checks(
     baselines = _as_mapping(payload.get("baselines"))
     caveats = _as_list(payload.get("comparison_caveats"))
     warnings = _as_list(payload.get("warnings"))
-    latest, invalid_signal_count, _ = _latest_signals(payload)
+    selection = _latest_signals(payload)
+    latest = selection.latest
+    invalid_signal_count = selection.invalid_row_count
     valid_latest = _valid_latest_signals(payload)
     selected_signal_dates = {
         str(item["symbol"]): signal_date
@@ -780,10 +812,15 @@ def _review_checks(
         _check(
             "signal_to_position",
             "method",
-            "pass" if latest and invalid_signal_count == 0 else "warning" if latest else "fail",
+            "pass"
+            if latest and selection.snapshot_complete
+            else "warning"
+            if latest
+            else "fail",
             "Latest persisted signal rows were bucketed by position sign.",
-            "Invalid latest signal rows were excluded from action rows."
-            if invalid_signal_count
+            "The latest signal snapshot is incomplete, mixed-date, duplicated, "
+            "or contains invalid rows."
+            if not selection.snapshot_complete
             else "Signal buckets are derived from numeric latest rows.",
             _refs(("signals", "signals")),
             {
@@ -1039,15 +1076,15 @@ def build_opinion_artifact(payload: Mapping[str, Any]) -> dict[str, Any]:
     if not signals:
         limitations.append("Signal artifact is unavailable.")
     else:
-        forward_signals, invalid_signal_count, unexpected_symbols = _latest_signals(
-            payload
-        )
+        selection = _latest_signals(payload)
+        forward_signals = selection.latest
+        unexpected_symbols = selection.unexpected_symbols
         if not forward_signals:
             limitations.append(
                 "Prospective direction-confirmed signals are unavailable; "
                 "holdout evaluation signals are not investment opinions."
             )
-        elif invalid_signal_count:
+        elif not selection.snapshot_complete:
             limitations.append(
                 "Prospective signals must contain exactly one valid row per declared "
                 "symbol on a common as-of date."

--- a/backend/research/services/eligibility.py
+++ b/backend/research/services/eligibility.py
@@ -16,6 +16,7 @@ _BATCH_SOURCES = (
     market_data_ingestion.SOURCE_TWSE_MI_INDEX,
     market_data_ingestion.SOURCE_TPEX_AFTERTRADING_OTC,
 )
+_AUDIT_PAYLOAD_CHUNK_SIZE = 50
 _DATE_PATTERN = re.compile(r"(?:^|;)date=(\d{8}|\d{4}/\d{2}/\d{2})(?:;|$)")
 
 
@@ -38,15 +39,15 @@ def load_official_no_data_dates(*, start_date: date, end_date: date) -> set[date
         time.min,
         tzinfo=market_data_ingestion.TW_TIMEZONE,
     ).astimezone(timezone.utc)
-    latest_by_date_source: dict[tuple[date, str], tuple[str, str | None]] = {}
+    latest_by_date_source: dict[tuple[date, str], tuple[int, str]] = {}
     try:
         with SessionLocal() as session:
             rows = session.execute(
                 select(
+                    RawIngestAudit.id,
                     RawIngestAudit.source_name,
                     RawIngestAudit.fetch_status,
                     RawIngestAudit.expected_symbol_context,
-                    RawIngestAudit.payload_body,
                 )
                 .where(RawIngestAudit.market == "TW")
                 .where(RawIngestAudit.source_name.in_(_BATCH_SOURCES))
@@ -60,8 +61,8 @@ def load_official_no_data_dates(*, start_date: date, end_date: date) -> set[date
                 trading_date = _audit_trading_date(row.expected_symbol_context)
                 if trading_date is not None and start_date <= trading_date <= end_date:
                     latest_by_date_source[trading_date, row.source_name] = (
+                        row.id,
                         row.fetch_status,
-                        row.payload_body,
                     )
     except Exception:
         logger.warning(
@@ -74,14 +75,43 @@ def load_official_no_data_dates(*, start_date: date, end_date: date) -> set[date
         return set()
 
     try:
+        successful_audit_ids = [
+            audit_id
+            for audit_id, fetch_status in latest_by_date_source.values()
+            if fetch_status == "success"
+        ]
+        no_data_audit_ids: set[int] = set()
+        if successful_audit_ids:
+            with SessionLocal() as session:
+                for offset in range(
+                    0,
+                    len(successful_audit_ids),
+                    _AUDIT_PAYLOAD_CHUNK_SIZE,
+                ):
+                    audit_id_chunk = successful_audit_ids[
+                        offset : offset + _AUDIT_PAYLOAD_CHUNK_SIZE
+                    ]
+                    payload_rows = session.execute(
+                        select(RawIngestAudit.id, RawIngestAudit.payload_body).where(
+                            RawIngestAudit.id.in_(audit_id_chunk)
+                        )
+                    )
+                    no_data_audit_ids.update(
+                        row.id
+                        for row in payload_rows
+                        if market_data_ingestion.payload_declares_no_data(
+                            row.payload_body
+                        )
+                    )
+
         return {
             trading_date
             for trading_date in {key[0] for key in latest_by_date_source}
             if all(
                 (audit := latest_by_date_source.get((trading_date, source)))
                 is not None
-                and audit[0] == "success"
-                and market_data_ingestion.payload_declares_no_data(audit[1])
+                and audit[1] == "success"
+                and audit[0] in no_data_audit_ids
                 for source in _BATCH_SOURCES
             )
         }

--- a/backend/research/services/eligibility.py
+++ b/backend/research/services/eligibility.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import logging
+import re
+from datetime import date, datetime
+
+import pandas as pd
+from sqlalchemy import select
+
+from backend.database import RawIngestAudit, SessionLocal
+from scripts import market_data_ingestion as market_data_ingestion
+
+logger = logging.getLogger(__name__)
+
+_BATCH_SOURCES = (
+    market_data_ingestion.SOURCE_TWSE_MI_INDEX,
+    market_data_ingestion.SOURCE_TPEX_AFTERTRADING_OTC,
+)
+_DATE_PATTERN = re.compile(r"(?:^|;)date=(\d{8}|\d{4}/\d{2}/\d{2})(?:;|$)")
+
+
+def _audit_trading_date(expected_symbol_context: str) -> date | None:
+    match = _DATE_PATTERN.search(expected_symbol_context or "")
+    if match is None:
+        return None
+    value = match.group(1)
+    try:
+        format_string = "%Y%m%d" if "/" not in value else "%Y/%m/%d"
+        return datetime.strptime(value, format_string).date()
+    except ValueError:
+        return None
+
+
+def load_official_no_data_dates(*, start_date: date, end_date: date) -> set[date]:
+    """Return dates where both official TW batch sources last reported no data."""
+    try:
+        with SessionLocal() as session:
+            rows = session.execute(
+                select(RawIngestAudit)
+                .where(RawIngestAudit.market == "TW")
+                .where(RawIngestAudit.source_name.in_(_BATCH_SOURCES))
+                .order_by(
+                    RawIngestAudit.fetch_timestamp.asc(), RawIngestAudit.id.asc()
+                )
+            ).scalars()
+
+            latest_by_date_source: dict[tuple[date, str], object] = {}
+            for row in rows:
+                trading_date = _audit_trading_date(row.expected_symbol_context)
+                if trading_date is not None and start_date <= trading_date <= end_date:
+                    latest_by_date_source[trading_date, row.source_name] = row
+    except Exception:
+        logger.warning(
+            "Failed to load official TW no-data audits start=%s end=%s; retaining all rows.",
+            start_date,
+            end_date,
+        )
+        return set()
+
+    return {
+        trading_date
+        for trading_date in {key[0] for key in latest_by_date_source}
+        if all(
+            (row := latest_by_date_source.get((trading_date, source))) is not None
+            and row.fetch_status == "success"
+            and market_data_ingestion._payload_declares_no_data(row.payload_body)
+            for source in _BATCH_SOURCES
+        )
+    }
+
+
+def exclude_non_official_rows_on_official_no_data(
+    df: pd.DataFrame, official_no_data_dates: set[date]
+) -> pd.DataFrame:
+    if df.empty or "source" not in df.columns or not official_no_data_dates:
+        return df
+    row_dates = pd.to_datetime(df.index).date
+    excluded = (~df["source"].isin(market_data_ingestion.OFFICIAL_SOURCES)) & pd.Series(
+        row_dates, index=df.index
+    ).isin(official_no_data_dates)
+    return df.loc[~excluded].copy()

--- a/backend/research/services/eligibility.py
+++ b/backend/research/services/eligibility.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
-from datetime import date, datetime
+from datetime import date, datetime, time, timezone
 
 import pandas as pd
 from sqlalchemy import select
@@ -33,40 +33,67 @@ def _audit_trading_date(expected_symbol_context: str) -> date | None:
 
 def load_official_no_data_dates(*, start_date: date, end_date: date) -> set[date]:
     """Return dates where both official TW batch sources last reported no data."""
+    fetch_timestamp_floor = datetime.combine(
+        start_date,
+        time.min,
+        tzinfo=market_data_ingestion.TW_TIMEZONE,
+    ).astimezone(timezone.utc)
+    latest_by_date_source: dict[tuple[date, str], tuple[str, str | None]] = {}
     try:
         with SessionLocal() as session:
             rows = session.execute(
-                select(RawIngestAudit)
+                select(
+                    RawIngestAudit.source_name,
+                    RawIngestAudit.fetch_status,
+                    RawIngestAudit.expected_symbol_context,
+                    RawIngestAudit.payload_body,
+                )
                 .where(RawIngestAudit.market == "TW")
                 .where(RawIngestAudit.source_name.in_(_BATCH_SOURCES))
+                .where(RawIngestAudit.fetch_timestamp >= fetch_timestamp_floor)
                 .order_by(
                     RawIngestAudit.fetch_timestamp.asc(), RawIngestAudit.id.asc()
                 )
-            ).scalars()
+            )
 
-            latest_by_date_source: dict[tuple[date, str], object] = {}
             for row in rows:
                 trading_date = _audit_trading_date(row.expected_symbol_context)
                 if trading_date is not None and start_date <= trading_date <= end_date:
-                    latest_by_date_source[trading_date, row.source_name] = row
+                    latest_by_date_source[trading_date, row.source_name] = (
+                        row.fetch_status,
+                        row.payload_body,
+                    )
     except Exception:
         logger.warning(
-            "Failed to load official TW no-data audits start=%s end=%s; retaining all rows.",
+            "Failed to load official TW no-data audits start=%s end=%s; "
+            "retaining all rows.",
             start_date,
             end_date,
+            exc_info=True,
         )
         return set()
 
-    return {
-        trading_date
-        for trading_date in {key[0] for key in latest_by_date_source}
-        if all(
-            (row := latest_by_date_source.get((trading_date, source))) is not None
-            and row.fetch_status == "success"
-            and market_data_ingestion._payload_declares_no_data(row.payload_body)
-            for source in _BATCH_SOURCES
+    try:
+        return {
+            trading_date
+            for trading_date in {key[0] for key in latest_by_date_source}
+            if all(
+                (audit := latest_by_date_source.get((trading_date, source)))
+                is not None
+                and audit[0] == "success"
+                and market_data_ingestion.payload_declares_no_data(audit[1])
+                for source in _BATCH_SOURCES
+            )
+        }
+    except Exception:
+        logger.warning(
+            "Failed to evaluate official TW no-data audits start=%s end=%s; "
+            "retaining all rows.",
+            start_date,
+            end_date,
+            exc_info=True,
         )
-    }
+        return set()
 
 
 def exclude_non_official_rows_on_official_no_data(

--- a/backend/research/services/execution.py
+++ b/backend/research/services/execution.py
@@ -170,8 +170,7 @@ def load_symbol_data(
             ),
         )
 
-    unshifted_features = feature_engine.add_features(df.copy(), feature_config)
-    df_features = unshifted_features.copy()
+    df_features = feature_engine.add_features(df.copy(), feature_config)
     apply_feature_shifts(df_features, shift_map, symbol)
     df_features, factor_materializations = materialize_run_factors(
         request,
@@ -851,8 +850,8 @@ def execute_research_run(
             feature_config,
             shift_map,
             test_size,
-            peer_feature_map,
-            official_no_data_dates,
+            peer_feature_map=peer_feature_map,
+            official_no_data_dates=official_no_data_dates,
         )
         for symbol in request.symbols
     ]

--- a/backend/research/services/execution.py
+++ b/backend/research/services/execution.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import math
 from dataclasses import dataclass
+from datetime import date
 
 import pandas as pd
 from sklearn.metrics import (
@@ -34,6 +35,10 @@ from backend.research.contracts.runtime_metadata import (
 )
 from backend.research.domain.version_pack import build_version_pack_payload
 from backend.research.services.adaptive import record_run_adaptive_exclusion
+from backend.research.services.eligibility import (
+    exclude_non_official_rows_on_official_no_data,
+    load_official_no_data_dates,
+)
 from backend.research.services.run_foundations import (
     build_run_foundation_context,
     build_run_peer_feature_map,
@@ -141,6 +146,7 @@ def load_symbol_data(
     shift_map: dict,
     test_size: float,
     peer_feature_map: dict[str, dict[pd.Timestamp, dict[str, float]]] | None = None,
+    official_no_data_dates: set[date] | None = None,
 ) -> dict:
     logger.info("Loading symbol=%s market=%s", symbol, request.market)
     df = data_service.get_data(
@@ -153,8 +159,19 @@ def load_symbol_data(
         raise DataNotFoundError(
             f"No data found for symbol '{symbol}' in the specified date range."
         )
+    if request.market == "TW" and "source" in df.columns:
+        df = exclude_non_official_rows_on_official_no_data(
+            df,
+            official_no_data_dates
+            if official_no_data_dates is not None
+            else load_official_no_data_dates(
+                start_date=request.date_range.start,
+                end_date=request.date_range.end,
+            ),
+        )
 
-    df_features = feature_engine.add_features(df.copy(), feature_config)
+    unshifted_features = feature_engine.add_features(df.copy(), feature_config)
+    df_features = unshifted_features.copy()
     apply_feature_shifts(df_features, shift_map, symbol)
     df_features, factor_materializations = materialize_run_factors(
         request,
@@ -817,6 +834,14 @@ def execute_research_run(
     feature_config, shift_map = build_feature_config(request)
     test_size = request.validation.test_size if request.validation else 0.2
     peer_feature_map = build_run_peer_feature_map(request)
+    official_no_data_dates = (
+        load_official_no_data_dates(
+            start_date=request.date_range.start,
+            end_date=request.date_range.end,
+        )
+        if request.market == "TW"
+        else set()
+    )
 
     symbol_data = [
         load_symbol_data(
@@ -827,6 +852,7 @@ def execute_research_run(
             shift_map,
             test_size,
             peer_feature_map,
+            official_no_data_dates,
         )
         for symbol in request.symbols
     ]

--- a/scripts/market_data_ingestion.py
+++ b/scripts/market_data_ingestion.py
@@ -275,7 +275,7 @@ def _empty_batch_result(
     )
 
 
-def _payload_declares_no_data(payload_body: str) -> bool:
+def payload_declares_no_data(payload_body: str | None) -> bool:
     try:
         payload = json.loads(payload_body)
     except (TypeError, ValueError):
@@ -1114,7 +1114,7 @@ def fetch_twse_market_batch(trading_date: date) -> BatchFetchResult:
         raw_payload_id, TWSE_MI_INDEX_PARSER_VERSION
     )
 
-    if _payload_declares_no_data(payload_body):
+    if payload_declares_no_data(payload_body):
         return _empty_batch_result(
             SOURCE_TWSE_MI_INDEX,
             metadata=metadata,
@@ -1216,7 +1216,7 @@ def fetch_tpex_market_batch(trading_date: date) -> BatchFetchResult:
         raw_payload_id, TPEX_AFTERTRADING_OTC_PARSER_VERSION
     )
 
-    if _payload_declares_no_data(payload_body):
+    if payload_declares_no_data(payload_body):
         return _empty_batch_result(
             SOURCE_TPEX_AFTERTRADING_OTC,
             metadata=metadata,

--- a/tests/research/test_execution.py
+++ b/tests/research/test_execution.py
@@ -132,6 +132,62 @@ def test_research_eligibility_excludes_audits_before_tw_start_date_floor(
     )
 
 
+def test_research_eligibility_includes_delayed_historical_backfill_audits(
+    monkeypatch,
+):
+    session_local = _eligibility_session(monkeypatch)
+    trading_date = date(2024, 1, 3)
+    delayed_fetch_timestamp = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    with session_local() as session:
+        session.add_all(
+            [
+                _official_audit(
+                    source_name=eligibility_service._BATCH_SOURCES[0],
+                    trading_date=trading_date,
+                    payload_body='{"stat": "沒有符合條件"}',
+                    fetch_timestamp=delayed_fetch_timestamp,
+                ),
+                _official_audit(
+                    source_name=eligibility_service._BATCH_SOURCES[1],
+                    trading_date=trading_date,
+                    payload_body='{"stat": "ok", "tables": [{"totalCount": 0, "data": []}]}',
+                    fetch_timestamp=delayed_fetch_timestamp,
+                ),
+            ]
+        )
+        session.commit()
+
+    assert eligibility_service.load_official_no_data_dates(
+        start_date=trading_date,
+        end_date=trading_date,
+    ) == {trading_date}
+
+
+def test_research_eligibility_loads_no_data_payloads_across_chunks(monkeypatch):
+    session_local = _eligibility_session(monkeypatch)
+    trading_dates = [date(2026, 7, day) for day in range(8, 11)]
+    with session_local() as session:
+        session.add_all(
+            [
+                _official_audit(
+                    source_name=source,
+                    trading_date=trading_date,
+                    payload_body='{"stat": "沒有符合條件"}',
+                )
+                for trading_date in trading_dates
+                for source in eligibility_service._BATCH_SOURCES
+            ]
+        )
+        session.commit()
+
+    monkeypatch.setattr(eligibility_service, "_AUDIT_PAYLOAD_CHUNK_SIZE", 2)
+
+    assert eligibility_service.load_official_no_data_dates(
+        start_date=trading_dates[0],
+        end_date=trading_dates[-1],
+    ) == set(trading_dates)
+
+
 @pytest.mark.parametrize("include_tpex", [False, True])
 def test_research_eligibility_keeps_non_official_row_without_two_latest_no_data_audits(
     monkeypatch, include_tpex

--- a/tests/research/test_execution.py
+++ b/tests/research/test_execution.py
@@ -1,8 +1,14 @@
+from datetime import date, datetime, timedelta, timezone
+
 import pandas as pd
 import pytest
 from pydantic import ValidationError
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
 import backend.research.services.execution as backtest_engine_service
+import backend.research.services.eligibility as eligibility_service
+from backend.database import Base, RawIngestAudit
 from backend.platform.errors import InsufficientDataError
 from backend.research.contracts.runs import (
     ResearchRunCreateRequest,
@@ -10,6 +16,211 @@ from backend.research.contracts.runs import (
     ValidationSummary,
 )
 from backend.shared.analytics.strategy import ResearchStrategyConfig
+
+
+def _eligibility_session(monkeypatch):
+    engine = create_engine("sqlite:///:memory:")
+    testing_session_local = sessionmaker(
+        autoflush=False, autocommit=False, bind=engine
+    )
+    Base.metadata.create_all(bind=engine, tables=[RawIngestAudit.__table__])
+    monkeypatch.setattr(eligibility_service, "SessionLocal", testing_session_local)
+    return testing_session_local
+
+
+def _official_audit(
+    *,
+    source_name: str,
+    trading_date: date,
+    payload_body: str,
+    offset: int = 0,
+    fetch_status: str = "success",
+) -> RawIngestAudit:
+    date_value = (
+        trading_date.strftime("%Y%m%d")
+        if source_name == eligibility_service._BATCH_SOURCES[0]
+        else trading_date.strftime("%Y/%m/%d")
+    )
+    return RawIngestAudit(
+        source_name=source_name,
+        symbol=(
+            "TWSE_BATCH_DAILY"
+            if source_name == eligibility_service._BATCH_SOURCES[0]
+            else "TPEX_BATCH_DAILY"
+        ),
+        market="TW",
+        fetch_timestamp=(
+            datetime(2026, 7, 1, tzinfo=timezone.utc) + timedelta(seconds=offset)
+        ),
+        parser_version="fixture",
+        fetch_status=fetch_status,
+        expected_symbol_context=f"market=TW;date={date_value};type=ALL",
+        payload_body=payload_body,
+    )
+
+
+def _non_official_frame(trading_date: date) -> pd.DataFrame:
+    return pd.DataFrame(
+        {"source": ["yfinance"], "close": [100.0]},
+        index=pd.to_datetime([trading_date]),
+    )
+
+
+def test_research_eligibility_excludes_non_official_row_on_official_no_data(
+    monkeypatch,
+):
+    session_local = _eligibility_session(monkeypatch)
+    trading_date = date(2026, 7, 10)
+    with session_local() as session:
+        session.add_all(
+            [
+                _official_audit(
+                    source_name=eligibility_service._BATCH_SOURCES[0],
+                    trading_date=trading_date,
+                    payload_body='{"stat": "沒有符合條件"}',
+                ),
+                _official_audit(
+                    source_name=eligibility_service._BATCH_SOURCES[1],
+                    trading_date=trading_date,
+                    payload_body='{"stat": "ok", "tables": [{"totalCount": 0, "data": []}]}',
+                ),
+            ]
+        )
+        session.commit()
+
+    dates = eligibility_service.load_official_no_data_dates(
+        start_date=trading_date, end_date=trading_date
+    )
+
+    assert dates == {trading_date}
+    assert eligibility_service.exclude_non_official_rows_on_official_no_data(
+        _non_official_frame(trading_date), dates
+    ).empty
+
+
+@pytest.mark.parametrize("include_tpex", [False, True])
+def test_research_eligibility_keeps_non_official_row_without_two_latest_no_data_audits(
+    monkeypatch, include_tpex
+):
+    session_local = _eligibility_session(monkeypatch)
+    trading_date = date(2026, 7, 10)
+    with session_local() as session:
+        session.add(
+            _official_audit(
+                source_name=eligibility_service._BATCH_SOURCES[0],
+                trading_date=trading_date,
+                payload_body='{"stat": "沒有符合條件"}',
+            )
+        )
+        if include_tpex:
+            session.add_all(
+                [
+                    _official_audit(
+                        source_name=eligibility_service._BATCH_SOURCES[1],
+                        trading_date=trading_date,
+                        payload_body='{"stat": "ok", "tables": [{"totalCount": 0, "data": []}]}',
+                    ),
+                    _official_audit(
+                        source_name=eligibility_service._BATCH_SOURCES[1],
+                        trading_date=trading_date,
+                        payload_body='{"stat": "ok", "tables": [{"totalCount": 1, "data": [["row"]]}]}',
+                        offset=1,
+                    ),
+                ]
+            )
+        session.commit()
+
+    dates = eligibility_service.load_official_no_data_dates(
+        start_date=trading_date, end_date=trading_date
+    )
+
+    assert not dates
+    assert len(eligibility_service.exclude_non_official_rows_on_official_no_data(
+        _non_official_frame(trading_date), dates
+    )) == 1
+
+
+def test_research_eligibility_keeps_official_row_on_official_no_data(monkeypatch):
+    session_local = _eligibility_session(monkeypatch)
+    trading_date = date(2026, 7, 10)
+    with session_local() as session:
+        session.add_all(
+            [
+                _official_audit(
+                    source_name=eligibility_service._BATCH_SOURCES[0],
+                    trading_date=trading_date,
+                    payload_body='{"stat": "沒有符合條件"}',
+                ),
+                _official_audit(
+                    source_name=eligibility_service._BATCH_SOURCES[1],
+                    trading_date=trading_date,
+                    payload_body='{"stat": "ok", "tables": [{"totalCount": 0, "data": []}]}',
+                ),
+            ]
+        )
+        session.commit()
+
+    frame = _non_official_frame(trading_date).assign(
+        source=eligibility_service._BATCH_SOURCES[0]
+    )
+    dates = eligibility_service.load_official_no_data_dates(
+        start_date=trading_date, end_date=trading_date
+    )
+
+    assert len(eligibility_service.exclude_non_official_rows_on_official_no_data(
+        frame, dates
+    )) == 1
+
+
+def test_research_eligibility_keeps_fallback_when_latest_audit_failed(monkeypatch):
+    session_local = _eligibility_session(monkeypatch)
+    trading_date = date(2026, 7, 10)
+    with session_local() as session:
+        session.add_all(
+            [
+                _official_audit(
+                    source_name=eligibility_service._BATCH_SOURCES[0],
+                    trading_date=trading_date,
+                    payload_body='{"stat": "沒有符合條件"}',
+                ),
+                _official_audit(
+                    source_name=eligibility_service._BATCH_SOURCES[1],
+                    trading_date=trading_date,
+                    payload_body='{"stat": "ok", "tables": [{"totalCount": 0, "data": []}]}',
+                ),
+                _official_audit(
+                    source_name=eligibility_service._BATCH_SOURCES[0],
+                    trading_date=trading_date,
+                    payload_body="",
+                    offset=1,
+                    fetch_status="failed",
+                ),
+            ]
+        )
+        session.commit()
+
+    assert not eligibility_service.load_official_no_data_dates(
+        start_date=trading_date, end_date=trading_date
+    )
+
+
+def test_research_eligibility_keeps_rows_when_audit_query_fails(monkeypatch, caplog):
+    class _FailingSession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def execute(self, statement):
+            raise RuntimeError("audit query unavailable")
+
+    monkeypatch.setattr(eligibility_service, "SessionLocal", _FailingSession)
+
+    assert not eligibility_service.load_official_no_data_dates(
+        start_date=date(2026, 7, 10), end_date=date(2026, 7, 10)
+    )
+    assert "retaining all rows" in caplog.text
 
 
 def _make_request() -> ResearchRunCreateRequest:
@@ -244,6 +455,7 @@ def test_direction_diagnostics_fail_closed_for_partial_universe():
 
 def test_execute_research_run_accepts_foundation_version_pack_fields(monkeypatch):
     request = _make_request()
+    request.symbols = ["2330", "2317"]
     request.baselines = ["buy_and_hold", "naive_momentum"]
     request.validation = ValidationConfig(
         method="holdout", splits=1, test_size=0.25
@@ -318,11 +530,19 @@ def test_execute_research_run_accepts_foundation_version_pack_fields(monkeypatch
         "build_run_peer_feature_map",
         lambda request: {},
     )
+    eligibility_dates = {date(2024, 1, 2)}
+    eligibility_load_calls: list[dict] = []
+    symbol_eligibility_dates: list[set[date]] = []
+    monkeypatch.setattr(
+        backtest_engine_service,
+        "load_official_no_data_dates",
+        lambda **kwargs: eligibility_load_calls.append(kwargs) or eligibility_dates,
+    )
     sample_index = pd.to_datetime(["2024-01-03"])
     monkeypatch.setattr(
         backtest_engine_service,
         "load_symbol_data",
-        lambda *args, **kwargs: {
+        lambda *args, **kwargs: symbol_eligibility_dates.append(args[7]) or {
             "symbol": args[2],
             "df_model": pd.DataFrame(
                 {
@@ -469,6 +689,10 @@ def test_execute_research_run_accepts_foundation_version_pack_fields(monkeypatch
     ]
     assert artifacts.warnings == artifacts.response.warnings
     assert exclusion_calls == ["run_foundation_response"]
+    assert eligibility_load_calls == [
+        {"start_date": request.date_range.start, "end_date": request.date_range.end}
+    ]
+    assert symbol_eligibility_dates == [eligibility_dates, eligibility_dates]
 
     monkeypatch.setattr(
         backtest_engine_service.backtest_service,

--- a/tests/research/test_execution.py
+++ b/tests/research/test_execution.py
@@ -35,6 +35,7 @@ def _official_audit(
     payload_body: str,
     offset: int = 0,
     fetch_status: str = "success",
+    fetch_timestamp: datetime | None = None,
 ) -> RawIngestAudit:
     date_value = (
         trading_date.strftime("%Y%m%d")
@@ -49,8 +50,10 @@ def _official_audit(
             else "TPEX_BATCH_DAILY"
         ),
         market="TW",
-        fetch_timestamp=(
-            datetime(2026, 7, 1, tzinfo=timezone.utc) + timedelta(seconds=offset)
+        fetch_timestamp=fetch_timestamp
+        or (
+            datetime.combine(trading_date, datetime.min.time(), tzinfo=timezone.utc)
+            + timedelta(hours=6, seconds=offset)
         ),
         parser_version="fixture",
         fetch_status=fetch_status,
@@ -96,6 +99,37 @@ def test_research_eligibility_excludes_non_official_row_on_official_no_data(
     assert eligibility_service.exclude_non_official_rows_on_official_no_data(
         _non_official_frame(trading_date), dates
     ).empty
+
+
+def test_research_eligibility_excludes_audits_before_tw_start_date_floor(
+    monkeypatch,
+):
+    session_local = _eligibility_session(monkeypatch)
+    trading_date = date(2026, 7, 10)
+    fetch_timestamp_floor = datetime.combine(
+        trading_date,
+        datetime.min.time(),
+        tzinfo=eligibility_service.market_data_ingestion.TW_TIMEZONE,
+    ).astimezone(timezone.utc)
+    with session_local() as session:
+        session.add_all(
+            [
+                _official_audit(
+                    source_name=source,
+                    trading_date=trading_date,
+                    payload_body='{"stat": "沒有符合條件"}',
+                    fetch_timestamp=fetch_timestamp_floor
+                    - timedelta(microseconds=1),
+                )
+                for source in eligibility_service._BATCH_SOURCES
+            ]
+        )
+        session.commit()
+
+    assert not eligibility_service.load_official_no_data_dates(
+        start_date=trading_date,
+        end_date=trading_date,
+    )
 
 
 @pytest.mark.parametrize("include_tpex", [False, True])
@@ -167,6 +201,7 @@ def test_research_eligibility_keeps_official_row_on_official_no_data(monkeypatch
         start_date=trading_date, end_date=trading_date
     )
 
+    assert dates == {trading_date}
     assert len(eligibility_service.exclude_non_official_rows_on_official_no_data(
         frame, dates
     )) == 1
@@ -220,7 +255,45 @@ def test_research_eligibility_keeps_rows_when_audit_query_fails(monkeypatch, cap
     assert not eligibility_service.load_official_no_data_dates(
         start_date=date(2026, 7, 10), end_date=date(2026, 7, 10)
     )
+    assert "Failed to load official TW no-data audits" in caplog.text
     assert "retaining all rows" in caplog.text
+    assert any(record.exc_info is not None for record in caplog.records)
+
+
+def test_research_eligibility_keeps_rows_when_audit_evaluation_fails(
+    monkeypatch, caplog
+):
+    session_local = _eligibility_session(monkeypatch)
+    trading_date = date(2026, 7, 10)
+    with session_local() as session:
+        session.add_all(
+            [
+                _official_audit(
+                    source_name=source,
+                    trading_date=trading_date,
+                    payload_body='{"stat": "沒有符合條件"}',
+                )
+                for source in eligibility_service._BATCH_SOURCES
+            ]
+        )
+        session.commit()
+
+    def _fail_evaluation(payload_body):
+        raise RuntimeError("audit evaluation unavailable")
+
+    monkeypatch.setattr(
+        eligibility_service.market_data_ingestion,
+        "payload_declares_no_data",
+        _fail_evaluation,
+    )
+
+    assert not eligibility_service.load_official_no_data_dates(
+        start_date=trading_date,
+        end_date=trading_date,
+    )
+    assert "Failed to evaluate official TW no-data audits" in caplog.text
+    assert "retaining all rows" in caplog.text
+    assert any(record.exc_info is not None for record in caplog.records)
 
 
 def _make_request() -> ResearchRunCreateRequest:
@@ -539,11 +612,20 @@ def test_execute_research_run_accepts_foundation_version_pack_fields(monkeypatch
         lambda **kwargs: eligibility_load_calls.append(kwargs) or eligibility_dates,
     )
     sample_index = pd.to_datetime(["2024-01-03"])
-    monkeypatch.setattr(
-        backtest_engine_service,
-        "load_symbol_data",
-        lambda *args, **kwargs: symbol_eligibility_dates.append(args[7]) or {
-            "symbol": args[2],
+
+    def _fake_load_symbol_data(
+        run_id,
+        request,
+        symbol,
+        feature_config,
+        shift_map,
+        test_size,
+        peer_feature_map=None,
+        official_no_data_dates=None,
+    ):
+        symbol_eligibility_dates.append(official_no_data_dates)
+        return {
+            "symbol": symbol,
             "df_model": pd.DataFrame(
                 {
                     "open": [100.0],
@@ -556,14 +638,19 @@ def test_execute_research_run_accepts_foundation_version_pack_fields(monkeypatch
             ),
             "X": pd.DataFrame({"MA_5": [1.0]}, index=sample_index),
             "y": pd.Series([0.01], index=sample_index),
-            "scores": pd.Series([0.42], index=sample_index, name=args[2]),
-            "open": pd.Series([100.0], index=sample_index, name=args[2]),
-            "high": pd.Series([101.0], index=sample_index, name=args[2]),
-            "low": pd.Series([99.0], index=sample_index, name=args[2]),
-            "close": pd.Series([100.5], index=sample_index, name=args[2]),
-            "volume": pd.Series([1000], index=sample_index, name=args[2]),
+            "scores": pd.Series([0.42], index=sample_index, name=symbol),
+            "open": pd.Series([100.0], index=sample_index, name=symbol),
+            "high": pd.Series([101.0], index=sample_index, name=symbol),
+            "low": pd.Series([99.0], index=sample_index, name=symbol),
+            "close": pd.Series([100.5], index=sample_index, name=symbol),
+            "volume": pd.Series([1000], index=sample_index, name=symbol),
             "factor_materializations": [],
-        },
+        }
+
+    monkeypatch.setattr(
+        backtest_engine_service,
+        "load_symbol_data",
+        _fake_load_symbol_data,
     )
     monkeypatch.setattr(
         backtest_engine_service.backtest_service,

--- a/tests/research/test_runs.py
+++ b/tests/research/test_runs.py
@@ -367,32 +367,8 @@ def test_opinion_builder_uses_latest_dated_signal_rows_for_actions_and_checks():
             },
             "outside the declared run universe: 2454",
         ),
-        (
-            {
-                "date": "2024-01-01",
-                "symbol": "2330",
-                "score": float("nan"),
-                "position": 1.0,
-                "signal_kind": "forward_opinion",
-                "up_probability": 0.8,
-                "predicted_direction": "up",
-            },
-            "exactly one valid row",
-        ),
-        (
-            {
-                "date": "2024-01-01",
-                "symbol": "2330",
-                "score": 0.5,
-                "position": float("inf"),
-                "signal_kind": "forward_opinion",
-                "up_probability": 0.8,
-                "predicted_direction": "up",
-            },
-            "exactly one valid row",
-        ),
     ],
-    ids=["invalid-date", "undeclared-symbol", "non-finite-score", "non-finite-position"],
+    ids=["invalid-date", "undeclared-symbol"],
 )
 def test_opinion_builder_invalid_signal_noise_fails_closed_without_driving_checks(
     noise, expected_limitation
@@ -424,6 +400,113 @@ def test_opinion_builder_invalid_signal_noise_fails_closed_without_driving_check
         "top_n_minus_1": 1,
         "top_n_plus_1": 2,
     }
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("score", float("nan")), ("position", float("inf"))],
+)
+def test_opinion_builder_counts_invalid_selected_latest_numeric_row(field, value):
+    payload = make_opinion_payload()
+    payload["signals"][0][field] = value
+
+    artifact = build_opinion_artifact(payload)
+    checks = {item["check"]: item for item in artifact["review_checks"]}
+
+    assert artifact["state"] == "no-opinion"
+    assert checks["signal_to_position"]["result"]["invalid_row_count"] == 1
+
+
+def test_opinion_builder_ignores_non_finite_numeric_value_on_older_signal_row():
+    payload = make_opinion_payload()
+    payload["signals"].append(
+        {
+            "date": "2024-01-01",
+            "symbol": "2330",
+            "score": float("nan"),
+            "position": 1.0,
+            "signal_kind": "forward_opinion",
+            "up_probability": 0.8,
+            "predicted_direction": "up",
+        }
+    )
+
+    artifact = build_opinion_artifact(payload)
+    checks = {item["check"]: item for item in artifact["review_checks"]}
+
+    assert artifact["state"] == "viable"
+    assert checks["signal_to_position"]["result"]["invalid_row_count"] == 0
+
+
+def test_opinion_builder_counts_symbols_behind_latest_common_date():
+    payload = make_opinion_payload()
+    payload["request_payload"]["symbols"] = ["2330", "2317", "2454"]
+    payload["signals"][0]["date"] = "2024-01-03"
+    payload["signals"].append(
+        {
+            "date": "2024-01-02",
+            "symbol": "2454",
+            "score": 0.005,
+            "position": 1.0,
+            "signal_kind": "forward_opinion",
+            "up_probability": 0.8,
+            "predicted_direction": "up",
+        }
+    )
+
+    artifact = build_opinion_artifact(payload)
+    checks = {item["check"]: item for item in artifact["review_checks"]}
+
+    assert artifact["state"] == "no-opinion"
+    assert checks["signal_to_position"]["result"] == {
+        "checked_symbol_count": 3,
+        "positive_count": 2,
+        "negative_count": 0,
+        "flat_count": 1,
+        "invalid_row_count": 2,
+    }
+    assert checks["signal_to_position"]["risk_or_warning"] == (
+        "The latest signal snapshot is incomplete, mixed-date, duplicated, "
+        "or contains invalid rows."
+    )
+    assert checks["parameter_sensitivity"]["status"] == "warning"
+    assert checks["parameter_sensitivity"]["evidence_reason"] == (
+        "Sensitivity scenarios were computed from valid latest rows, but "
+        "the latest signal snapshot is incomplete or invalid."
+    )
+
+
+def test_opinion_builder_counts_invalid_date_once_when_symbol_has_no_valid_row():
+    payload = make_opinion_payload()
+    payload["signals"][1]["date"] = "not-a-date"
+
+    artifact = build_opinion_artifact(payload)
+    checks = {item["check"]: item for item in artifact["review_checks"]}
+
+    assert artifact["state"] == "no-opinion"
+    assert checks["signal_to_position"]["result"] == {
+        "checked_symbol_count": 1,
+        "positive_count": 1,
+        "negative_count": 0,
+        "flat_count": 0,
+        "invalid_row_count": 1,
+    }
+
+
+def test_opinion_builder_missing_declared_symbol_does_not_invent_invalid_row():
+    payload = make_opinion_payload()
+    payload["signals"] = payload["signals"][:1]
+
+    artifact = build_opinion_artifact(payload)
+    checks = {item["check"]: item for item in artifact["review_checks"]}
+
+    assert artifact["state"] == "no-opinion"
+    assert checks["signal_to_position"]["status"] == "warning"
+    assert checks["signal_to_position"]["result"]["invalid_row_count"] == 0
+    assert checks["signal_to_position"]["risk_or_warning"] == (
+        "The latest signal snapshot is incomplete, mixed-date, duplicated, "
+        "or contains invalid rows."
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/research/test_runs.py
+++ b/tests/research/test_runs.py
@@ -272,55 +272,158 @@ def test_opinion_contract_allows_default_result_for_not_evaluated_check():
 
 def test_opinion_builder_uses_latest_dated_signal_rows_for_actions_and_checks():
     payload = make_opinion_payload()
-    payload["symbols"] = ["2330", "2317", "2454", "9999", "8888"]
     payload["signals"] = [
         {
-            "date": datetime(2024, 1, 4, 12, 30),
+            "date": "2024-01-01",
             "symbol": "2330",
-            "score": 0.02,
-            "position": 1.0,
+            "score": -0.04,
+            "position": -1.0,
+            "signal_kind": "forward_opinion",
+            "up_probability": 0.2,
+            "predicted_direction": "down",
         },
-        {"date": "2024-01-01", "symbol": "2330", "score": -0.04, "position": -1.0},
-        {"date": "2024-01-01", "symbol": "2317", "score": 0.04, "position": 1.0},
-        {"date": "2024-01-04", "symbol": "2317", "score": -0.03, "position": -1.0},
-        {"date": "2024-01-04", "symbol": "2454", "score": 0.0, "position": 0.0},
-        {"date": "2024-01-04", "symbol": "9999", "score": None, "position": 1.0},
-        {"date": "not-a-date", "symbol": "8888", "score": 0.5, "position": 1.0},
-        {"date": "2024-01-04", "score": 0.5, "position": 1.0},
+        {
+            "date": datetime(2024, 1, 4, 12, 30),
+            "symbol": "2317",
+            "score": -0.02,
+            "position": 0.0,
+            "signal_kind": "forward_opinion",
+            "up_probability": 0.2,
+            "predicted_direction": "down",
+        },
+        {
+            "date": "2024-01-01",
+            "symbol": "2317",
+            "score": 0.04,
+            "position": 1.0,
+            "signal_kind": "forward_opinion",
+            "up_probability": 0.8,
+            "predicted_direction": "up",
+        },
+        {
+            "date": "2024-01-04",
+            "symbol": "2330",
+            "score": 0.004,
+            "position": 1.0,
+            "signal_kind": "forward_opinion",
+            "up_probability": 0.8,
+            "predicted_direction": "up",
+        },
     ]
+
+    artifact = build_opinion_artifact(payload)
+    checks = {item["check"]: item for item in artifact["review_checks"]}
+
+    assert artifact["state"] == "viable"
+    assert artifact["opinion_as_of"] == "2024-01-04"
+    assert [row["symbol"] for row in artifact["buy_candidates"]] == ["2330"]
+    assert [row["symbol"] for row in artifact["sell_or_avoid"]] == ["2317"]
+    assert checks["signal_to_position"]["result"] == {
+        "checked_symbol_count": 2,
+        "positive_count": 1,
+        "negative_count": 0,
+        "flat_count": 1,
+        "invalid_row_count": 0,
+    }
+    assert checks["parameter_sensitivity"]["result"] == {
+        "base_candidate_symbols": ["2330"],
+        "scenario_candidate_counts": {
+            "strict_threshold": 1,
+            "loose_threshold": 1,
+            "top_n_minus_1": 1,
+            "top_n_plus_1": 2,
+        },
+        "stable_symbols": ["2330"],
+        "changed_symbols": ["2317"],
+        "provisional_policy": opinion_domain.PROVISIONAL_POLICY,
+        "skipped_scenarios": [],
+    }
+
+
+@pytest.mark.parametrize(
+    ("noise", "expected_limitation"),
+    [
+        (
+            {
+                "date": "not-a-date",
+                "symbol": "2330",
+                "score": 0.5,
+                "position": 1.0,
+                "signal_kind": "forward_opinion",
+                "up_probability": 0.8,
+                "predicted_direction": "up",
+            },
+            "exactly one valid row",
+        ),
+        (
+            {
+                "date": "2024-01-01",
+                "symbol": "2454",
+                "score": 0.5,
+                "position": 1.0,
+                "signal_kind": "forward_opinion",
+                "up_probability": 0.8,
+                "predicted_direction": "up",
+            },
+            "outside the declared run universe: 2454",
+        ),
+        (
+            {
+                "date": "2024-01-01",
+                "symbol": "2330",
+                "score": float("nan"),
+                "position": 1.0,
+                "signal_kind": "forward_opinion",
+                "up_probability": 0.8,
+                "predicted_direction": "up",
+            },
+            "exactly one valid row",
+        ),
+        (
+            {
+                "date": "2024-01-01",
+                "symbol": "2330",
+                "score": 0.5,
+                "position": float("inf"),
+                "signal_kind": "forward_opinion",
+                "up_probability": 0.8,
+                "predicted_direction": "up",
+            },
+            "exactly one valid row",
+        ),
+    ],
+    ids=["invalid-date", "undeclared-symbol", "non-finite-score", "non-finite-position"],
+)
+def test_opinion_builder_invalid_signal_noise_fails_closed_without_driving_checks(
+    noise, expected_limitation
+):
+    payload = make_opinion_payload()
+    payload["signals"].append(noise)
 
     artifact = build_opinion_artifact(payload)
     checks = {item["check"]: item for item in artifact["review_checks"]}
 
     assert artifact["state"] == "no-opinion"
     assert artifact["buy_candidates"] == []
-    assert checks["signal_to_position"]["status"] == "fail"
-    assert "holdout evaluation signals are not investment opinions" in " ".join(
-        artifact["evidence_limitations"]
-    )
-
-
-def test_opinion_builder_undeclared_signal_symbol_blocks_viability():
-    payload = make_opinion_payload()
-    payload["signals"].append(
-        {
-            "date": "2024-01-02",
-            "symbol": "2454",
-            "score": 0.03,
-            "position": 1.0,
-            "signal_kind": "forward_opinion",
-            "up_probability": 0.8,
-            "predicted_direction": "up",
-        }
-    )
-
-    artifact = build_opinion_artifact(payload)
-
-    assert artifact["state"] == "no-opinion"
-    assert artifact["buy_candidates"] == []
-    assert "outside the declared run universe: 2454" in " ".join(
-        artifact["evidence_limitations"]
-    )
+    assert artifact["sell_or_avoid"] == []
+    assert artifact["watch"] == []
+    assert expected_limitation in " ".join(artifact["evidence_limitations"])
+    assert checks["signal_to_position"]["result"] == {
+        "checked_symbol_count": 2,
+        "positive_count": 1,
+        "negative_count": 0,
+        "flat_count": 1,
+        "invalid_row_count": 1,
+    }
+    assert checks["parameter_sensitivity"]["result"]["base_candidate_symbols"] == [
+        "2330"
+    ]
+    assert checks["parameter_sensitivity"]["result"]["scenario_candidate_counts"] == {
+        "strict_threshold": 1,
+        "loose_threshold": 1,
+        "top_n_minus_1": 1,
+        "top_n_plus_1": 2,
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/scripts/test_market_data_ingestion.py
+++ b/tests/scripts/test_market_data_ingestion.py
@@ -446,7 +446,7 @@ def test_sanitize_numeric_value_strips_html_tags():
 
 @pytest.mark.parametrize("payload_body", ["[]", '"no data"'])
 def test_payload_declares_no_data_ignores_non_mapping_json(payload_body):
-    assert scraper._payload_declares_no_data(payload_body) is False
+    assert scraper.payload_declares_no_data(payload_body) is False
 
 
 @pytest.mark.parametrize(
@@ -460,7 +460,7 @@ def test_payload_declares_no_data_ignores_non_mapping_json(payload_body):
     ],
 )
 def test_payload_declares_provider_no_data_markers_and_explicit_zero(payload_body):
-    assert scraper._payload_declares_no_data(payload_body) is True
+    assert scraper.payload_declares_no_data(payload_body) is True
 
 
 def test_payload_declares_no_data_requires_all_tables_to_be_empty():
@@ -471,7 +471,7 @@ def test_payload_declares_no_data_requires_all_tables_to_be_empty():
         ']}'
     )
 
-    assert scraper._payload_declares_no_data(payload_body) is False
+    assert scraper.payload_declares_no_data(payload_body) is False
 
 
 @pytest.mark.parametrize(
@@ -487,7 +487,7 @@ def test_payload_declares_no_data_requires_all_tables_to_be_empty():
     ],
 )
 def test_payload_declares_no_data_requires_explicit_structural_shape(payload_body):
-    assert scraper._payload_declares_no_data(payload_body) is False
+    assert scraper.payload_declares_no_data(payload_body) is False
 
 
 def test_ingest_symbol_tw_calls_daily_update(monkeypatch):


### PR DESCRIPTION
## Summary

- harden research opinion eligibility and common-date validation
- add regression coverage for invalid and stale evidence

## Verification

- focused research tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能改善**
  * 強化前瞻性意見信號的最新日期分桶與嚴格快照驗證，用於更一致的狀態/檢查/限制訊息呈現。
  * 台灣市場官方宣告無資料日期的載入與排除流程更精準（正確時區/時間邊界），並能容忍無資料判定所需欄位缺失。
* **錯誤修正**
  * 稽核資料載入/判定失敗或快照結構不完整時，改採更保守策略，避免產生不當的可行性結論。
  * 強化無效信號、缺失標的與日期不一致時的統計與訊息一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->